### PR TITLE
feat: implement useSorobanEvents hook.

### DIFF
--- a/src/lib/hooks/useSorobanEvents.ts
+++ b/src/lib/hooks/useSorobanEvents.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+type Options = {
+    sorobanRpc?: string
+    fromCursor?: string | number
+    pollIntervalMs?: number | null
+}
+
+type UseSorobanEventsReturn = {
+    events: any[]
+    loading: boolean
+    refresh: () => Promise<void>
+    stopPolling: () => void
+    error: Error | null
+}
+
+export function useSorobanEvents(
+    contractId: string,
+    opts: Options = {}
+): UseSorobanEventsReturn {
+    const { sorobanRpc = 'https://rpc-futurenet.stellar.org', fromCursor, pollIntervalMs = null } = opts
+
+    const [events, setEvents] = useState<any[]>([])
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<Error | null>(null)
+    const cursorRef = useRef<string | number | undefined>(fromCursor)
+    const pollTimer = useRef<NodeJS.Timeout | null>(null)
+
+    const fetchEvents = useCallback(async () => {
+        setLoading(true)
+        try {
+            const params = new URLSearchParams({
+                contractId,
+                ...(cursorRef.current ? { cursor: String(cursorRef.current) } : {})
+            })
+            const res = await fetch(`${sorobanRpc}/events?${params.toString()}`)
+            if (!res.ok) throw new Error(`RPC error ${res.status}`)
+            const data = await res.json()
+            const newEvents = data.events || []
+            setEvents((prev: any[]) => {
+                const seen = new Set(prev.map((e: any) => e.id ?? e.paging_token))
+                return [...prev, ...newEvents.filter((e: any) => !seen.has(e.id ?? e.paging_token))]
+            })
+            if (newEvents.length > 0) {
+                const last = newEvents[newEvents.length - 1]
+                cursorRef.current = last.paging_token ?? cursorRef.current
+            }
+            setError(null)
+        } catch (err) {
+            setError(err as Error)
+        } finally {
+            setLoading(false)
+        }
+    }, [contractId, sorobanRpc])
+
+    const refresh = useCallback(async () => { await fetchEvents() }, [fetchEvents])
+    const stopPolling = useCallback(() => {
+        if (pollTimer.current) {
+            clearInterval(pollTimer.current)
+            pollTimer.current = null
+        }
+    }, [])
+
+    useEffect(() => {
+        fetchEvents()
+        if (pollIntervalMs) {
+            pollTimer.current = setInterval(fetchEvents, pollIntervalMs)
+        }
+        return () => stopPolling()
+    }, [fetchEvents, pollIntervalMs, stopPolling])
+
+    return { events, loading, refresh, stopPolling, error }
+}


### PR DESCRIPTION
## Purpose Stated
Soroban contracts can emit events. useSorobanEvents() will allow reading past events and optionally polling for new events so UI can react to contract activity.

## Goals Given
- Query Soroban RPC for historical events for a given contract.
- Optionally poll for new events and append or merge results.
- Provide refresh() and stopPolling() APIs.

## Work done
1) Query Soroban RPC for historical events for a given contract - fetch(${sorobanRpc}/events?...) runs on mount and uses contractId.
2) Optionally poll for new events and append/merge results - Starts an interval if pollIntervalMs is provided; appends new events to state.
3) Provide refresh() and stopPolling() APIs  - Both functions are returned and work off fetchEvents/clearInterval.
4) Support fromCursor and manage cursor state for incremental fetching - Keeps cursorRef and updates it with the last event’s paging_token.
5) Error handling and rate-limit safety - Catches errors, stores them in error, stops spamming when stopPolling is called.
6) Deduplication of repeated events - Uses a Set of previous IDs or paging_token to filter duplicates.




