### PR TITLE
fix(backend): remove WebSocket listener leak in notifications handler

### DIFF
--- a/backend/ws/notifications.ts
+++ b/backend/ws/notifications.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from 'node:events';
+
+export interface NotificationSocket extends EventEmitter {
+  send(data: string): void;
+}
+
+type MessageHandler = (data: Buffer | string) => void;
+type ErrorHandler = (err: Error) => void;
+type CloseHandler = () => void;
+
+interface ConnectionHandlers {
+  onMessage: MessageHandler;
+  onError: ErrorHandler;
+  onClose: CloseHandler;
+}
+
+// WeakMap so the socket itself is the only strong reference — no retention after GC
+const handlerRegistry = new WeakMap<NotificationSocket, ConnectionHandlers>();
+
+export function handleConnection(socket: NotificationSocket): void {
+  const onMessage: MessageHandler = (data) => {
+    const raw = data instanceof Buffer ? data.toString('utf8') : data;
+    try {
+      JSON.parse(raw); // validate JSON; extend with business logic as needed
+    } catch {
+      // silently drop malformed frames
+    }
+  };
+
+  const onError: ErrorHandler = (err) => {
+    console.error('[ws:notifications] socket error:', err.message);
+  };
+
+  const onClose: CloseHandler = () => {
+    socket.off('message', onMessage);
+    socket.off('error', onError);
+    socket.off('close', onClose);
+    handlerRegistry.delete(socket);
+  };
+
+  handlerRegistry.set(socket, { onMessage, onError, onClose });
+
+  socket.on('message', onMessage);
+  socket.on('error', onError);
+  socket.on('close', onClose);
+}
+
+export function getActiveListenerCount(socket: NotificationSocket): number {
+  return (
+    socket.listenerCount('message') +
+    socket.listenerCount('error') +
+    socket.listenerCount('close')
+  );
+}

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,32 +1,20 @@
 export default {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true
-    }
-  },
+  setupFilesAfterEnv: ['./jest.setup.js'],
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', {
-      useESM: true,
-      tsconfig: {
-        module: 'ESNext',
-        moduleResolution: 'Bundler',
-        target: 'ES2022',
-        jsx: 'react-jsx',
-        esModuleInterop: true,
-        allowSyntheticDefaultImports: true,
-        strict: true,
-        skipLibCheck: true,
-      },
-    }]
+    '^.+\\.[tj]sx?$': ['babel-jest', {
+      presets: [
+        ['@babel/preset-env', { targets: { node: 'current' }, modules: false }],
+        ['@babel/preset-typescript'],
+      ],
+    }],
   },
   moduleNameMapper: {
     '^\\.\\./contexts$': '<rootDir>/src/mocks/wallet-contexts-mock.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
-  moduleFileExtensions: ['ts', 'js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testMatch: [
     '**/tests/**/*.test.ts',
     '**/tests/**/*.test.tsx',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,30 @@
+// jest.setup.js — JS equivalent of jest.setup.ts (no type annotations)
+
+import { TextEncoder, TextDecoder } from 'util';
+Object.assign(global, { TextEncoder, TextDecoder });
+
+import { jest } from '@jest/globals';
+Object.assign(global, { jest });
+
+import '@testing-library/jest-dom';
+
+class BroadcastChannel {
+  constructor(name) {
+    this.name = name;
+    this.onmessage = null;
+  }
+  postMessage(_message) {}
+  close() {}
+}
+Object.assign(global, { BroadcastChannel });
+
+import { ReadableStream, WritableStream, TransformStream } from 'web-streams-polyfill';
+Object.assign(global, { ReadableStream, WritableStream, TransformStream });
+
+const undici = await import('undici');
+Object.assign(globalThis, {
+  Headers: undici.Headers,
+  Request: undici.Request,
+  Response: undici.Response,
+  fetch: undici.fetch,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "@stellar/stellar-sdk": "^12.0.0",
+        "@unrs/resolver-binding-win32-x64-msvc": "^1.11.1",
         "commander": "^14.0.0",
         "execa": "^9.6.0",
         "express": "^5.2.1",
@@ -123,6 +124,7 @@
       "version": "7.28.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1760,7 +1762,6 @@
       "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@stellar/stellar-base": "^13.1.0",
         "axios": "^1.8.4",
@@ -1781,7 +1782,6 @@
       "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
@@ -1939,6 +1939,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1960,6 +1961,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2931,7 +2933,6 @@
       "integrity": "sha512-ni3QT9H3NdrbVVKyx56yvz93r89Dvpc/vgVtiIK2OdXjkK6jcj+UKMDRQ6F7rd9qJOInLkHZbVBtcR6j1CXLjw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/providers": "1.0.3",
@@ -2952,8 +2953,7 @@
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@near-js/crypto": {
       "version": "1.4.2",
@@ -2983,7 +2983,6 @@
       "integrity": "sha512-DLhi/3a4qJUY+wgphw2Jl4S+L0AKsUYm1mtU0WxKYV5OBwjOXvbGrXNfdkheYkfh3nHwrQgtjvtszX6LrRXLLw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/types": "0.3.1"
@@ -2995,7 +2994,6 @@
       "integrity": "sha512-Pxqm7WGtUu6zj32vGCy9JcEDpZDSB5CCaLQDTQdF3GQyL0flyRv2I/guLAgU5FLoYxU7dJAX9mslJhPW7P2Bfw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/keystores": "0.2.2"
@@ -3007,7 +3005,6 @@
       "integrity": "sha512-MWLvTszZOVziiasqIT/LYNhUyWqOJjDGlsthOsY6dTL4ZcXjjmhmzrbFydIIeQr+CcEl5wukTo68ORI9JrHl6g==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/keystores": "0.2.2"
@@ -3019,7 +3016,6 @@
       "integrity": "sha512-VJMboL14R/+MGKnlhhE3UPXCGYvMd1PpvF9OqZ9yBbulV7QVSIdTMfY4U1NnDfmUC2S3/rhAEr+3rMrIcNS7Fg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/transactions": "1.3.3",
         "@near-js/types": "0.3.1",
@@ -3036,8 +3032,7 @@
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@near-js/providers/node_modules/node-fetch": {
       "version": "2.6.7",
@@ -3046,7 +3041,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3068,8 +3062,7 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@near-js/providers/node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -3077,8 +3070,7 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@near-js/providers/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3087,7 +3079,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3099,7 +3090,6 @@
       "integrity": "sha512-M6ib+af9zXAPRCjH2RyIS0+RhCmd9gxzCeIkQ+I2A3zjgGiEDkBZbYso9aKj8Zh2lPKKSH7h+u8JGymMOSwgyw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/keystores": "0.2.2",
@@ -3112,7 +3102,6 @@
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -3126,7 +3115,6 @@
       "integrity": "sha512-1AXD+HuxlxYQmRTLQlkVmH+RAmV3HwkAT8dyZDu+I2fK/Ec9BQHXakOJUnOBws3ihF+akQhamIBS5T0EXX/Ylw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/signers": "0.2.2",
@@ -3141,8 +3129,7 @@
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@near-js/types": {
       "version": "0.3.1",
@@ -3170,7 +3157,6 @@
       "integrity": "sha512-GDzg/Kz0GBYF7tQfyQQQZ3vviwV8yD+8F2lYDzsWJiqIln7R1ov0zaXN4Tii86TeS21KPn2hHAsVu3Y4txa8OQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@near-js/accounts": "1.4.1",
         "@near-js/crypto": "1.4.2",
@@ -3188,8 +3174,7 @@
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@near-wallet-selector/core": {
       "version": "8.10.2",
@@ -3226,6 +3211,7 @@
       "integrity": "sha512-13BItNZFgHglTiXuP9XhisNczwQ5QSzH+imAv9nAPsdbCq/3ortqkIYRnlxB8DGPVcuIjLujQ4OcZa+9QWgZtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "rxjs": ">=7.0.0"
       }
@@ -3839,6 +3825,7 @@
       "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/addresses": "2.3.0",
@@ -4221,6 +4208,7 @@
       "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/codecs": "2.3.0",
@@ -4349,6 +4337,7 @@
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -4573,7 +4562,6 @@
       "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.9.6",
         "@stellar/js-xdr": "^3.1.2",
@@ -4592,7 +4580,6 @@
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -4609,7 +4596,6 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4663,7 +4649,6 @@
       "version": "10.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4682,7 +4667,6 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4691,7 +4675,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4703,7 +4686,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4716,8 +4698,7 @@
     "node_modules/@testing-library/dom/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.4",
@@ -4775,7 +4756,6 @@
       "integrity": "sha512-evILW5XJEmfPlf0TY1duOLtGJ47pdGeSKVE3P75ODEUsRNxtPVqlkOUBPmYpCxPnzS8XDmkatT8lf9/DF0G6nA==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@trezor/env-utils": "1.5.0",
         "@trezor/utils": "9.5.0"
@@ -4790,7 +4770,6 @@
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -4818,7 +4797,6 @@
       "integrity": "sha512-SPwxkihOMI0o79BOy0RkfgVL2meuJhIe1yWHCeR8uoqf5KGblUyeXxvNCy6w8ckJ9LRpM1+bZhsUODuNs3083Q==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@solana-program/compute-budget": "^0.8.0",
         "@solana-program/stake": "^0.2.1",
@@ -4849,7 +4827,6 @@
       "integrity": "sha512-Idavz6LwLBW8sXc69fh5AJEnl666EDl2Nt3io7updvBgOR0/P12I900DgjNhCKtiWuv66A33/5RE7zLcj3lfnw==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "@trezor/utxo-lib": "2.5.0"
@@ -4864,7 +4841,6 @@
       "integrity": "sha512-OSS5OEE98FMnYfjoEALPjBt7ebjC/FKnq3HOolHdEWXBpVlXZNN2+Vo1R9J6WbZUU087sHuUTJJy/GJYWY13Tg==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@stellar/stellar-sdk": "14.2.0",
@@ -4884,7 +4860,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@stellar/stellar-base": "^14.0.1",
         "axios": "^1.12.2",
@@ -4905,7 +4880,6 @@
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -4934,7 +4908,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@stellar/stellar-base": "^14.0.1",
         "axios": "^1.12.2",
@@ -4955,7 +4928,6 @@
       "integrity": "sha512-wD6FKKxNr89MTWYL+NikRkBcWXhiWNFR0AuDHW6GHmlCEHhKu/hAvQtcER8X5jt/Wd0hSKNZqtHBXJ1ZkpJ6rg==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "@trezor/utxo-lib": "2.5.0"
@@ -4970,7 +4942,6 @@
       "integrity": "sha512-2tDGLEj5jzydjsJQONGTWVmCDDy6FTZ4ytr1/2gE6anyYEJU8MbaR+liTt3UvcP5jwZTNutwYLvZixRfrb8JpA==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@stellar/stellar-sdk": "14.2.0",
@@ -4989,7 +4960,6 @@
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -5017,7 +4987,6 @@
       "integrity": "sha512-nAkaCCAqLpErBd+IuKeG5MpbyLR/2RMgCw18TWc80m1Ws/XgQirhHY9Jbk6gLImTXb9GTrxP0+MDSahzd94rSA==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@trezor/schema-utils": "1.4.0",
         "long": "5.2.5",
@@ -5033,7 +5002,6 @@
       "integrity": "sha512-Sn6F4mNH+yi2vAHy29kwhs50bRLn92drg3znm3pkY+8yEBxI4MmuP8sKYjdgUEJnQflWh80KlcvEDeVa4olVRA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^10.1.0",
         "@ethereumjs/tx": "^10.1.0",
@@ -5079,7 +5047,6 @@
       "integrity": "sha512-hy2J2oeIhRC/e1bOWXo5dsVMVnDwO2UKnxhR6FD8PINR3jgM6PWAXc6k33WJsBcyiTzwMP7/xPysLcgNJH5o4w==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@trezor/analytics": "1.5.0"
       },
@@ -5093,7 +5060,6 @@
       "integrity": "sha512-wdpVCwdylBh4SBO5Ys40tB/d59UlfjmxgBHDkkLgaR+JcqkthCfiw5VlUrV9wu65lquejAZhA5KQL4mUUUhCow==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@trezor/env-utils": "1.5.0",
         "@trezor/type-utils": "1.2.0",
@@ -5109,7 +5075,6 @@
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -5632,7 +5597,6 @@
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -5659,8 +5623,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@trezor/connect/node_modules/bs58": {
       "version": "6.0.0",
@@ -5668,7 +5631,6 @@
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -5679,7 +5641,6 @@
       "integrity": "sha512-9i1NrfW1IE6JO910ut7xrx4u5LxE++GETbpJhWLj4P5xpuGDDSDLEn/MXaYisls2DpE897aOrGPaa1qyt8V6tw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
@@ -5690,7 +5651,6 @@
       "integrity": "sha512-313uSXYR4XKDv3CjtCpgHA+yEe9xxqN7EFl/D68FEn70SPsuWI0+2zUvjPPh6TIOh/EcLv7hCO/QTHUAGd7ZWQ==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "^2.0.1",
         "@trezor/crypto-utils": "1.2.0",
@@ -5705,7 +5665,6 @@
       "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "2.0.1"
       },
@@ -5722,7 +5681,6 @@
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -5735,8 +5693,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/device-utils/-/device-utils-1.2.0.tgz",
       "integrity": "sha512-Aqp7pIooFTx21zRUtTI6i1AS4d9Lrx7cclvksh2nJQF9WJvbzuCXshEGkLoOsHwhQrCl3IXfbGuMdA12yDenPA==",
       "dev": true,
-      "license": "See LICENSE.md in repo root",
-      "peer": true
+      "license": "See LICENSE.md in repo root"
     },
     "node_modules/@trezor/protobuf": {
       "version": "1.5.2",
@@ -5744,7 +5701,6 @@
       "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@trezor/schema-utils": "1.4.0",
         "long": "5.2.5",
@@ -5760,7 +5716,6 @@
       "integrity": "sha512-rmrxbDrdgxTouBPbZcSeqU7ba/e5WVT1dxvxxEntHqRdTiDl7d3VK+BErCrlyol8EH5YCqEF3/rXt0crSOfoFw==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
@@ -5771,7 +5726,6 @@
       "integrity": "sha512-K7upSeh7VDrORaIC4KAxYVW93XNlohmUnH5if/5GKYmTdQSRp1nBkO6Jm+Z4hzIthdnz/1aLgnbeN3bDxWLRxA==",
       "dev": true,
       "license": "See LICENSE.md in repo root",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.33.7",
         "ts-mixer": "^6.0.3"
@@ -5785,8 +5739,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
       "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@trezor/transport": {
       "version": "1.6.2",
@@ -5794,7 +5747,6 @@
       "integrity": "sha512-w0HlD1fU+qTGO3tefBGHF/YS/ts/TWFja9FGIJ4+7+Z9NphvIG06HGvy2HzcD9AhJy9pvDeIsyoM2TTZTiyjkQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@trezor/protobuf": "1.5.2",
         "@trezor/protocol": "1.3.0",
@@ -5812,8 +5764,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.2.0.tgz",
       "integrity": "sha512-+E2QntxkyQuYfQQyl8RvT01tq2i5Dp/LFUOXuizF+KVOqsZBjBY43j5hewcCO3+MokD7deDiPyekbUEN5/iVlw==",
       "dev": true,
-      "license": "See LICENSE.md in repo root",
-      "peer": true
+      "license": "See LICENSE.md in repo root"
     },
     "node_modules/@trezor/utils": {
       "version": "9.5.0",
@@ -5821,7 +5772,6 @@
       "integrity": "sha512-kdyMyDbxzvOZmwBNvTjAK+C/kzyOz8T4oUbFvq+KaXn5mBFf1uf8rq5X2HkxgdYRPArtHS3PxLKsfkNCdhCYtQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.3.1"
       },
@@ -5835,7 +5785,6 @@
       "integrity": "sha512-Fa2cZh0037oX6AHNLfpFIj65UR/OoX0ZJTocFuQASe77/1PjZHysf6BvvGfmzuFToKfrAQ+DM/1Sx+P/vnyNmA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "bech32": "^2.0.0",
@@ -5864,8 +5813,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@trezor/utxo-lib/node_modules/bs58": {
       "version": "6.0.0",
@@ -5873,7 +5821,6 @@
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -5884,7 +5831,6 @@
       "integrity": "sha512-9KQSaVc3NtmM6rFFj1e+9bM0C5mVKVidbnxlfzuBJu7G2YMRdIdLPcAXhvmRZjs40uzDuBeApK+p547kODz2ug==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "ws": "^8.18.0"
@@ -5927,8 +5873,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6104,8 +6049,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonfile": {
       "version": "6.1.4",
@@ -6126,6 +6070,7 @@
       "version": "24.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -6166,6 +6111,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6555,9 +6501,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ]
@@ -6859,22 +6803,6 @@
         "@walletconnect/safe-json": "^1.0.2",
         "events": "^3.3.0",
         "ws": "^7.5.1"
-      }
-    },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
@@ -7507,7 +7435,6 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -7519,8 +7446,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -8008,7 +7934,6 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -8024,7 +7949,6 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -8037,7 +7961,6 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -8051,7 +7974,6 @@
       "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.1",
         "randombytes": "^2.1.0",
