### PR TITLE
feat: validate --horizon-url and --soroban-url inputs

### DIFF
--- a/dist/src/lib/scaffold.js
+++ b/dist/src/lib/scaffold.js
@@ -1,0 +1,158 @@
+import path from "path";
+import fs from "fs-extra";
+import { detectPackageManager, runInstall } from "./install.js";
+import { trackScaffoldEvent } from "./telemetry.js";
+import { fileURLToPath } from "url";
+import { validateHorizonUrl, validateSorobanUrl } from "./validate.js";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+export async function scaffold(options) {
+    const { appName, useTs, template, withContracts, horizonUrl, sorobanUrl, wallets, skipInstall, packageManager, installTimeout, telemetryEnabled, cliVersion, } = options;
+    const telemetryTemplate = template || "default";
+    const telemetryLanguage = useTs ? "typescript" : "javascript";
+    const telemetryNetwork = horizonUrl && horizonUrl.includes("public") ? "public" : "testnet";
+    const telemetryWallets = wallets && wallets.length > 0 ? wallets : ["freighter", "albedo", "lobstr"];
+    const templateName = template || "default";
+    if (!useTs && templateName !== "default") {
+        throw new Error(`Template "${templateName}" is not available for JavaScript yet. Please use the default template with --javascript.`);
+    }
+    const resolvedTemplateName = useTs ? templateName : "js-template";
+    // Validate custom URL overrides if provided
+    if (horizonUrl) {
+        validateHorizonUrl(horizonUrl);
+    }
+    if (sorobanUrl) {
+        validateSorobanUrl(sorobanUrl);
+    }
+    // Resolve templates across src/dist and nested workspace layouts.
+    const templateRoots = [
+        path.resolve(__dirname, "../templates"),
+        path.resolve(__dirname, "../../templates"),
+        path.resolve(__dirname, "../../../src/templates"),
+        path.resolve(__dirname, "../../nextellar/src/templates"),
+        path.resolve(__dirname, "../../../nextellar/src/templates"),
+    ];
+    const templateRoot = templateRoots.find((candidate) => fs.existsSync(path.join(candidate, resolvedTemplateName, "package.json"))) || templateRoots[templateRoots.length - 1];
+    const templateDir = path.join(templateRoot, resolvedTemplateName);
+    const targetDir = path.resolve(process.cwd(), appName);
+    const finalPackageManager = detectPackageManager(targetDir, packageManager);
+    if (await fs.pathExists(targetDir)) {
+        throw new Error(`Directory "${appName}" already exists.`);
+    }
+    try {
+        await fs.copy(templateDir, targetDir, {
+            filter: (src) => {
+                const basename = path.basename(src);
+                return basename !== ".git" && basename !== "node_modules";
+            },
+            preserveTimestamps: true,
+        });
+        if (withContracts) {
+            const contractsTemplateDir = path.join(templateRoot, "contracts-template");
+            if (await fs.pathExists(contractsTemplateDir)) {
+                await fs.copy(contractsTemplateDir, targetDir, {
+                    preserveTimestamps: true,
+                });
+            }
+            const pkgJsonPath = path.join(targetDir, "package.json");
+            if (await fs.pathExists(pkgJsonPath)) {
+                const pkgJson = await fs.readJson(pkgJsonPath);
+                pkgJson.scripts = pkgJson.scripts || {};
+                pkgJson.scripts["contracts:build"] =
+                    "cd contracts && stellar contract build";
+                pkgJson.scripts["contracts:test"] = "cd contracts && cargo test";
+                await fs.writeJson(pkgJsonPath, pkgJson, { spaces: 2 });
+            }
+            const envExamplePath = path.join(targetDir, ".env.example");
+            await fs.appendFile(envExamplePath, `\n# Soroban Smart Contracts\nNEXT_PUBLIC_HELLO_WORLD_CONTRACT_ID=C_REPLACE_WITH_YOUR_CONTRACT_ID\n`);
+        }
+        const replaceInFile = async (filePath, replacements) => {
+            const content = await fs.readFile(filePath, "utf8");
+            let newContent = content;
+            for (const [key, value] of Object.entries(replacements)) {
+                newContent = newContent.replaceAll(key, value);
+            }
+            await fs.writeFile(filePath, newContent, "utf8");
+        };
+        const config = {
+            "{{APP_NAME}}": appName,
+            "{{HORIZON_URL}}": horizonUrl || "https://horizon-testnet.stellar.org",
+            "{{SOROBAN_URL}}": sorobanUrl || "https://soroban-testnet.stellar.org",
+            "{{NETWORK}}": horizonUrl && horizonUrl.includes("public") ? "PUBLIC" : "TESTNET",
+            "{{WALLETS}}": wallets && wallets.length > 0
+                ? JSON.stringify(wallets)
+                : JSON.stringify(["freighter", "albedo", "lobstr"]),
+            "{{NEXTELLAR_VERSION}}": cliVersion ||
+                (() => {
+                    try {
+                        const pkgPath = fs.existsSync(path.resolve(__dirname, "../../package.json"))
+                            ? path.resolve(__dirname, "../../package.json")
+                            : path.resolve(__dirname, "../../../package.json");
+                        const myPkg = fs.readJsonSync(pkgPath);
+                        return myPkg.version || "0.0.0";
+                    }
+                    catch {
+                        return "0.0.0";
+                    }
+                })(),
+            "{{TEMPLATE_NAME}}": templateName,
+            "{{TIMESTAMP}}": new Date().toISOString(),
+        };
+        const filesToProcess = [
+            path.join(targetDir, "package.json"),
+            path.join(targetDir, "README.md"),
+            path.join(targetDir, "src/contexts/WalletProvider.tsx"),
+            path.join(targetDir, "src/contexts/WalletProvider.jsx"),
+            path.join(targetDir, "src/lib/stellar-wallet-kit.ts"),
+            path.join(targetDir, "src/lib/stellar-wallet-kit.js"),
+            path.join(targetDir, "src/hooks/useSorobanContract.ts"),
+            path.join(targetDir, "src/hooks/useSorobanContract.js"),
+            path.join(targetDir, ".env.example"),
+            path.join(targetDir, ".nextellar/config.json"),
+        ];
+        for (const filePath of filesToProcess) {
+            if (await fs.pathExists(filePath)) {
+                await replaceInFile(filePath, config);
+            }
+        }
+        console.log(`✔️  Scaffolded "${appName}" from template.`);
+        const result = await runInstall({
+            cwd: targetDir,
+            skipInstall,
+            packageManager,
+            timeout: installTimeout,
+        });
+        if (!result.success && !skipInstall) {
+            throw new Error(`Dependency installation failed. Please run "${result.packageManager} install" manually in "${appName}".`);
+        }
+        void trackScaffoldEvent({
+            template: telemetryTemplate,
+            language: telemetryLanguage,
+            network: telemetryNetwork,
+            wallets: telemetryWallets,
+            packageManager: finalPackageManager,
+            withContracts: !!withContracts,
+            skipInstall: !!skipInstall,
+            success: true,
+            cliVersion: cliVersion || "0.0.0",
+            nodeVersion: process.versions.node,
+            os: process.platform,
+        }, { noTelemetryFlag: telemetryEnabled === false });
+    }
+    catch (error) {
+        void trackScaffoldEvent({
+            template: telemetryTemplate,
+            language: telemetryLanguage,
+            network: telemetryNetwork,
+            wallets: telemetryWallets,
+            packageManager: finalPackageManager,
+            withContracts: !!withContracts,
+            skipInstall: !!skipInstall,
+            success: false,
+            cliVersion: cliVersion || "0.0.0",
+            nodeVersion: process.versions.node,
+            os: process.platform,
+        }, { noTelemetryFlag: telemetryEnabled === false });
+        throw error;
+    }
+}

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2128,6 +2129,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2151,6 +2153,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4967,7 +4970,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4988,7 +4990,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4999,7 +5000,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5013,7 +5013,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5028,8 +5027,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.4",
@@ -6206,8 +6204,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6376,6 +6373,7 @@
       "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -6404,6 +6402,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6498,6 +6497,7 @@
       "dev": true,
       "license": "ISC"
     },
