### PR TITLE
release: bump version to 1.1.0 and fix stellar-sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextellar",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "type": "module",
   "bin": {
     "nextellar": "dist/bin/nextellar.js"


### PR DESCRIPTION
## Summary

Prepare project for npm publish with version bump.

## Changes

- Version: \1.0.4\ -> \1.1.0\
- \@stellar/stellar-sdk\ already at \^14.4.3\ (verified correct)

## Validation

- Build passes
- All tests pass (11 suites, 97 tests)
- CLI smoke test: \
ode dist/bin/nextellar.js test-app --defaults --skip-install\ scaffolds correctly with correct SDK version
- \
pm publish --dry-run\ succeeds, shows \
extellar@1.1.0\

Closes #104 