### PR TITLE
fix: clear stale error state in useSorobanContract

### DIFF
--- a/src/templates/default/src/hooks/useSorobanContract.ts
+++ b/src/templates/default/src/hooks/useSorobanContract.ts
@@ -542,9 +542,11 @@ export function useSorobanContract(
         }
 
         if ("result" in simulation && simulation.result?.retval) {
+          setError(null);
           return fromXdrValue(simulation.result.retval);
         }
 
+        setError(null);
         return null;
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
@@ -585,7 +587,9 @@ export function useSorobanContract(
           .addOperation(operation)
           .setTimeout(30);
 
-        return txBuilder.build().toXDR();
+        const xdrResult = txBuilder.build().toXDR();
+        setError(null);
+        return xdrResult;
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         setError(error);
@@ -622,7 +626,9 @@ export function useSorobanContract(
         const transaction = TransactionBuilder.fromXDR(xdr, networkPassphrase);
         const keypair = Keypair.fromSecret(secret);
         transaction.sign(keypair);
-        return await rpcServer.sendTransaction(transaction);
+        const result = await rpcServer.sendTransaction(transaction);
+        setError(null);
+        return result;
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         setError(error);

--- a/src/templates/js-template/src/hooks/useSorobanContract.js
+++ b/src/templates/js-template/src/hooks/useSorobanContract.js
@@ -159,8 +159,10 @@ export function useSorobanContract(opts) {
             }
             // Extract and convert the result
             if ("result" in simulation && simulation.result?.retval) {
+                setError(null);
                 return fromXdrValue(simulation.result.retval);
             }
+            setError(null);
             return null;
         }
         catch (err) {
@@ -198,7 +200,9 @@ export function useSorobanContract(opts) {
                 .addOperation(operation)
                 .setTimeout(30);
             const transaction = txBuilder.build();
-            return transaction.toXDR();
+            const xdrResult = transaction.toXDR();
+            setError(null);
+            return xdrResult;
         }
         catch (err) {
             const error = err instanceof Error ? err : new Error(String(err));
@@ -229,8 +233,8 @@ export function useSorobanContract(opts) {
             // Sign with the provided secret key (DEV-ONLY)
             const keypair = Keypair.fromSecret(secret);
             transaction.sign(keypair);
-            // Submit the transaction
             const result = await rpcServer.sendTransaction(transaction);
+            setError(null);
             return result;
         }
         catch (err) {


### PR DESCRIPTION
## Summary

Clear stale error state after successful execution in \useSorobanContract\ hook.

## Changes

- Add explicit \setError(null)\ after successful execution in \callFunction\, \uildInvokeXDR\, and \submitInvokeWithSecret\
- Applied to both TypeScript (default template) and JavaScript (js-template) versions

## Problem

When a contract call fails and sets an error, subsequent successful calls would not clear the stale error state, causing error UI to persist incorrectly.

## Testing

- All existing tests pass (11/11 in useSorobanContract suite)
- Full test suite: 97/97 tests passing
- Build succeeds

Closes #126