+<<<<<<< HEAD
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -6772,9 +6772,12 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+=======
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+>>>>>>> 656d0c6 (feat: validate --horizon-url and --soroban-url inputs)
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
       "cpu": [
         "x64"
       ],
@@ -6782,7 +6785,21 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "win32"
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@wallet-standard/base": {
@@ -8287,6 +8304,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -9271,8 +9289,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -10889,6 +10906,7 @@
       "integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.5",
         "@jest/types": "30.0.5",
@@ -11625,6 +11643,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11929,7 +11948,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13853,8 +13871,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/secp256k1": {
       "version": "5.0.1",
@@ -14781,6 +14798,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14889,6 +14907,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13870,30 +13870,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/secp256k1": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
-      "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
-      "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "elliptic": "^6.5.7",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/secp256k1/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "dev": true,
-      "license": "MIT"
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/src/lib/scaffold.ts
+++ b/src/lib/scaffold.ts
@@ -4,6 +4,7 @@ import { detectPackageManager, runInstall } from "./install.js";
 import { trackScaffoldEvent } from "./telemetry.js";
 import { fileURLToPath } from "url";
 import { confirm } from "@clack/prompts";
+import { validateHorizonUrl, validateSorobanUrl } from "./validate.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -53,11 +54,19 @@ export async function scaffold(options: ScaffoldOptions) {
   const templateName = template || "default";
   if (!useTs && templateName !== "default") {
     throw new Error(
-      `Template "${templateName}" is not available for JavaScript yet. Please use the default template with --javascript.`
+      `Template "${templateName}" is not available for JavaScript yet. Please use the default template with --javascript.`,
     );
   }
 
   const resolvedTemplateName = useTs ? templateName : "js-template";
