### PR TITLE
Replace hardcoded JWT secret with environment variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Required — JWT signing secret. Use a long random string (e.g. openssl rand -hex 64).
+# The server will refuse to start if this variable is not set.
+JWT_SECRET=your-secret-here

--- a/backend/auth/token.ts
+++ b/backend/auth/token.ts
@@ -1,0 +1,32 @@
+import jwt from "jsonwebtoken";
+
+/**
+ * Reads JWT_SECRET from the environment at module load time.
+ * Throws immediately if the variable is absent — the server should
+ * never start with an undefined signing secret.
+ */
+function requireJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error(
+      "Missing required environment variable: JWT_SECRET. " +
+        "Set it in your .env file or deployment environment before starting the server.",
+    );
+  }
+  return secret;
+}
+
+const JWT_SECRET = requireJwtSecret();
+
+export type TokenPayload = {
+  sub: string;
+  role: string;
+};
+
+export function signToken(payload: TokenPayload, expiresIn = "1h"): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn });
+}
+
+export function verifyToken(token: string): TokenPayload {
+  return jwt.verify(token, JWT_SECRET) as TokenPayload;
+}

--- a/tests/auth/token.test.ts
+++ b/tests/auth/token.test.ts
@@ -1,0 +1,53 @@
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("token module startup", () => {
+  it("throws on import when JWT_SECRET is not set", async () => {
+    delete process.env.JWT_SECRET;
+    await expect(import("../../backend/auth/token")).rejects.toThrow(
+      "Missing required environment variable: JWT_SECRET",
+    );
+  });
+
+  it("loads successfully when JWT_SECRET is set", async () => {
+    process.env.JWT_SECRET = "test-secret-value";
+    await expect(import("../../backend/auth/token")).resolves.toBeDefined();
+  });
+});
+
+describe("signToken / verifyToken", () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-secret-value";
+  });
+
+  it("signs and verifies a token round-trip", async () => {
+    const { signToken, verifyToken } = await import("../../backend/auth/token");
+
+    const token = signToken({ sub: "user-123", role: "admin" });
+    const payload = verifyToken(token);
+
+    expect(payload.sub).toBe("user-123");
+    expect(payload.role).toBe("admin");
+  });
+
+  it("throws when verifying a token signed with a different secret", async () => {
+    const { signToken } = await import("../../backend/auth/token");
+    const token = signToken({ sub: "user-123", role: "user" });
+
+    // Re-load module with a different secret
+    jest.resetModules();
+    process.env.JWT_SECRET = "completely-different-secret";
+    const { verifyToken: verifyWithOtherSecret } =
+      await import("../../backend/auth/token");
+
+    expect(() => verifyWithOtherSecret(token)).toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

The JWT signing secret in backend/auth/token.ts was hardcoded as a plain
string literal. Anyone with read access to the repo could forge valid tokens.

## Changes

- `backend/auth/token.ts`
  - Removes the hardcoded secret entirely
  - Reads JWT_SECRET from process.env at module load time via requireJwtSecret()
  - Throws with a clear, actionable error message if the variable is absent —
    no silent fallback, no default value
- `backend/.env.example`
  - Documents JWT_SECRET with a comment explaining the requirement and how
    to generate a strong value

## Tests

Four cases in `tests/auth/token.test.ts`:
- ✅ Module throws on import when JWT_SECRET is not set
- ✅ Module loads cleanly when JWT_SECRET is present
- ✅ signToken / verifyToken round-trip succeeds
- ✅ Verification fails when token was signed with a different secret

## Required dependency

npm install jsonwebtoken
npm install --save-dev @types/jsonwebtoken

this pr Closes #181 
