### PR TITLE
fix: add isValidUrl check to interactive URL prompts

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -10,6 +10,7 @@ import {
   text,
 } from "@clack/prompts";
 import { detectPackageManager } from "./install.js";
+import { isValidUrl } from "./validate.js";
 
 export interface PromptResult {
   projectName: string;
@@ -85,7 +86,7 @@ export async function runInteractivePrompts(
         message: "Horizon URL",
         initialValue: "https://horizon-testnet.stellar.org",
         validate: (value: string) => {
-          if (!value || value.trim().length === 0) return "Horizon URL is required";
+          if (!isValidUrl(value)) return "Must be a valid HTTP/HTTPS URL (e.g. https://horizon-testnet.stellar.org)";
         },
       });
 
@@ -98,7 +99,7 @@ export async function runInteractivePrompts(
         message: "Soroban RPC URL",
         initialValue: "https://soroban-testnet.stellar.org",
         validate: (value: string) => {
-          if (!value || value.trim().length === 0) return "Soroban URL is required";
+          if (!isValidUrl(value)) return "Must be a valid HTTP/HTTPS URL (e.g. https://horizon-testnet.stellar.org)";
         },
       });
 


### PR DESCRIPTION
## Summary
- Import `isValidUrl` from `validate.ts` into `prompts.ts`
- Replace naive non-empty string checks with `isValidUrl` for both Horizon URL and Soroban RPC URL interactive prompts
- Invalid URLs (empty, malformed, non-HTTP/HTTPS) now display: `"Must be a valid HTTP/HTTPS URL (e.g. https://horizon-testnet.stellar.org)"`

## Test plan
- [x] `npm run build` passes
- [x] All 97 tests pass (`npm test`)
- [ ] Manual: enter `not-a-url` at Horizon prompt → rejected with error message
- [ ] Manual: enter `htps://invalid.com` at Soroban prompt → rejected
- [ ] Manual: enter `https://horizon-testnet.stellar.org` → accepted
- [ ] Manual: enter `http://localhost:8000` → accepted

Closes #124 