+
+  // Validate custom URL overrides if provided
+  if (horizonUrl) {
+    validateHorizonUrl(horizonUrl);
+  }
+  if (sorobanUrl) {
+    validateSorobanUrl(sorobanUrl);
+  }
 
   // Resolve templates across src/dist and nested workspace layouts.
   const templateRoots = [
@@ -69,7 +78,7 @@ export async function scaffold(options: ScaffoldOptions) {
   ];
   const templateRoot =
     templateRoots.find((candidate) =>
-      fs.existsSync(path.join(candidate, resolvedTemplateName, "package.json"))
+      fs.existsSync(path.join(candidate, resolvedTemplateName, "package.json")),
     ) || templateRoots[templateRoots.length - 1];
   const templateDir = path.join(templateRoot, resolvedTemplateName);
 
@@ -112,7 +121,10 @@ export async function scaffold(options: ScaffoldOptions) {
     });
 
     if (withContracts) {
-      const contractsTemplateDir = path.join(templateRoot, "contracts-template");
+      const contractsTemplateDir = path.join(
+        templateRoot,
+        "contracts-template",
+      );
 
       if (await fs.pathExists(contractsTemplateDir)) {
         await fs.copy(contractsTemplateDir, targetDir, {
@@ -133,13 +145,13 @@ export async function scaffold(options: ScaffoldOptions) {
       const envExamplePath = path.join(targetDir, ".env.example");
       await fs.appendFile(
         envExamplePath,
-        `\n# Soroban Smart Contracts\nNEXT_PUBLIC_HELLO_WORLD_CONTRACT_ID=C_REPLACE_WITH_YOUR_CONTRACT_ID\n`
+        `\n# Soroban Smart Contracts\nNEXT_PUBLIC_HELLO_WORLD_CONTRACT_ID=C_REPLACE_WITH_YOUR_CONTRACT_ID\n`,
       );
     }
 
     const replaceInFile = async (
       filePath: string,
-      replacements: Record<string, string>
+      replacements: Record<string, string>,
     ) => {
       const content = await fs.readFile(filePath, "utf8");
       let newContent = content;
@@ -163,7 +175,9 @@ export async function scaffold(options: ScaffoldOptions) {
         cliVersion ||
         (() => {
           try {
-            const pkgPath = fs.existsSync(path.resolve(__dirname, "../../package.json"))
+            const pkgPath = fs.existsSync(
+              path.resolve(__dirname, "../../package.json"),
+            )
               ? path.resolve(__dirname, "../../package.json")
               : path.resolve(__dirname, "../../../package.json");
             const myPkg = fs.readJsonSync(pkgPath);
@@ -206,7 +220,7 @@ export async function scaffold(options: ScaffoldOptions) {
 
     if (!result.success && !skipInstall) {
       throw new Error(
-        `Dependency installation failed. Please run "${result.packageManager} install" manually in "${appName}".`
+        `Dependency installation failed. Please run "${result.packageManager} install" manually in "${appName}".`,
       );
     }
 
@@ -224,7 +238,7 @@ export async function scaffold(options: ScaffoldOptions) {
         nodeVersion: process.versions.node,
         os: process.platform,
       },
-      { noTelemetryFlag: telemetryEnabled === false }
+      { noTelemetryFlag: telemetryEnabled === false },
     );
   } catch (error) {
     void trackScaffoldEvent(
@@ -241,7 +255,7 @@ export async function scaffold(options: ScaffoldOptions) {
         nodeVersion: process.versions.node,
         os: process.platform,
       },
-      { noTelemetryFlag: telemetryEnabled === false }
+      { noTelemetryFlag: telemetryEnabled === false },
     );
     throw error;
   }

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -1,0 +1,49 @@
+/**
+ * URL Validation Utilities
+ * Provides validation for Horizon and Soroban endpoint URLs
+ */
+
+/**
+ * Validates if a given string is a valid HTTP/HTTPS URL
+ * @param url - The URL string to validate
+ * @returns true if the URL is valid, false otherwise
+ */
+export function isValidUrl(url: string): boolean {
+  if (!url || typeof url !== "string" || url.trim().length === 0) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    // Only allow HTTP and HTTPS protocols
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates a Horizon URL and throws a descriptive error if invalid
+ * @param horizonUrl - The Horizon URL to validate
+ * @throws Error with clear message if URL is invalid
+ */
+export function validateHorizonUrl(horizonUrl: string): void {
+  if (!isValidUrl(horizonUrl)) {
+    throw new Error(
+      `Invalid Horizon URL: "${horizonUrl}". Must be a valid HTTP/HTTPS URL.`,
+    );
+  }
+}
+
+/**
+ * Validates a Soroban URL and throws a descriptive error if invalid
+ * @param sorobanUrl - The Soroban URL to validate
+ * @throws Error with clear message if URL is invalid
+ */
+export function validateSorobanUrl(sorobanUrl: string): void {
+  if (!isValidUrl(sorobanUrl)) {
+    throw new Error(
+      `Invalid Soroban URL: "${sorobanUrl}". Must be a valid HTTP/HTTPS URL.`,
+    );
+  }
+}


### PR DESCRIPTION
Added validation for custom endpoint override flags to prevent invalid URLs from being silently injected into scaffolded project configuration files. Invalid URLs (typos like htps://, non-HTTP schemes like ftp://, or malformed strings like not-a-url) are now caught at scaffold time with clear error messages.

## Changes

Created new utility module src/lib/validate.ts
with:
isValidUrl(url: string): boolean - Core validation checking for valid HTTP/HTTPS URLs
validateHorizonUrl(url: string): void - Validates Horizon endpoint with descriptive error
validateSorobanUrl(url: string): void - Validates Soroban endpoint with descriptive error
Modified src/lib/scaffold.ts

## Behavior:
Invalid URLs are rejected with clear error messages at scaffold time
Valid URLs (including localhost with ports, URLs with trailing slashes) pass validation
Default values are not validated (they are known-good)
Only HTTP and HTTPS protocols are allowed

Close #33 