### PR TITLE
removed hardcoded admin email from POST /forgot-password route

### DIFF
--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -22,6 +22,9 @@ type AuthDependencies = {
     username: string,
     password: string,
   ) => Promise<{ userId: string; token: string } | null>;
+  generateResetToken: (email: string) => Promise<string>;
+  sendResetEmail: (email: string, token: string) => Promise<void>;
+  sendAdminAlert: (adminEmail: string, requestedFor: string) => Promise<void>;
 };
 
 export const authDeps: AuthDependencies = {
@@ -30,6 +33,11 @@ export const authDeps: AuthDependencies = {
     void password;
     return null;
   },
+  generateResetToken: async (_email: string) => {
+    return "";
+  },
+  sendResetEmail: async (_email: string, _token: string) => {},
+  sendAdminAlert: async (_adminEmail: string, _requestedFor: string) => {},
 };
 
 function normalizeUsername(username: string): string {
@@ -207,6 +215,38 @@ router.post(
       return res.status(401).json({
         success: false,
         message: "Invalid credentials",
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+router.post(
+  "/forgot-password",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const email =
+        typeof req.body?.email === "string" ? req.body.email.trim() : "";
+
+      if (!email) {
+        return res
+          .status(400)
+          .json({ success: false, message: "email is required" });
+      }
+
+      const token = await authDeps.generateResetToken(email);
+      await authDeps.sendResetEmail(email, token);
+
+      const adminEmail = process.env.ADMIN_ALERT_EMAIL;
+      if (adminEmail) {
+        // Only send a notification — never include the reset token
+        await authDeps.sendAdminAlert(adminEmail, email);
+      }
+
+      return res.status(200).json({
+        success: true,
+        message: "If that email exists, a reset link has been sent.",
       });
     } catch (err) {
       return next(err);

--- a/tests/routes/auth.test.ts
+++ b/tests/routes/auth.test.ts
@@ -201,3 +201,69 @@ describe("GET /auth/callback", () => {
     expect(res.headers.location).toBe("/");
   });
 });
+
+describe("POST /forgot-password", () => {
+  const app = buildApp();
+  let generateResetTokenMock: jest.MockedFunction<typeof authDeps.generateResetToken>;
+  let sendResetEmailMock: jest.MockedFunction<typeof authDeps.sendResetEmail>;
+  let sendAdminAlertMock: jest.MockedFunction<typeof authDeps.sendAdminAlert>;
+
+  beforeEach(() => {
+    generateResetTokenMock = jest.fn().mockResolvedValue("test-token-abc");
+    sendResetEmailMock = jest.fn().mockResolvedValue(undefined);
+    sendAdminAlertMock = jest.fn().mockResolvedValue(undefined);
+    authDeps.generateResetToken = generateResetTokenMock;
+    authDeps.sendResetEmail = sendResetEmailMock;
+    authDeps.sendAdminAlert = sendAdminAlertMock;
+    delete process.env.ADMIN_ALERT_EMAIL;
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await request(app).post("/forgot-password").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 and sends reset email", async () => {
+    const res = await request(app)
+      .post("/forgot-password")
+      .send({ email: "user@example.com" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(sendResetEmailMock).toHaveBeenCalledWith("user@example.com", "test-token-abc");
+  });
+
+  it("does not call sendAdminAlert when ADMIN_ALERT_EMAIL is not set", async () => {
+    await request(app)
+      .post("/forgot-password")
+      .send({ email: "user@example.com" });
+
+    expect(sendAdminAlertMock).not.toHaveBeenCalled();
+  });
+
+  it("calls sendAdminAlert with admin email when ADMIN_ALERT_EMAIL is set", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "ops@company.com";
+
+    await request(app)
+      .post("/forgot-password")
+      .send({ email: "user@example.com" });
+
+    expect(sendAdminAlertMock).toHaveBeenCalledWith("ops@company.com", "user@example.com");
+  });
+
+  it("does not include the reset token in the admin alert", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "ops@company.com";
+
+    await request(app)
+      .post("/forgot-password")
+      .send({ email: "user@example.com" });
+
+    const [, alertArg2] = sendAdminAlertMock.mock.calls[0];
+    // second arg is the requesting email, not the token
+    expect(alertArg2).toBe("user@example.com");
+    expect(alertArg2).not.toBe("test-token-abc");
+    // ensure token was never passed to sendAdminAlert at all
+    const allArgs = sendAdminAlertMock.mock.calls[0];
+    expect(allArgs).not.toContain("test-token-abc");
+  });
+});


### PR DESCRIPTION
## what was done:

Added POST /forgot-password to auth.ts

Reads process.env.ADMIN_ALERT_EMAIL — no hardcoded fallback
If the env var is absent, sendAdminAlert is never called
The reset token is only passed to sendResetEmail; sendAdminAlert receives only the admin email and the requesting user's email — never the token
Extended AuthDependencies with generateResetToken, sendResetEmail, and sendAdminAlert stubs so the handler is fully injectable and testable.

Added 5 tests to 
auth.test.ts
 covering: missing email (400), successful flow, no admin alert without env var, admin alert with env var, and token absence from the alert payload.

 
 Close #227