### PR TITLE
fix: validate XDR base64 string before passing to Stellar SDK in useS…

### DIFF
--- a/src/templates/default/src/hooks/useStellarPayment.ts
+++ b/src/templates/default/src/hooks/useStellarPayment.ts
@@ -248,11 +248,14 @@ export function useStellarPayment(
       throw new Error('Horizon server not initialized');
     }
 
-    if (!signedXdrBase64 || typeof signedXdrBase64 !== 'string') {
-      return {
-        success: false,
-        error: 'Invalid XDR: must be a non-empty string'
-      };
+    const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+    if (
+      !signedXdrBase64 || 
+      typeof signedXdrBase64 !== 'string' || 
+      signedXdrBase64.length <= 50 || 
+      !base64Regex.test(signedXdrBase64)
+    ) {
+      throw new Error('Invalid signed transaction XDR. The wallet may have returned a corrupted response.');
     }
 
     try {


### PR DESCRIPTION
# Description

This PR implements validation for the `signedXdrBase64` string passed to the Stellar SDK inside the [useStellarPayment](cci:1://file:///Users/kevinbrenes/nextellar/src/templates/default/src/hooks/useStellarPayment.ts:42:0-365:1) hook. Previously, passing invalid or truncated XDR strings (e.g. from a wallet returning corrupted data) resulted in vague, low-level error messages like "XDR decode failed" without any context for the user. 

Now, we catch this at the application layer by validating the XDR string format before parsing it. 

### Changes Made:
- Added `base64Regex` check (`/^[A-Za-z0-9+/]*={0,2}$/`) to ensure the input string is structurally valid base64.
- Added strict checks to verify the string is non-empty and of type `string`.
- Implemented a minimum length check (`> 50 chars`) since a valid bound Stellar transaction XDR is never shorter.
- Included a descriptive fallback error: `"Invalid signed transaction XDR. The wallet may have returned a corrupted response."`

## Motivation and Context
This acts as a failsafe against wallets returning corrupted or invalid payloads and prevents confusing unhandled parsing exceptions from being presented to end-users. 

## Related Issues
Closes #128 

## PR Title (Reminder)
`fix: validate XDR base64 string before passing to Stellar SDK in useStellarPayment`
