### PR TITLE
feat: add nextellar deploy command with project validation and bundling

### DIFF
--- a/bin/nextellar.ts
+++ b/bin/nextellar.ts
@@ -7,6 +7,7 @@ import pc from "picocolors";
 import gradient from "gradient-string";
 import { scaffold } from "../src/lib/scaffold.js";
 import { upgrade } from "../src/lib/upgrade.js";
+import { runDeploy } from "../src/lib/deploy.js";
 import { displaySuccess, NEXTELLAR_LOGO } from "../src/lib/feedback.js";
 import { detectPackageManager } from "../src/lib/install.js";
 
@@ -59,6 +60,22 @@ program
       await upgrade({ dryRun: options.dryRun, yes: options.yes });
     } catch (err: any) {
       console.error(`\n❌ Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("deploy")
+  .description("Validate and prepare a deployment bundle for Nextellar Cloud")
+  .option("--dry-run", "validate and show what would be deployed without bundling")
+  .action(async (cmdOpts: { dryRun?: boolean }) => {
+    try {
+      await runDeploy({
+        cwd: process.cwd(),
+        dryRun: !!cmdOpts.dryRun,
+      });
+    } catch (err: any) {
+      console.error(`\n❌ Error: ${err?.message || err}`);
       process.exit(1);
     }
   });

--- a/dist/bin/nextellar.js
+++ b/dist/bin/nextellar.js
@@ -7,6 +7,7 @@ import pc from "picocolors";
 import gradient from "gradient-string";
 import { scaffold } from "../src/lib/scaffold.js";
 import { upgrade } from "../src/lib/upgrade.js";
+import { runDeploy } from "../src/lib/deploy.js";
 import { displaySuccess, NEXTELLAR_LOGO } from "../src/lib/feedback.js";
 import { detectPackageManager } from "../src/lib/install.js";
 const __filename = fileURLToPath(import.meta.url);
@@ -54,6 +55,22 @@ program
     }
     catch (err) {
         console.error(`\n❌ Error: ${err.message}`);
+        process.exit(1);
+    }
+});
+program
+    .command("deploy")
+    .description("Validate and prepare a deployment bundle for Nextellar Cloud")
+    .option("--dry-run", "validate and show what would be deployed without bundling")
+    .action(async (cmdOpts) => {
+    try {
+        await runDeploy({
+            cwd: process.cwd(),
+            dryRun: !!cmdOpts.dryRun,
+        });
+    }
+    catch (err) {
+        console.error(`\n❌ Error: ${err?.message || err}`);
         process.exit(1);
     }
 });

--- a/dist/src/lib/deploy.js
+++ b/dist/src/lib/deploy.js
@@ -1,0 +1,119 @@
+import path from "path";
+import fs from "fs-extra";
+import { spawn } from "child_process";
+import pc from "picocolors";
+const DEPLOY_STATE_DIR = path.join(".nextellar", "deploy");
+const DEPLOY_STATE_FILE = "latest-bundle.json";
+export async function runDeploy(options = {}) {
+    const projectRoot = options.cwd || process.cwd();
+    const dryRun = !!options.dryRun;
+    const context = await validateProject(projectRoot);
+    const bundlePath = getBundlePath(projectRoot);
+    console.log(pc.green("✔ Project validation passed"));
+    console.log(`  Root: ${pc.cyan(context.projectRoot)}`);
+    console.log(`  Contracts: ${pc.cyan(context.hasContracts ? "detected (/contracts)" : "not detected")}`);
+    if (dryRun) {
+        console.log(`\n${pc.yellow("Dry run mode: no bundle created")}`);
+        console.log(`  Would create: ${pc.cyan(bundlePath)}`);
+        console.log("  Excludes: node_modules, .git, .next/cache");
+        printComingSoonMessage();
+        return;
+    }
+    await fs.ensureDir(path.dirname(bundlePath));
+    await createBundle(context.projectRoot, bundlePath);
+    const bundleStats = await fs.stat(bundlePath);
+    await writeBundleState(projectRoot, bundlePath, bundleStats.size, context.hasContracts);
+    console.log(`\n${pc.green("✔ Deployment bundle created")}`);
+    console.log(`  Path: ${pc.cyan(bundlePath)}`);
+    console.log(`  Size: ${pc.cyan(formatBytes(bundleStats.size))}`);
+    console.log(`  Saved: ${pc.cyan(path.join(projectRoot, DEPLOY_STATE_DIR, DEPLOY_STATE_FILE))}`);
+    // TODO(platform): accept --token <api-token> and authenticate upload requests.
+    // TODO(platform): POST bundle to /v1/deployments and stream deployment logs.
+    // TODO(platform): print deployment URL when build completes on Nextellar Cloud.
+    if (options.token) {
+        console.log(`\n${pc.dim("API token received. Nextellar Cloud API upload is not available yet.")}`);
+    }
+    printComingSoonMessage();
+}
+async function validateProject(projectRoot) {
+    const packageJsonPath = path.join(projectRoot, "package.json");
+    if (!(await fs.pathExists(packageJsonPath))) {
+        throw new Error("No package.json found in this directory. Run this command from a Next.js project root.");
+    }
+    const packageJson = (await fs.readJson(packageJsonPath));
+    const dependencies = packageJson.dependencies || {};
+    const devDependencies = packageJson.devDependencies || {};
+    const hasNextDependency = Boolean(dependencies.next || devDependencies.next);
+    if (!hasNextDependency) {
+        throw new Error("This is not a Next.js project (missing \"next\" dependency in package.json).");
+    }
+    const nextDir = path.join(projectRoot, ".next");
+    if (!(await fs.pathExists(nextDir))) {
+        throw new Error("Missing production build (.next). Run 'npm run build' first.");
+    }
+    const contractsDir = path.join(projectRoot, "contracts");
+    const hasContracts = await fs.pathExists(contractsDir);
+    return {
+        projectRoot,
+        packageJsonPath,
+        packageJson,
+        nextDir,
+        contractsDir,
+        hasContracts,
+    };
+}
+function getBundlePath(projectRoot) {
+    const appName = path.basename(projectRoot);
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    return path.join(projectRoot, DEPLOY_STATE_DIR, `${appName}-${stamp}.tar.gz`);
+}
+async function createBundle(projectRoot, bundlePath) {
+    const args = [
+        "-czf",
+        bundlePath,
+        "--exclude=node_modules",
+        "--exclude=.git",
+        "--exclude=.next/cache",
+        "--exclude=.nextellar/deploy",
+        "-C",
+        projectRoot,
+        ".",
+    ];
+    await new Promise((resolve, reject) => {
+        const child = spawn("tar", args, {
+            stdio: "inherit",
+        });
+        child.on("error", (error) => {
+            reject(new Error(`Failed to run tar while creating deployment bundle: ${error.message}`));
+        });
+        child.on("close", (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(`Failed to create deployment bundle (tar exit code ${code}).`));
+        });
+    });
+}
+async function writeBundleState(projectRoot, bundlePath, bundleSizeBytes, hasContracts) {
+    const stateDir = path.join(projectRoot, DEPLOY_STATE_DIR);
+    const statePath = path.join(stateDir, DEPLOY_STATE_FILE);
+    await fs.ensureDir(stateDir);
+    await fs.writeJson(statePath, {
+        bundlePath,
+        bundleSizeBytes,
+        hasContracts,
+        createdAt: new Date().toISOString(),
+    }, { spaces: 2 });
+}
+function printComingSoonMessage() {
+    console.log(`\n${pc.yellow("Nextellar Cloud is coming soon. For now, deploy with Vercel: npx vercel")}`);
+}
+function formatBytes(bytes) {
+    if (bytes === 0)
+        return "0 B";
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / 1024 ** exponent;
+    return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -1,0 +1,185 @@
+import path from "path";
+import fs from "fs-extra";
+import { spawn } from "child_process";
+import pc from "picocolors";
+
+export interface DeployOptions {
+  cwd?: string;
+  dryRun?: boolean;
+  token?: string;
+}
+
+interface DeployContext {
+  projectRoot: string;
+  packageJsonPath: string;
+  packageJson: Record<string, any>;
+  nextDir: string;
+  contractsDir: string;
+  hasContracts: boolean;
+}
+
+const DEPLOY_STATE_DIR = path.join(".nextellar", "deploy");
+const DEPLOY_STATE_FILE = "latest-bundle.json";
+
+export async function runDeploy(options: DeployOptions = {}): Promise<void> {
+  const projectRoot = options.cwd || process.cwd();
+  const dryRun = !!options.dryRun;
+
+  const context = await validateProject(projectRoot);
+  const bundlePath = getBundlePath(projectRoot);
+
+  console.log(pc.green("✔ Project validation passed"));
+  console.log(`  Root: ${pc.cyan(context.projectRoot)}`);
+  console.log(
+    `  Contracts: ${pc.cyan(context.hasContracts ? "detected (/contracts)" : "not detected")}`
+  );
+
+  if (dryRun) {
+    console.log(`\n${pc.yellow("Dry run mode: no bundle created")}`);
+    console.log(`  Would create: ${pc.cyan(bundlePath)}`);
+    console.log("  Excludes: node_modules, .git, .next/cache");
+    printComingSoonMessage();
+    return;
+  }
+
+  await fs.ensureDir(path.dirname(bundlePath));
+  await createBundle(context.projectRoot, bundlePath);
+  const bundleStats = await fs.stat(bundlePath);
+
+  await writeBundleState(projectRoot, bundlePath, bundleStats.size, context.hasContracts);
+
+  console.log(`\n${pc.green("✔ Deployment bundle created")}`);
+  console.log(`  Path: ${pc.cyan(bundlePath)}`);
+  console.log(`  Size: ${pc.cyan(formatBytes(bundleStats.size))}`);
+  console.log(`  Saved: ${pc.cyan(path.join(projectRoot, DEPLOY_STATE_DIR, DEPLOY_STATE_FILE))}`);
+
+  // TODO(platform): accept --token <api-token> and authenticate upload requests.
+  // TODO(platform): POST bundle to /v1/deployments and stream deployment logs.
+  // TODO(platform): print deployment URL when build completes on Nextellar Cloud.
+  if (options.token) {
+    console.log(
+      `\n${pc.dim(
+        "API token received. Nextellar Cloud API upload is not available yet."
+      )}`
+    );
+  }
+
+  printComingSoonMessage();
+}
+
+async function validateProject(projectRoot: string): Promise<DeployContext> {
+  const packageJsonPath = path.join(projectRoot, "package.json");
+  if (!(await fs.pathExists(packageJsonPath))) {
+    throw new Error(
+      "No package.json found in this directory. Run this command from a Next.js project root."
+    );
+  }
+
+  const packageJson = (await fs.readJson(packageJsonPath)) as Record<string, any>;
+  const dependencies = packageJson.dependencies || {};
+  const devDependencies = packageJson.devDependencies || {};
+  const hasNextDependency = Boolean(dependencies.next || devDependencies.next);
+
+  if (!hasNextDependency) {
+    throw new Error(
+      "This is not a Next.js project (missing \"next\" dependency in package.json)."
+    );
+  }
+
+  const nextDir = path.join(projectRoot, ".next");
+  if (!(await fs.pathExists(nextDir))) {
+    throw new Error("Missing production build (.next). Run 'npm run build' first.");
+  }
+
+  const contractsDir = path.join(projectRoot, "contracts");
+  const hasContracts = await fs.pathExists(contractsDir);
+
+  return {
+    projectRoot,
+    packageJsonPath,
+    packageJson,
+    nextDir,
+    contractsDir,
+    hasContracts,
+  };
+}
+
+function getBundlePath(projectRoot: string): string {
+  const appName = path.basename(projectRoot);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return path.join(projectRoot, DEPLOY_STATE_DIR, `${appName}-${stamp}.tar.gz`);
+}
+
+async function createBundle(projectRoot: string, bundlePath: string): Promise<void> {
+  const args = [
+    "-czf",
+    bundlePath,
+    "--exclude=node_modules",
+    "--exclude=.git",
+    "--exclude=.next/cache",
+    "--exclude=.nextellar/deploy",
+    "-C",
+    projectRoot,
+    ".",
+  ];
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("tar", args, {
+      stdio: "inherit",
+    });
+
+    child.on("error", (error) => {
+      reject(
+        new Error(
+          `Failed to run tar while creating deployment bundle: ${error.message}`
+        )
+      );
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`Failed to create deployment bundle (tar exit code ${code}).`));
+    });
+  });
+}
+
+async function writeBundleState(
+  projectRoot: string,
+  bundlePath: string,
+  bundleSizeBytes: number,
+  hasContracts: boolean
+): Promise<void> {
+  const stateDir = path.join(projectRoot, DEPLOY_STATE_DIR);
+  const statePath = path.join(stateDir, DEPLOY_STATE_FILE);
+  await fs.ensureDir(stateDir);
+
+  await fs.writeJson(
+    statePath,
+    {
+      bundlePath,
+      bundleSizeBytes,
+      hasContracts,
+      createdAt: new Date().toISOString(),
+    },
+    { spaces: 2 }
+  );
+}
+
+function printComingSoonMessage() {
+  console.log(
+    `\n${pc.yellow(
+      "Nextellar Cloud is coming soon. For now, deploy with Vercel: npx vercel"
+    )}`
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}


### PR DESCRIPTION
## Description
Add `nextellar deploy` command (platform prep) with project validation, deployment bundle creation, and a temporary Vercel fallback message.

Closes #69

## Changes proposed

### What were you told to do?
I was tasked with adding a CLI-side deployment interface ahead of the backend platform so users can follow a clear flow today (scaffold → develop → deploy). Requirements included:

- Add a `nextellar deploy` subcommand.
- Validate current directory is a Next.js project (`package.json` with `next` dependency).
- Require a production build (`.next/`) and show a helpful error if missing.
- Detect `/contracts` and note it for future contract deployment integration.
- Create a `.tar.gz` bundle excluding `node_modules`, `.git`, and `.next/cache`.
- Display bundle size and save bundle path for future API usage.
- Support `--dry-run` to validate and preview deployment without creating a bundle.
- Show a temporary message: `Nextellar Cloud is coming soon. For now, deploy with Vercel: npx vercel`.
- Structure code for easy future API wiring (`--token`, upload endpoint, logs, live URL).

### What did I do?

#### Added deploy service
- Created `src/lib/deploy.ts` with:
  - `runDeploy(options)` orchestration
  - project validation (Next.js detection + `.next` existence)
  - contracts directory detection
  - tarball bundling logic
  - bundle-size reporting
  - persisted metadata output for latest bundle
  - dry-run support

#### Added deploy subcommand in CLI
- Updated `bin/nextellar.ts`:
  - registered `deploy` subcommand
  - added `--dry-run` option
  - wired command to call `runDeploy(...)`
  - preserved existing scaffold/doctor behavior

#### Bundle output + exclusions
- Bundles are written to:
  - `.nextellar/deploy/<project>-<timestamp>.tar.gz`
- Saved latest bundle metadata at:
  - `.nextellar/deploy/latest-bundle.json`
- Archive exclusions include:
  - `node_modules`
  - `.git`
  - `.next/cache`
  - `.nextellar/deploy` (prevents self-inclusion recursion)

#### Future integration TODOs
- Added explicit TODOs in `src/lib/deploy.ts` for:
  - `--token <api-token>` handling
  - `POST /v1/deployments` upload
  - deployment logs streaming
  - live URL output

#### Build output updates
- Generated and included runtime artifacts:
  - `dist/bin/nextellar.js`
  - `dist/src/lib/deploy.js`

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
```bash
$ npm run build

> nextellar@1.0.4 build
> npx tsc -p tsconfig.build.json

$ node dist/bin/nextellar.js deploy --dry-run
✔ Project validation passed
  Root: /private/tmp/nextellar-deploy-pr69
  Contracts: detected (/contracts)

Dry run mode: no bundle created
  Would create: /private/tmp/nextellar-deploy-pr69/.nextellar/deploy/nextellar-deploy-pr69-2026-02-22T00-41-08-156Z.tar.gz
  Excludes: node_modules, .git, .next/cache

Nextellar Cloud is coming soon. For now, deploy with Vercel: npx vercel

$ node dist/bin/nextellar.js deploy
✔ Project validation passed
  Root: /private/tmp/nextellar-deploy-pr69
  Contracts: detected (/contracts)

✔ Deployment bundle created
  Path: /private/tmp/nextellar-deploy-pr69/.nextellar/deploy/nextellar-deploy-pr69-2026-02-22T00-41-08-482Z.tar.gz
  Size: 709 KB
  Saved: /private/tmp/nextellar-deploy-pr69/.nextellar/deploy/latest-bundle.json

Nextellar Cloud is coming soon. For now, deploy with Vercel: npx vercel

$ rm -rf .next
$ node dist/bin/nextellar.js deploy

❌ Error: Missing production build (.next). Run 'npm run build' first.
```