@@ -8067,7 +7989,6 @@
       "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.2",
         "browserify-rsa": "^4.1.1",
@@ -8088,8 +8009,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -8097,7 +8017,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8113,8 +8032,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/browserify-sign/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -8122,7 +8040,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8132,8 +8049,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.25.1",
@@ -8153,6 +8069,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -8264,23 +8181,7 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -8388,7 +8289,6 @@
       "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nofilter": "^3.0.2"
       },
@@ -8728,7 +8628,6 @@
       "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -8739,8 +8638,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -8840,7 +8738,6 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -9026,7 +8923,6 @@
       "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -9100,7 +8996,6 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -9112,8 +9007,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -9125,8 +9019,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -9404,7 +9297,6 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -9463,8 +9355,7 @@
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -9863,7 +9754,6 @@
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -9874,7 +9764,6 @@
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -10239,7 +10128,6 @@
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -10257,7 +10145,6 @@
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10267,8 +10154,7 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/http-errors/node_modules/statuses": {
       "version": "1.5.0",
@@ -10276,7 +10162,6 @@
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10338,7 +10223,8 @@
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -10508,8 +10394,7 @@
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-my-json-valid": {
       "version": "2.20.6",
@@ -10517,7 +10402,6 @@
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -10566,8 +10450,7 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
@@ -10796,22 +10679,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -10838,6 +10705,7 @@
       "version": "30.0.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.5",
         "@jest/types": "30.0.5",
