### PR TITLE
fix: remove duplicate sorobanUrl key in WalletProvider

### DIFF
--- a/src/templates/default/src/contexts/WalletProvider.tsx
+++ b/src/templates/default/src/contexts/WalletProvider.tsx
@@ -59,7 +59,6 @@ interface WalletConfigContextState {
   horizonUrl: string;
   sorobanUrl: string;
   network: string;
-  sorobanUrl: string;
   switchNetwork: (networkKey: string) => void;
 }
 
@@ -356,7 +355,6 @@ export function WalletProvider({
     horizonUrl,
     sorobanUrl,
     network,
-    sorobanUrl,
     switchNetwork,
   };
 


### PR DESCRIPTION
## Summary

Remove duplicate \sorobanUrl\ declarations in the default template's \WalletProvider.tsx\.

## Changes

- Remove duplicate \sorobanUrl: string\ from \WalletConfigContextState\ interface
- Remove duplicate \sorobanUrl\ from \configValue\ object literal

## Problem

The \sorobanUrl\ key appeared twice in both the \WalletConfigContextState\ interface and the \configValue\ useMemo object. While TypeScript silently uses the last occurrence, duplicate keys are a code quality issue and can cause confusion.

## Testing

- Build succeeds with no errors
- Full test suite: 97/97 tests passing
- Only the default template had this issue; minimal, defi, and js-template are clean

Closes #108