### PR TITLE
fix(cli,templates): validate install-timeout and fix template JSX mode

### DIFF
--- a/bin/nextellar.ts
+++ b/bin/nextellar.ts
@@ -323,6 +323,22 @@ program.action(async (projectName, options) => {
     finalWallets = walletsFlagProvided ? finalWallets : defaultWallets;
   }
 
+  const MIN_INSTALL_TIMEOUT_MS = 5_000;
+  const MAX_INSTALL_TIMEOUT_MS = 3_600_000;
+  const rawInstallTimeout = String(options.installTimeout).trim();
+  const installTimeoutMs = Number(rawInstallTimeout);
+  if (
+    !Number.isFinite(installTimeoutMs) ||
+    !Number.isInteger(installTimeoutMs) ||
+    installTimeoutMs < MIN_INSTALL_TIMEOUT_MS ||
+    installTimeoutMs > MAX_INSTALL_TIMEOUT_MS
+  ) {
+    console.error(
+      `Invalid --install-timeout value: "${rawInstallTimeout}". Must be a positive integer of milliseconds between ${MIN_INSTALL_TIMEOUT_MS} and ${MAX_INSTALL_TIMEOUT_MS}.`,
+    );
+    return await exitWithTelemetry(1);
+  }
+
   try {
     await maybeShowTelemetryNotice({ noTelemetryFlag: options.telemetry === false });
 
@@ -337,7 +353,7 @@ program.action(async (projectName, options) => {
       defaults: options.defaults,
       skipInstall: finalSkipInstall,
       packageManager: finalPackageManager,
-      installTimeout: parseInt(options.installTimeout),
+      installTimeout: installTimeoutMs,
       telemetryEnabled: options.telemetry,
       cliVersion: pkg.version,
       force: options.force,

--- a/src/templates/defi/tsconfig.json
+++ b/src/templates/defi/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/src/templates/minimal/tsconfig.json
+++ b/src/templates/minimal/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- **#117 — validate \`--install-timeout\`**: \`bin/nextellar.ts\` now rejects non-numeric and out-of-range values before \`parseInt\`. Bad input (\`abc\`, \`-1\`, \`3\`) prints a clear error and exits 1, instead of passing \`NaN\` to \`execa\` and hanging the install indefinitely. Allowed range is 5s..1h.
- **#134 — \`jsx: react-jsx\` in template tsconfigs**: Updated \`src/templates/minimal\` and \`src/templates/defi\` to use \`"jsx": "react-jsx"\` — matching the \`default\` template and the correct setting for Next 16 + React 19's automatic JSX runtime. Fixes \`tsc --noEmit\` and IDE tooling outside the Next.js compilation context.

## Not in this PR

- **#106 — Delete empty root-level \`templates/minimal\` directory**: Verified the root-level \`templates/\` directory no longer exists on \`main\`, so the cleanup is already done. No changes required; closing the issue with this PR.

## Closes
closes #106
closes #117
closes #134

## Test plan
- [x] \`npx tsc -p tsconfig.build.json\` — build clean
- [x] \`node dist/bin/nextellar.js my-app --install-timeout abc --defaults --skip-install\` → exits 1 with clear error
- [x] \`node dist/bin/nextellar.js my-app --install-timeout -1 --defaults --skip-install\` → exits 1
- [x] \`node dist/bin/nextellar.js my-app --install-timeout 60000 --defaults --skip-install\` → scaffolds successfully
- [ ] Manual: \`tsc --noEmit\` inside a scaffolded \`minimal\` and \`defi\` template still passes
