### PR TITLE
fix: reset isFetchingRef on re-mount in useSorobanEvents

### DIFF
--- a/src/templates/default/src/hooks/useSorobanEvents.ts
+++ b/src/templates/default/src/hooks/useSorobanEvents.ts
@@ -323,6 +323,7 @@ export function useSorobanEvents(
 
   useEffect(() => {
     isMountedRef.current = true;
+    isFetchingRef.current = false;
     cursorRef.current = fromCursor;
 
     // Run initial fetch immediately, then let refresh schedule polling

--- a/src/templates/js-template/src/hooks/useSorobanEvents.js
+++ b/src/templates/js-template/src/hooks/useSorobanEvents.js
@@ -217,6 +217,7 @@ export function useSorobanEvents(contractId, opts = {}) {
     // ── Initial load + polling setup ───────────────────────────────────────────
     useEffect(() => {
         isMountedRef.current = true;
+        isFetchingRef.current = false;
         cursorRef.current = fromCursor;
         // Run initial fetch immediately, then let refresh schedule polling
         refresh();


### PR DESCRIPTION
## Summary

Fix skipped updates during dependency changes in \useSorobanEvents\ hook by resetting \isFetchingRef\ on re-mount.

## Changes

- Add \isFetchingRef.current = false\ at the top of the effect body alongside \isMountedRef.current = true\
- Applied to both TypeScript (default template) and JavaScript (js-template) versions

## Problem

When dependencies (\contractId\, \sorobanRpc\) change, the effect cleanup sets \isMountedRef.current = false\ but does not reset \isFetchingRef\. If a fetch is still in-flight, the new effect's \efresh()\ call bails out because \isFetchingRef.current\ is still \	rue\, causing updates to be silently skipped.

## Testing

- All existing tests pass (24/24 in useSorobanEvents suite)
- Full test suite: 97/97 tests passing
- Build succeeds

Closes #125