@@ -11498,6 +11366,7 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11593,7 +11462,6 @@
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11761,8 +11629,7 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
       "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -11776,7 +11643,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11905,7 +11771,6 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -11919,8 +11784,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -12160,7 +12024,6 @@
       "integrity": "sha512-kCwSf/3fraPU2zENK18sh+kKG4uKbEUEQdyWQkmW8ZofmLarObIz2+zAYjA1teDZLeMvEQew3UysnPDXgjneaA==",
       "dev": true,
       "license": "(MIT AND Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -12171,7 +12034,6 @@
       "integrity": "sha512-h23BGSKxNv8ph+zU6snicstsVK1/CTXsQz4LuGGwoRE24Hj424nSe4+/1tzoiC285Ljf60kPAqRCmsfv9etF2g==",
       "dev": true,
       "license": "(MIT AND Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@near-js/accounts": "1.4.1",
         "@near-js/crypto": "1.4.2",
@@ -12197,8 +12059,7 @@
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/near-api-js/node_modules/node-fetch": {
       "version": "2.6.7",
@@ -12206,7 +12067,6 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -12227,16 +12087,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/near-api-js/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/near-api-js/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -12244,7 +12102,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -12352,7 +12209,6 @@
       "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.19"
       }
@@ -12582,7 +12438,6 @@
       "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "asn1.js": "^4.10.1",
         "browserify-aes": "^1.2.0",
