### PR TITLE
fix: throw on unrecognised XDR type instead of silent toString fallback

### DIFF
--- a/src/mocks/stellar-sdk-mock.ts
+++ b/src/mocks/stellar-sdk-mock.ts
@@ -2,16 +2,34 @@
  * Shared mock for @stellar/stellar-sdk used by template hook tests.
  * The jest.config moduleNameMapper redirects '@stellar/stellar-sdk' to this file.
  * Tests import mockGetEvents / mockServerConstructor to control behavior.
+ *
+ * Re-exports real SDK symbols so hooks that import Address, xdr, Contract, etc.
+ * can function normally while rpc.Server is fully mocked.
  */
+export {
+  xdr,
+  Address,
+  Contract,
+  Account,
+  TransactionBuilder,
+  Networks,
+  Keypair,
+} from "../../node_modules/@stellar/stellar-sdk/lib/index.js";
 
 export const mockGetEvents = jest.fn();
+export const mockSimulateTransaction = jest.fn();
+export const mockSendTransaction = jest.fn();
 
-export const mockServerConstructor = jest.fn().mockImplementation(() => ({
-  getEvents: mockGetEvents,
-}));
+class MockRpcServer {
+  simulateTransaction(...args: unknown[]) { return mockSimulateTransaction(...args); }
+  sendTransaction(...args: unknown[]) { return mockSendTransaction(...args); }
+  getEvents(...args: unknown[]) { return mockGetEvents(...args); }
+}
+
+export const mockServerConstructor = MockRpcServer;
 
 export const rpc = {
-  Server: mockServerConstructor,
+  Server: MockRpcServer,
 };
 
 // ── Horizon mock for useTransactionHistory ──────────────────────────────────

--- a/src/templates/default/src/hooks/useSorobanContract.ts
+++ b/src/templates/default/src/hooks/useSorobanContract.ts
@@ -503,7 +503,7 @@ export function useSorobanContract(
       return map;
     }
 
-    return scVal.toString();
+    throw new Error(`Unsupported Soroban XDR type: ${scVal.switch().name}. Please open an issue at https://github.com/nextellarlabs/nextellar/issues`);
   }, []);
 
   // ── callFunction ───────────────────────────────────────────────────────────

--- a/src/templates/js-template/package.json
+++ b/src/templates/js-template/package.json
@@ -2,6 +2,7 @@
   "name": "js-template",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/src/templates/js-template/src/hooks/useSorobanContract.js
+++ b/src/templates/js-template/src/hooks/useSorobanContract.js
@@ -122,7 +122,7 @@ export function useSorobanContract(opts) {
             case xdr.ScValType.scvAddress():
                 return scVal.address().toString();
             default:
-                return scVal.toString();
+                throw new Error(`Unsupported Soroban XDR type: ${scVal.switch().name}. Please open an issue at https://github.com/nextellarlabs/nextellar/issues`);
         }
     }, []);
     /**

--- a/tests/hooks/useSorobanContract.test.ts
+++ b/tests/hooks/useSorobanContract.test.ts
@@ -244,8 +244,8 @@ describe("useSorobanContract", () => {
   });
 
   it("network failure is surfaced through MSW", async () => {
-    server.use(
-      http.post(SOROBAN_RPC_URL, async () => HttpResponse.json({ error: "boom" }, { status: 500 }))
+    jest.spyOn(rpc.Server.prototype, "simulateTransaction").mockRejectedValue(
+      new Error("request failed with status code 500")
     );
 
     const { result } = renderHook(() =>
@@ -266,19 +266,8 @@ describe("useSorobanContract", () => {
   });
 
   it("simulation failure payload is surfaced", async () => {
-    server.use(
-      http.post(SOROBAN_RPC_URL, async ({ request }) => {
-        const body = (await request.json()) as { id?: number };
-
-        return HttpResponse.json({
-          jsonrpc: "2.0",
-          id: body.id ?? 1,
-          error: {
-            code: -32000,
-            message: "simulated host function failure",
-          },
-        });
-      })
+    jest.spyOn(rpc.Server.prototype, "simulateTransaction").mockRejectedValue(
+      new Error("simulated host function failure")
     );
 
     const { result } = renderHook(() =>


### PR DESCRIPTION
## fix: throw on unrecognised XDR type instead of silent toString fallback

Closes #145

---

## What was done

### The bug

`fromXdrValue` in both template hooks had a silent `default` fallback:

```js
default:
  return scVal.toString(); // returns "[object ScVal]" or raw hex — useless
```

When a contract returns an XDR type that isn't handled (e.g. a future Soroban protocol addition), the app received garbage data with no indication anything was wrong.

### The fix

Both templates now throw a descriptive error in the `default` case:

```js
default:
  throw new Error(
    `Unsupported Soroban XDR type: ${scVal.switch().name}. ` +
    `Please open an issue at https://github.com/nextellarlabs/nextellar/issues`
  );
```

The error message includes the exact XDR type name (e.g. `scvContractInstance`) so developers know exactly what's missing, and a direct link to open a GitHub issue to request support for it.

Applied to:
- `src/templates/js-template/src/hooks/useSorobanContract.js`
- `src/templates/default/src/hooks/useSorobanContract.ts`

### Test suite fixes (unblocked by this PR)

The `useSorobanContract` test suite was completely broken on `main` (0/11 tests ran). Three infrastructure issues were fixed to get it running:

**1. `js-template/package.json` — added `"type": "module"`**
The JS template had no module type declared, so Node/Jest loaded its `import`-based hooks as CommonJS and crashed before any test ran.

**2. `stellar-sdk-mock.ts` — re-exports real SDK symbols and uses a proper class**
The mock only exposed `rpc` but the JS hook also imports `xdr`, `Address`, `Contract`, `Account`, `TransactionBuilder`, `Networks`, and `Keypair`. These are now re-exported from the real SDK. The mock `Server` was also converted from a plain object factory to a real `class` so `jest.spyOn(rpc.Server.prototype, ...)` works correctly.

**3. `useSorobanContract.test.ts` — two error-path tests replaced MSW with spies**
Two tests set up MSW HTTP overrides to simulate a 500 response and an RPC error, but because `rpc.Server` is mocked, no real HTTP requests are ever made — MSW never triggers. These tests now use `jest.spyOn(...).mockRejectedValue(...)`, consistent with every other test in the file.

**Result: 11/11 tests pass** (was 0/11 on `main`).

---

## What was achieved

- Silent data corruption replaced with a clear, actionable error message
- Developers are immediately aware when their contract uses an unsupported XDR type
- The error includes the type name and a link to report it upstream
- All 11 `useSorobanContract` tests now pass
