### PR TITLE
fix: resolve wave-3 telemetry, wallet provider, and prepublish issues

### DIFF
--- a/bin/nextellar.ts
+++ b/bin/nextellar.ts
@@ -12,6 +12,7 @@ import { displaySuccess, NEXTELLAR_LOGO } from "../src/lib/feedback.js";
 import { detectPackageManager } from "../src/lib/install.js";
 import { runInteractivePrompts } from "../src/lib/prompts.js";
 import {
+  flushTelemetry,
   getTelemetryStatus,
   isTelemetryDisabledByEnv,
   maybeShowTelemetryNotice,
@@ -40,6 +41,11 @@ const findPkg = () => {
 
 const pkg = findPkg();
 
+const exitWithTelemetry = async (code: number): Promise<never> => {
+  await flushTelemetry();
+  process.exit(code);
+};
+
 const program = new Command();
 
 // Register a dedicated `doctor` subcommand so Commander handles `--json`.
@@ -51,10 +57,10 @@ program
     try {
       const { runDoctor } = await import("../src/lib/doctor.js");
       const exitCode = await runDoctor({ json: !!cmdOpts.json });
-      process.exit(exitCode);
+      await exitWithTelemetry(exitCode);
     } catch (err: any) {
       console.error("Failed to run doctor:", err?.message || err);
-      process.exit(1);
+      await exitWithTelemetry(1);
     }
   });
 
@@ -81,7 +87,7 @@ program
       }
       if (!feature || feature.trim() === "") {
         console.error("Please specify a feature. Use " + pc.cyan("nextellar add --list") + " to see options.");
-        process.exit(1);
+        return await exitWithTelemetry(1);
       }
       const result = await runAdd(feature, {
         force: cmdOpts.force,
@@ -90,11 +96,13 @@ program
       });
       if (!result.success) {
         console.error(result.message ?? "Add failed.");
-        process.exit(1);
+        await exitWithTelemetry(1);
       }
     } catch (err: any) {
       console.error("Add failed:", err?.message || err);
-      process.exit(1);
+      await exitWithTelemetry(1);
+    } finally {
+      await flushTelemetry();
     }
   });
 
@@ -102,38 +110,42 @@ program
   .command("telemetry <action>")
   .description("Manage anonymous telemetry settings")
   .action(async (action: string) => {
-    const normalized = action.toLowerCase();
+    try {
+      const normalized = action.toLowerCase();
 
-    if (normalized === "status") {
-      const status = await getTelemetryStatus();
-      console.log(`Telemetry is ${status}.`);
-      console.log(`Config: ${telemetryConfigPath}`);
-      if (isTelemetryDisabledByEnv()) {
-        console.log(
-          "NEXTELLAR_TELEMETRY_DISABLED is set, so telemetry is forced off for this environment."
-        );
+      if (normalized === "status") {
+        const status = await getTelemetryStatus();
+        console.log(`Telemetry is ${status}.`);
+        console.log(`Config: ${telemetryConfigPath}`);
+        if (isTelemetryDisabledByEnv()) {
+          console.log(
+            "NEXTELLAR_TELEMETRY_DISABLED is set, so telemetry is forced off for this environment."
+          );
+        }
+        return;
       }
-      return;
-    }
 
-    if (normalized === "disable") {
-      await setTelemetryEnabled(false);
-      console.log("Telemetry disabled.");
-      console.log(`Saved to: ${telemetryConfigPath}`);
-      return;
-    }
+      if (normalized === "disable") {
+        await setTelemetryEnabled(false);
+        console.log("Telemetry disabled.");
+        console.log(`Saved to: ${telemetryConfigPath}`);
+        return;
+      }
 
-    if (normalized === "enable") {
-      await setTelemetryEnabled(true);
-      console.log("Telemetry enabled.");
-      console.log(`Saved to: ${telemetryConfigPath}`);
-      return;
-    }
+      if (normalized === "enable") {
+        await setTelemetryEnabled(true);
+        console.log("Telemetry enabled.");
+        console.log(`Saved to: ${telemetryConfigPath}`);
+        return;
+      }
 
-    console.error(
-      `Unknown telemetry action \"${action}\". Use: status, enable, disable.`
-    );
-    process.exit(1);
+      console.error(
+        `Unknown telemetry action \"${action}\". Use: status, enable, disable.`
+      );
+      await exitWithTelemetry(1);
+    } finally {
+      await flushTelemetry();
+    }
   });
 
 program
@@ -146,7 +158,9 @@ program
       await upgrade({ dryRun: options.dryRun, yes: options.yes });
     } catch (err: any) {
       console.error(`\n❌ Error: ${err.message}`);
-      process.exit(1);
+      await exitWithTelemetry(1);
+    } finally {
+      await flushTelemetry();
     }
   });
 
