### PR TITLE
feat: Implement --force Flag to Overwrite Existing Directories

### DIFF
--- a/bin/nextellar.ts
+++ b/bin/nextellar.ts
@@ -200,6 +200,11 @@ program
     false,
   )
   .option(
+    "--force",
+    "overwrite existing directory",
+    false,
+  )
+  .option(
     "--install-timeout <ms>",
     "installation timeout in milliseconds",
     "1200000",
@@ -319,6 +324,7 @@ program.action(async (projectName, options) => {
       installTimeout: parseInt(options.installTimeout),
       telemetryEnabled: options.telemetry,
       cliVersion: pkg.version,
+      force: options.force,
     });
 
     const pkgManager = detectPackageManager(

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2051,6 +2052,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2074,6 +2076,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2903,7 +2906,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2924,7 +2926,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2935,7 +2936,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2949,7 +2949,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2964,8 +2963,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.4",
@@ -3067,8 +3065,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3219,6 +3216,7 @@
       "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -3247,6 +3245,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4010,6 +4009,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4619,8 +4619,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5684,6 +5683,7 @@
       "integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.5",
         "@jest/types": "30.0.5",
@@ -6413,6 +6413,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6612,7 +6613,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7780,8 +7780,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8457,6 +8456,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8552,6 +8552,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/lib/scaffold.ts
+++ b/src/lib/scaffold.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra";
 import { detectPackageManager, runInstall } from "./install.js";
 import { trackScaffoldEvent } from "./telemetry.js";
 import { fileURLToPath } from "url";
+import { confirm } from "@clack/prompts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -21,6 +22,7 @@ export interface ScaffoldOptions {
   installTimeout?: number;
   telemetryEnabled?: boolean;
   cliVersion?: string;
+  force?: boolean;
 }
 
 export async function scaffold(options: ScaffoldOptions) {
@@ -37,6 +39,8 @@ export async function scaffold(options: ScaffoldOptions) {
     installTimeout,
     telemetryEnabled,
     cliVersion,
+    force,
+    defaults,
   } = options;
 
   const telemetryTemplate = template || "default";
@@ -73,7 +77,29 @@ export async function scaffold(options: ScaffoldOptions) {
   const finalPackageManager = detectPackageManager(targetDir, packageManager);
 
   if (await fs.pathExists(targetDir)) {
-    throw new Error(`Directory "${appName}" already exists.`);
+    if (!force) {
+      throw new Error(`Directory "${appName}" already exists.`);
+    }
+
+    // Handle force flag
+    const shouldPrompt =
+      process.stdout.isTTY &&
+      process.stdin.isTTY &&
+      !defaults &&
+      !process.env.CI;
+
+    if (shouldPrompt) {
+      const overwrite = await confirm({
+        message: `Directory "${appName}" already exists. Overwrite?`,
+      });
+
+      if (overwrite !== true) {
+        process.exit(0);
+      }
+    }
+
+    // Remove existing directory
+    await fs.remove(targetDir);
   }
 
   try {


### PR DESCRIPTION
Closes #60

## Summary
This PR adds a `--force` flag to the Nextellar CLI that allows users to overwrite existing directories when scaffolding a new project. This is a standard feature for CLI scaffolding tools and improves the development experience when iterating on project setup.

## Changes Made

### bin/nextellar.ts
- Added `--force` option to Commander definition with description "overwrite existing directory"
- Passed the `force` option to the `scaffold()` function

### src/lib/scaffold.ts
- Added `force?: boolean` to `ScaffoldOptions` interface
- Imported `confirm` from `@clack/prompts` for interactive prompts
- Implemented force logic in directory existence check:
  - If `--force` is not set and directory exists: keep current error behavior
  - If `--force` is set and running interactively (TTY, no `--defaults`): show confirmation prompt
  - If `--force` is set with `--defaults`: overwrite without prompting
  - Use `fs-extra.remove()` to delete existing directory before scaffolding

## Behavior

### With --force flag
- `npx nextellar my-app --force` - prompts for confirmation before overwriting
- `npx nextellar my-app --force --defaults` - overwrites without prompting
- Completely removes old directory before scaffolding (no leftover files)

### Without --force flag
- `npx nextellar my-app` - maintains current error behavior when directory exists

## Validation

✅ **Help output**: `--force` flag is documented in `--help` output  
✅ **Force overwrite**: `npx nextellar test-app --force --defaults --skip-install` succeeds  
✅ **File verification**: Scaffolded `package.json` exists after force overwrite  
✅ **Error preservation**: Without `--force`, existing directory still throws error  
✅ **Complete removal**: Old directory contents are completely removed before scaffolding  
