### PR TITLE
fix: include horizonUrl in useEffect dependencies for balance and trustline hooks.

### DIFF
--- a/src/templates/default/src/hooks/useStellarBalances.ts
+++ b/src/templates/default/src/hooks/useStellarBalances.ts
@@ -278,7 +278,7 @@ export function useStellarBalances(
     return () => {
       stopPolling();
     };
-  }, [publicKey, pollIntervalMs, refresh, stopPolling]);
+  }, [publicKey, pollIntervalMs, refresh, stopPolling, horizonUrl]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/templates/default/src/hooks/useTrustlines.ts
+++ b/src/templates/default/src/hooks/useTrustlines.ts
@@ -484,7 +484,7 @@ export function useTrustlines(
 
     // Initial load
     refresh();
-  }, [publicKey, refresh]);
+  }, [publicKey, refresh, horizonUrl]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
fix: include horizonUrl in useEffect dependencies for balance and trustline hooks.

closes #113 