### PR TITLE
fix: clarify doctor memory check label to say RAM not Disk/Memory

### DIFF
--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -223,11 +223,11 @@ async function checkDisk(): Promise<CheckResult> {
   const ok = free > 1_000_000_000; // > 1GB
   return {
     id: "disk",
-    name: "Disk / Memory",
+    name: "Free Memory (RAM)",
     required: true,
     ok,
-    detail: ok ? `${Math.round(free / (1024 * 1024))} MB free` : `${Math.round(free / (1024 * 1024))} MB free`,
-    fix: "Free up at least 1GB of memory/disk space",
+    detail: ok ? `${Math.round(free / (1024 * 1024))} MB RAM free` : `${Math.round(free / (1024 * 1024))} MB RAM free`,
+    fix: "Free up at least 1GB of RAM",
   };
 }
 


### PR DESCRIPTION
## Summary

Rename misleading label in the \doctor\ command's memory check.

## Changes

- Label: \Disk / Memory\ -> \Free Memory (RAM)\
- Detail: \X MB free\ -> \X MB RAM free\
- Fix message: \Free up at least 1GB of memory/disk space\ -> \Free up at least 1GB of RAM\

The check uses \os.freemem()\ which reports RAM only, not disk. The labels now accurately reflect this.

## Testing

- Build passes
- All tests pass (11 suites, 97 tests)

Closes #120 