@@ -162,7 +176,9 @@ program
       });
     } catch (err: any) {
       console.error(`\n❌ Error: ${err?.message || err}`);
-      process.exit(1);
+      await exitWithTelemetry(1);
+    } finally {
+      await flushTelemetry();
     }
   });
 
@@ -233,7 +249,7 @@ program.action(async (projectName, options) => {
     console.error(
       `Unknown template "${template}". Available: default, minimal, defi`,
     );
-    process.exit(1);
+    return await exitWithTelemetry(1);
   }
 
   // Clear console and show welcome banner
@@ -286,7 +302,7 @@ program.action(async (projectName, options) => {
     });
 
     if (!promptResult) {
-      process.exit(0);
+      return await exitWithTelemetry(0);
     }
 
     finalProjectName = promptResult.projectName;
@@ -335,7 +351,9 @@ program.action(async (projectName, options) => {
     await displaySuccess(finalProjectName, pkgManager, finalSkipInstall);
   } catch (err: any) {
     console.error(`\n❌ Error: ${err.message}`);
-    process.exit(1);
+    await exitWithTelemetry(1);
+  } finally {
+    await flushTelemetry();
   }
 });
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -7,7 +7,7 @@ Nextellar telemetry is anonymous, minimal, and opt-in.
 - Telemetry is disabled by default until explicitly enabled.
 - On first run, Nextellar shows a transparency notice:
   - `Nextellar collects anonymous usage data to improve the tool.`
-  - `You can disable this with --no-telemetry or NEXTELLAR_TELEMETRY_DISABLED=1`
+  - `You can disable this with --no-telemetry or NEXTELLAR_TELEMETRY_DISABLED=1|true|yes|on`
   - `Learn more: https://nextellar.dev/telemetry`
 - Users can manage preferences with:
   - `nextellar telemetry status`
@@ -19,7 +19,7 @@ Preferences are stored in `~/.nextellar/config.json`.
 ## Disable Controls
 
 - Per invocation: `--no-telemetry`
-- Environment override: `NEXTELLAR_TELEMETRY_DISABLED=1`
+- Environment override: `NEXTELLAR_TELEMETRY_DISABLED=1|true|yes|on` (case-insensitive)
 - Persistent opt-out: `nextellar telemetry disable`
 
 ## Data Collected

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "ts-node bin/nextellar.ts",
     "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest",
     "clean": "rimraf dist",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm test && npm run build"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -35,9 +35,16 @@ interface TelemetryEvent {
   properties: ScaffoldTelemetryProperties;
 }
 
