### PR TITLE
fix: add try/finally to readline prompt in upgrade.ts to prevent resource leak

### DIFF
--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -132,12 +132,18 @@ export async function upgrade(opts: UpgradeOptions = {}) {
   if (!opts.yes) {
     // Prompt the user with Node built-ins to avoid extra runtime deps.
     const rl = readline.createInterface({ input, output });
-    const answer =
-      (await rl.question(pc.yellow("Apply these changes? (y/N) "))) || "";
-    rl.close();
-    if (!/^y(es)?$/i.test(answer.trim())) {
-      console.log("Aborted by user.");
+    try {
+      const answer =
+        (await rl.question(pc.yellow("Apply these changes? (y/N) "))) || "";
+      if (!/^y(es)?$/i.test(answer.trim())) {
+        console.log("Aborted by user.");
+        return;
+      }
+    } catch {
+      console.log("\nUpgrade cancelled.");
       return;
+    } finally {
+      rl.close();
     }
   }
 


### PR DESCRIPTION
## Summary

Fix unsafe readline usage in the upgrade prompt that could cause unhandled rejections and resource leaks.

## Changes

- Wrap \
l.question()\ in try/catch/finally
- \
l.close()\ is now guaranteed to run in \inally\ block
- On error: prints user-friendly message and cancels upgrade (safe default)

## Testing

- Build passes
- All tests pass (11 suites, 97 tests)

Closes #119 