### PR TITLE
fix: use stdio:inherit in install.ts so package manager output is vis…

### DIFF
--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -97,7 +97,7 @@ export async function runInstall(
     spinner: "dots",
   }).start();
 
-  const stdio = captureOutput ? "pipe" : "ignore"; // Use ignore to keep spinner visible
+  const stdio = captureOutput ? "pipe" : "inherit";
 
   try {
     await execa(command, args, {


### PR DESCRIPTION
## fix: use stdio:inherit in install.ts so package manager output is visible

Closes #143

---

## What was done

A single character change in [src/lib/install.ts](src/lib/install.ts):

```diff
- const stdio = captureOutput ? "pipe" : "ignore"; // Use ignore to keep spinner visible
+ const stdio = captureOutput ? "pipe" : "inherit";
```

`"ignore"` silently discarded all stdout and stderr from the package manager subprocess. When an install failed — registry error, peer dependency conflict, network timeout — the user saw only nextellar's generic "Installation failed" message with no context about what actually went wrong.

`"inherit"` passes the subprocess's file descriptors directly to the parent process, so npm/yarn/pnpm output appears in the terminal in real time. Users now see progress bars during install and the package manager's own error messages on failure.

The `captureOutput: true` path (used by tests) still uses `"pipe"` and is completely unaffected.

---

## What was achieved

- Package manager output (progress, warnings, errors) is visible during `nextellar my-app`
- Install failures surface the actual error from npm/yarn/pnpm, not just a generic message
- All 5 install tests pass
