### PR TITLE
fix: add missing .env.example to js-template

### DIFF
--- a/src/templates/js-template/.env.example
+++ b/src/templates/js-template/.env.example
@@ -1,0 +1,16 @@
+# Nextellar — Environment Variables
+# Copy this file to .env.local and fill in your values
+
+# Stellar Network Configuration
+NEXT_PUBLIC_HORIZON_URL={{HORIZON_URL}}
+NEXT_PUBLIC_SOROBAN_URL={{SOROBAN_URL}}
+NEXT_PUBLIC_NETWORK={{NETWORK}}
+
+# Wallet Configuration (comma-separated: freighter,albedo,lobstr,xbull,hana)
+# NEXT_PUBLIC_WALLETS=freighter,albedo,lobstr
+
+# Soroban Contract IDs (add after deploying contracts)
+# NEXT_PUBLIC_CONTRACT_ID=
+
+# App Metadata
+NEXT_PUBLIC_APP_NAME={{APP_NAME}}

--- a/src/templates/js-template/.gitignore
+++ b/src/templates/js-template/.gitignore
@@ -30,8 +30,11 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
+# env files
+.env
+.env.local
+.env.development
+.env.production
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary

Closes #132

## Problem

The `js-template` was missing a `.env.example` file while all other templates (`default`, `minimal`, `defi`) have one. Additionally, the `js-template/.gitignore` used a broad `.env*` glob that would have swallowed `.env.example` even if it existed.

## Changes

- Created `src/templates/js-template/.env.example` with all `NEXT_PUBLIC_*` env vars and scaffold placeholder tokens, matching the structure of other templates
- Fixed `src/templates/js-template/.gitignore`: replaced `.env*` glob with explicit entries (`.env`, `.env.local`, `.env.development`, `.env.production`) to align with `default`, `minimal`, and `defi` templates

## Validation

```bash
node dist/bin/nextellar.js my-js-app --javascript --defaults --skip-install
cat my-js-app/.env.example
```

Output:
```
NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
NEXT_PUBLIC_SOROBAN_URL=https://soroban-testnet.stellar.org
NEXT_PUBLIC_NETWORK=TESTNET
NEXT_PUBLIC_APP_NAME=my-js-app
```

All placeholder tokens substituted correctly by `scaffold.ts`.