+const TELEMETRY_TIMEOUT_MS = 3000;
+const pendingTelemetryRequests = new Set<Promise<void>>();
+
 export function isTelemetryDisabledByEnv(): boolean {
   const value = process.env.NEXTELLAR_TELEMETRY_DISABLED;
-  return value === "1" || value === "true";
+  if (!value) {
+    return false;
+  }
+
+  return /^(1|true|yes|on)$/i.test(value.trim());
 }
 
 export async function readTelemetryConfig(): Promise<TelemetryConfig> {
@@ -106,7 +113,7 @@ export async function maybeShowTelemetryNotice(options?: {
 
   console.log("\nNextellar collects anonymous usage data to improve the tool.");
   console.log(
-    "You can disable this with --no-telemetry or NEXTELLAR_TELEMETRY_DISABLED=1"
+    "You can disable this with --no-telemetry or NEXTELLAR_TELEMETRY_DISABLED=1|true|yes|on"
   );
   console.log("Learn more: https://nextellar.dev/telemetry\n");
 
@@ -159,7 +166,7 @@ function shouldSkipTelemetry(noTelemetryFlag?: boolean): boolean {
 async function postTelemetryEvent(event: TelemetryEvent): Promise<void> {
   const endpoint = process.env.NEXTELLAR_TELEMETRY_ENDPOINT || DEFAULT_ENDPOINT;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 3000);
+  const timeout = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
 
   try {
     await fetch(endpoint, {
@@ -174,6 +181,28 @@ async function postTelemetryEvent(event: TelemetryEvent): Promise<void> {
     // Silent failure: telemetry should never block scaffolding.
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+export async function flushTelemetry(): Promise<void> {
+  if (isTelemetryDisabledByEnv() || pendingTelemetryRequests.size === 0) {
+    return;
+  }
+
+  const timeoutPromise = new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      clearTimeout(timeout);
+      resolve();
+    }, TELEMETRY_TIMEOUT_MS);
+  });
+
+  try {
+    await Promise.race([
+      Promise.allSettled(Array.from(pendingTelemetryRequests)).then(() => undefined),
+      timeoutPromise,
+    ]);
+  } catch {
+    // Never allow telemetry flush to break CLI commands.
   }
 }
 
@@ -195,10 +224,15 @@ export async function trackScaffoldEvent(
     return;
   }
 
-  void postTelemetryEvent({
+  const request = postTelemetryEvent({
     event: "scaffold",
     anonymousId,
     properties,
+  });
+
+  pendingTelemetryRequests.add(request);
+  void request.finally(() => {
+    pendingTelemetryRequests.delete(request);
   });
 }
 

--- a/src/templates/default/src/contexts/WalletProvider.tsx
+++ b/src/templates/default/src/contexts/WalletProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react';
 import {
   Horizon,
   TransactionBuilder,
@@ -120,10 +120,13 @@ export function WalletProvider({
   const network = initialNetwork || config.passphrase;
 
   const [server, setServer] = useState(() => new Server(horizonUrl));
+  const serverRef = useRef(server);
 
   // Update server when network changes
   useEffect(() => {
-    setServer(new Server(horizonUrl));
+    const nextServer = new Server(horizonUrl);
+    setServer(nextServer);
+    serverRef.current = nextServer;
   }, [horizonUrl]);
 
   /**
@@ -157,7 +160,7 @@ export function WalletProvider({
 
           // Load balances
           try {
-            const account = await server.accounts().accountId(address).call();
+            const account = await serverRef.current.accounts().accountId(address).call();
             setBalances(account.balances);
           } catch (error: unknown) {
             if (error && typeof error === 'object' && 'response' in error && (error as { response?: { status?: number } }).response?.status === 404) {
@@ -173,7 +176,7 @@ export function WalletProvider({
       console.error('Failed to connect wallet:', error);
       throw error;
     }
-  }, [server]);
+  }, [activeNetworkKey]);
 
   /**
    * Disconnect wallet and clear state
@@ -223,7 +226,7 @@ export function WalletProvider({
     if (!publicKey) return;
 
     try {
-      const account = await server.accounts().accountId(publicKey).call();
+      const account = await serverRef.current.accounts().accountId(publicKey).call();
       setBalances(account.balances);
     } catch (error: unknown) {
       if (error && typeof error === 'object' && 'response' in error && (error as { response?: { status?: number } }).response?.status === 404) {
@@ -233,7 +236,7 @@ export function WalletProvider({
         setBalances([]);
       }
     }
-  }, [publicKey, server]);
+  }, [publicKey]);
 
   /**
    * Send a payment transaction
@@ -244,7 +247,7 @@ export function WalletProvider({
     }
 
     try {
-      const account = await server.loadAccount(publicKey);
+      const account = await serverRef.current.loadAccount(publicKey);
       const asset = opts.asset === 'XLM' || !opts.asset
         ? Asset.native()
         : new Asset(opts.asset.code, opts.asset.issuer);
@@ -283,7 +286,7 @@ export function WalletProvider({
       }
 
       const signedTransaction = TransactionBuilder.fromXDR(signedTxXdr, network);
-      const result = await server.submitTransaction(signedTransaction);
+      const result = await serverRef.current.submitTransaction(signedTransaction);
 
       await refreshBalances();
       return result;
@@ -291,7 +294,7 @@ export function WalletProvider({
       console.error('Payment failed:', error);
       throw error;
     }
-  }, [publicKey, connected, server, network, refreshBalances]);
+  }, [publicKey, connected, network, refreshBalances]);
 
   // Auto-reconnect wallet on mount if previously connected
   useEffect(() => {
@@ -316,7 +319,7 @@ export function WalletProvider({
             setConnected(true);
 
             try {
-              const account = await server.accounts().accountId(address).call();
+              const account = await serverRef.current.accounts().accountId(address).call();
               setBalances(account.balances);
             } catch (error: unknown) {
               if (error && typeof error === 'object' && 'response' in error && (error as { response?: { status?: number } }).response?.status === 404) {
@@ -338,7 +341,7 @@ export function WalletProvider({
     };
 
     autoReconnect();
-  }, [server]);
+  }, [activeNetworkKey]);
 
   const walletValue: WalletContextState = {
     connected,


### PR DESCRIPTION
## Summary
- add pending telemetry request tracking with a safe `flushTelemetry()` cap so CLI commands wait briefly for in-flight events before exit without failing commands
- expand `NEXTELLAR_TELEMETRY_DISABLED` handling to accept `1|true|yes|on` (case-insensitive) and update telemetry docs/notice text
- prevent stale Horizon server usage in the default WalletProvider connect/balance/payment/reconnect flows by reading from an updated server ref
- update `prepublishOnly` to run `clean -> test -> build` so broken test suites block publish

Closes #122
Closes #123
Closes #130
Closes #131