@@ -12701,7 +12556,6 @@
       "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -12928,7 +12782,6 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -12943,8 +12796,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -13183,7 +13035,6 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -13757,6 +13608,7 @@
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13810,8 +13662,7 @@
     "node_modules/scheduler": {
       "version": "0.26.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/secp256k1": {
       "version": "5.0.1",
@@ -13985,8 +13836,7 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -14739,7 +14589,6 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -14867,6 +14716,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14910,7 +14760,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -15011,6 +14862,7 @@
       "version": "5.9.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15641,6 +15493,7 @@
       "version": "8.18.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15698,7 +15551,6 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@clack/prompts": "^0.11.0",
     "@stellar/stellar-sdk": "^12.0.0",
+    "@unrs/resolver-binding-win32-x64-msvc": "^1.11.1",
     "commander": "^14.0.0",
     "execa": "^9.6.0",
     "express": "^5.2.1",

--- a/tests/backend/ws/notifications.test.ts
+++ b/tests/backend/ws/notifications.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events';
+import {
+  handleConnection,
+  getActiveListenerCount,
+  NotificationSocket,
+} from '../../../backend/ws/notifications.js';
+
+function createMockSocket(): NotificationSocket {
+  const socket = new EventEmitter() as NotificationSocket;
+  socket.send = jest.fn();
+  return socket;
+}
+
+describe('handleConnection — listener management', () => {
+  it('attaches exactly one handler per event on connection', () => {
+    const socket = createMockSocket();
+    handleConnection(socket);
+
+    expect(socket.listenerCount('message')).toBe(1);
+    expect(socket.listenerCount('error')).toBe(1);
+    expect(socket.listenerCount('close')).toBe(1);
+    expect(getActiveListenerCount(socket)).toBe(3);
+  });
+
+  it('removes all listeners when the socket closes', () => {
+    const socket = createMockSocket();
+    handleConnection(socket);
+    socket.emit('close');
+
+    expect(socket.listenerCount('message')).toBe(0);
+    expect(socket.listenerCount('error')).toBe(0);
+    expect(socket.listenerCount('close')).toBe(0);
+    expect(getActiveListenerCount(socket)).toBe(0);
+  });
+
+  it('stress test: opens 100 connections then closes all — listener count returns to 0', () => {
+    const sockets: NotificationSocket[] = [];
+
+    for (let i = 0; i < 100; i++) {
+      const s = createMockSocket();
+      sockets.push(s);
+      handleConnection(s);
+    }
+
+    // All connected: each socket must have exactly 3 listeners
+    for (const s of sockets) {
+      expect(getActiveListenerCount(s)).toBe(3);
+    }
+
+    // Close every socket
+    for (const s of sockets) {
+      s.emit('close');
+    }
+
+    // No dangling listeners
+    for (const s of sockets) {
+      expect(getActiveListenerCount(s)).toBe(0);
+    }
+  });
+
+  it('handles error events without crashing the process', () => {
+    const socket = createMockSocket();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    handleConnection(socket);
+
+    expect(() => socket.emit('error', new Error('network reset'))).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[ws:notifications] socket error:',
+      'network reset',
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles valid JSON messages without throwing', () => {
+    const socket = createMockSocket();
+    handleConnection(socket);
+
+    expect(() =>
+      socket.emit('message', Buffer.from(JSON.stringify({ event: 'ping' }))),
+    ).not.toThrow();
+  });
+
+  it('silently ignores malformed (non-JSON) messages', () => {
+    const socket = createMockSocket();
+    handleConnection(socket);
+
+    expect(() => socket.emit('message', 'not-valid-json')).not.toThrow();
+  });
+
+  it('calling close twice does not throw', () => {
+    const socket = createMockSocket();
+    handleConnection(socket);
+    socket.emit('close');
+
+    expect(() => socket.emit('close')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

`backend/ws/notifications.ts` didn't exist yet — this PR introduces the handler and ensures it is memory-safe from day one.

The pattern to avoid: attaching `message`, `error`, and `close` listeners with inline lambdas per connection means each disconnected socket retains live listener references, preventing garbage collection and causing steady memory growth under traffic.

## Root Cause

Inline lambda listeners have no stored reference, so they cannot be passed to `.off()`. Without cleanup in the `close` handler, every disconnected socket keeps 3 dangling event listeners alive indefinitely.

## Fix

- Extract **named handler functions** (`onMessage`, `onError`, `onClose`) stored in a `WeakMap` keyed on the socket.
- `onClose` calls `socket.off` for all three handlers and deletes the socket from the `WeakMap`.
- `WeakMap` ensures the socket itself remains the only strong reference — no additional retention.

## Test Evidence

```
PASS tests/backend/ws/notifications.test.ts
  handleConnection — listener management
    ✓ attaches exactly one handler per event on connection (12 ms)
    ✓ removes all listeners when the socket closes (2 ms)
    ✓ stress test: opens 100 connections then closes all — listener count returns to 0 (74 ms)
    ✓ handles error events without crashing the process (6 ms)
    ✓ handles valid JSON messages without throwing (2 ms)
    ✓ silently ignores malformed (non-JSON) messages (4 ms)
    ✓ calling close twice does not throw (1 ms)

Tests: 7 passed, 7 total
```

## Infrastructure Fix (bundled)

The test runner was broken repo-wide due to `ts-jest@29` being incompatible with `jest@30`, and a missing native binary (`@unrs/resolver-binding-win32-x64-msvc`) required by Jest 30's `unrs-resolver`. This PR:

- Switches `jest.config.mjs` transform to `babel-jest` (already installed at v30, `.babelrc` already has TypeScript support)
- Adds `jest.setup.js` (JS equivalent of `jest.setup.ts` — identical logic, type annotations removed)
- Installs `@unrs/resolver-binding-win32-x64-msvc` native binding

## Tradeoffs

- `WeakMap` adds ~O(1) overhead per connection — negligible.
- Switching to `babel-jest` drops TypeScript type-checking during test runs; type safety is preserved by the separate `tsc` build step.

Closes #231