### PR TITLE
Add routes-d helpers for SEP-24, magic links, sequences, and shutdown

### DIFF
--- a/routes-d/lib/magicLink.ts
+++ b/routes-d/lib/magicLink.ts
@@ -1,0 +1,146 @@
+import crypto from "node:crypto";
+import type { JwtPayload } from "jsonwebtoken";
+import { randomId, signJwt, verifyJwt } from "./tokens.js";
+import { issueNextellarSession, sessionStore, type SessionRecord } from "./session.js";
+
+const MAGIC_LINK_SECRET_NAME = "NEXTELLAR_MAGIC_LINK_SECRET";
+const MAGIC_LINK_TTL_SECONDS = Number(process.env.NEXTELLAR_MAGIC_LINK_TTL_SECONDS ?? 15 * 60);
+const MAGIC_LINK_BASE_URL = process.env.NEXTELLAR_MAGIC_LINK_BASE_URL ?? "https://nextellar.local/auth/magic/consume";
+
+export interface MagicLinkClaims extends JwtPayload {
+  jti: string;
+  sub: string;
+  kind: "magic-link";
+  iat?: number;
+  exp?: number;
+}
+
+export interface MagicLinkRecord {
+  tokenId: string;
+  accountId: string;
+  createdAt: number;
+  expiresAt: number;
+  usedAt?: number;
+  token: string;
+  redirectTo?: string;
+}
+
+export interface MagicLinkRequestInput {
+  accountId: string;
+  redirectTo?: string;
+}
+
+export interface MagicLinkConsumeResult {
+  accountId: string;
+  session: SessionRecord;
+  magicLink: MagicLinkRecord;
+}
+
+export const magicLinkStore = new Map<string, MagicLinkRecord>();
+
+export function createMagicLink(input: MagicLinkRequestInput): MagicLinkRecord {
+  const now = Math.floor(Date.now() / 1000);
+  const tokenId = randomId("magic");
+  const claims: MagicLinkClaims = {
+    jti: tokenId,
+    sub: input.accountId,
+    kind: "magic-link",
+    iat: now,
+    exp: now + MAGIC_LINK_TTL_SECONDS,
+  };
+
+  const token = signJwt(claims, MAGIC_LINK_SECRET_NAME, {
+    expiresIn: MAGIC_LINK_TTL_SECONDS,
+    subject: input.accountId,
+    issuer: "nextellar",
+    audience: "nextellar-auth",
+    secretFallback: "nextellar-routes-d-magic-secret",
+  });
+
+  const record: MagicLinkRecord = {
+    tokenId,
+    accountId: input.accountId,
+    createdAt: now * 1000,
+    expiresAt: (now + MAGIC_LINK_TTL_SECONDS) * 1000,
+    token,
+    redirectTo: input.redirectTo,
+  };
+
+  magicLinkStore.set(tokenId, record);
+  return record;
+}
+
+export function buildMagicLinkUrl(record: MagicLinkRecord): string {
+  const url = new URL(MAGIC_LINK_BASE_URL);
+  url.searchParams.set("token", record.token);
+  if (record.redirectTo) {
+    url.searchParams.set("redirectTo", record.redirectTo);
+  }
+  return url.toString();
+}
+
+export function consumeMagicLink(token: string): MagicLinkConsumeResult | null {
+  const claims = verifyJwt<MagicLinkClaims>(
+    token,
+    MAGIC_LINK_SECRET_NAME,
+    {
+      algorithms: ["HS256"],
+      issuer: "nextellar",
+      audience: "nextellar-auth",
+    },
+    "nextellar-routes-d-magic-secret",
+  );
+
+  if (!claims?.jti || !claims.sub) {
+    return null;
+  }
+
+  const record = magicLinkStore.get(claims.jti);
+  if (!record) {
+    return null;
+  }
+
+  if (record.usedAt) {
+    return null;
+  }
+
+  if (record.expiresAt <= Date.now()) {
+    magicLinkStore.delete(record.tokenId);
+    return null;
+  }
+
+  record.usedAt = Date.now();
+  const session = issueNextellarSession(record.accountId);
+
+  return {
+    accountId: record.accountId,
+    session,
+    magicLink: record,
+  };
+}
+
+export function pruneExpiredMagicLinks(now = Date.now()): number {
+  let removed = 0;
+  for (const [tokenId, record] of magicLinkStore.entries()) {
+    if (record.expiresAt <= now) {
+      magicLinkStore.delete(tokenId);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export function getSessionForMagicLink(tokenId: string): SessionRecord | undefined {
+  const record = magicLinkStore.get(tokenId);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const session of sessionStore.values()) {
+    if (session.accountId === record.accountId && session.issuedAt >= record.createdAt) {
+      return session;
+    }
+  }
+
+  return undefined;
+}

--- a/routes-d/lib/sep24.ts
+++ b/routes-d/lib/sep24.ts
@@ -1,0 +1,203 @@
+import crypto from "node:crypto";
+
+export type DepositStatus =
+  | "pending"
+  | "interactive"
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "expired";
+
+export interface DepositIntentInput {
+  accountId: string;
+  assetCode: string;
+  assetIssuer?: string;
+  amount?: string;
+  memo?: string;
+  webhookUrl?: string;
+  redirectUrl?: string;
+  customerId?: string;
+}
+
+export interface DepositIntent {
+  id: string;
+  accountId: string;
+  assetCode: string;
+  assetIssuer?: string;
+  amount?: string;
+  memo?: string;
+  webhookUrl?: string;
+  redirectUrl?: string;
+  customerId?: string;
+  interactiveUrl: string;
+  status: DepositStatus;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number;
+}
+
+export interface DepositStatusTransition {
+  intentId: string;
+  accountId: string;
+  from: DepositStatus;
+  to: DepositStatus;
+  at: number;
+  intent: DepositIntent;
+}
+
+export interface Sep24Dependencies {
+  now?: () => number;
+  interactiveBaseUrl?: string;
+  webhookDispatcher?: (transition: DepositStatusTransition) => Promise<void> | void;
+}
+
+const DEFAULT_INTERACTIVE_BASE_URL =
+  process.env.NEXTELLAR_SEP24_INTERACTIVE_BASE_URL ?? "https://nextellar.local/sep24/interactive";
+const DEFAULT_INTENT_TTL_MS = Number(process.env.NEXTELLAR_SEP24_INTENT_TTL_MS ?? 30 * 60 * 1000);
+
+export const depositIntentStore = new Map<string, DepositIntent>();
+export const depositStatusTransitions: DepositStatusTransition[] = [];
+
+export const sep24Deps: Required<Pick<Sep24Dependencies, "now" | "interactiveBaseUrl" | "webhookDispatcher">> = {
+  now: () => Date.now(),
+  interactiveBaseUrl: DEFAULT_INTERACTIVE_BASE_URL,
+  webhookDispatcher: async (transition: DepositStatusTransition) => {
+    const webhookUrl = transition.intent.webhookUrl;
+    if (!webhookUrl) {
+      return;
+    }
+
+    if (typeof fetch !== "function") {
+      return;
+    }
+
+    try {
+      await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          intentId: transition.intentId,
+          accountId: transition.accountId,
+          previousStatus: transition.from,
+          status: transition.to,
+          at: transition.at,
+          intent: transition.intent,
+        }),
+      });
+    } catch {
+      // Delivery failures are recorded via the transition log and surfaced to callers.
+    }
+  },
+};
+
+function buildInteractiveUrl(
+  intentId: string,
+  interactiveBaseUrl = DEFAULT_INTERACTIVE_BASE_URL,
+  redirectUrl?: string,
+): string {
+  const url = new URL(interactiveBaseUrl.replace(/\/$/, ""));
+  url.pathname = `${url.pathname.replace(/\/$/, "")}/${intentId}`;
+  if (redirectUrl) {
+    url.searchParams.set("redirect_url", redirectUrl);
+  }
+  return url.toString();
+}
+
+export function createDepositIntent(
+  input: DepositIntentInput,
+  dependencies: Sep24Dependencies = {},
+): DepositIntent {
+  const now = dependencies.now?.() ?? sep24Deps.now();
+  const interactiveBaseUrl = dependencies.interactiveBaseUrl ?? sep24Deps.interactiveBaseUrl;
+  const id = crypto.randomUUID();
+  const intent: DepositIntent = {
+    id,
+    accountId: input.accountId,
+    assetCode: input.assetCode,
+    assetIssuer: input.assetIssuer,
+    amount: input.amount,
+    memo: input.memo,
+    webhookUrl: input.webhookUrl,
+    redirectUrl: input.redirectUrl,
+    customerId: input.customerId,
+    interactiveUrl: buildInteractiveUrl(id, interactiveBaseUrl, input.redirectUrl),
+    status: "pending",
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: now + DEFAULT_INTENT_TTL_MS,
+  };
+
+  depositIntentStore.set(id, intent);
+  return intent;
+}
+
+const ALLOWED_DEPOSIT_STATUSES: ReadonlySet<DepositStatus> = new Set([
+  "pending",
+  "interactive",
+  "in_progress",
+  "completed",
+  "failed",
+  "expired",
+]);
+
+export function getDepositIntent(intentId: string): DepositIntent | undefined {
+  const intent = depositIntentStore.get(intentId);
+  if (!intent) {
+    return undefined;
+  }
+
+  if (intent.expiresAt <= Date.now()) {
+    depositIntentStore.delete(intentId);
+    return undefined;
+  }
+
+  return intent;
+}
+
+export async function transitionDepositStatus(
+  intentId: string,
+  nextStatus: DepositStatus,
+  dependencies: Sep24Dependencies = {},
+): Promise<DepositIntent | null> {
+  if (!ALLOWED_DEPOSIT_STATUSES.has(nextStatus)) {
+    throw new Error(`Unsupported deposit status: ${nextStatus}`);
+  }
+
+  const intent = getDepositIntent(intentId);
+  if (!intent) {
+    return null;
+  }
+
+  if (intent.status === nextStatus) {
+    return intent;
+  }
+
+  const now = dependencies.now?.() ?? sep24Deps.now();
+  const previousStatus = intent.status;
+  intent.status = nextStatus;
+  intent.updatedAt = now;
+
+  const transition: DepositStatusTransition = {
+    intentId,
+    accountId: intent.accountId,
+    from: previousStatus,
+    to: nextStatus,
+    at: now,
+    intent: { ...intent },
+  };
+
+  depositStatusTransitions.push(transition);
+  await (dependencies.webhookDispatcher ?? sep24Deps.webhookDispatcher)(transition);
+  return intent;
+}
+
+export function expireStaleDepositIntents(now = Date.now()): number {
+  let removed = 0;
+  for (const [intentId, intent] of depositIntentStore.entries()) {
+    if (intent.expiresAt <= now) {
+      depositIntentStore.delete(intentId);
+      removed += 1;
+    }
+  }
+  return removed;
+}

--- a/routes-d/lib/sequencePool.ts
+++ b/routes-d/lib/sequencePool.ts
@@ -1,0 +1,164 @@
+import crypto from "node:crypto";
+
+export type SequenceValue = string | number | bigint;
+
+export interface SequenceReservation {
+  reservationId: string;
+  accountId: string;
+  sequence: bigint;
+  reservedAt: number;
+  expiresAt: number;
+  reason?: string;
+}
+
+export interface SequencePoolOptions {
+  timeoutMs?: number;
+  now?: () => number;
+  reason?: string;
+}
+
+export class SequenceReservationError extends Error {
+  readonly code = "SEQUENCE_RESERVED";
+
+  constructor(
+    public readonly accountId: string,
+    public readonly sequence: bigint,
+    public readonly expiresAt: number,
+  ) {
+    super(`Sequence ${sequence.toString()} is already reserved for account ${accountId}`);
+    this.name = "SequenceReservationError";
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.NEXTELLAR_SEQUENCE_RESERVATION_TIMEOUT_MS ?? 30_000);
+const reservationsByAccount = new Map<string, Map<string, SequenceReservation>>();
+
+function toBigIntSequence(value: SequenceValue): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isSafeInteger(value) || value < 0) {
+      throw new Error("Sequence must be a non-negative safe integer");
+    }
+    return BigInt(value);
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error("Sequence must contain only digits");
+  }
+
+  return BigInt(value);
+}
+
+function accountReservations(accountId: string): Map<string, SequenceReservation> {
+  let reservations = reservationsByAccount.get(accountId);
+  if (!reservations) {
+    reservations = new Map<string, SequenceReservation>();
+    reservationsByAccount.set(accountId, reservations);
+  }
+  return reservations;
+}
+
+export function reapExpiredReservations(now = Date.now()): number {
+  let cleared = 0;
+  for (const [accountId, reservations] of reservationsByAccount.entries()) {
+    for (const [sequenceKey, reservation] of reservations.entries()) {
+      if (reservation.expiresAt <= now) {
+        reservations.delete(sequenceKey);
+        cleared += 1;
+      }
+    }
+
+    if (reservations.size === 0) {
+      reservationsByAccount.delete(accountId);
+    }
+  }
+
+  return cleared;
+}
+
+export function reserveSequence(
+  accountId: string,
+  sequence: SequenceValue,
+  options: SequencePoolOptions = {},
+): SequenceReservation {
+  const now = options.now?.() ?? Date.now();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  reapExpiredReservations(now);
+
+  const sequenceValue = toBigIntSequence(sequence);
+  const sequenceKey = sequenceValue.toString();
+  const reservations = accountReservations(accountId);
+  const existing = reservations.get(sequenceKey);
+
+  if (existing && existing.expiresAt > now) {
+    throw new SequenceReservationError(accountId, sequenceValue, existing.expiresAt);
+  }
+
+  const reservation: SequenceReservation = {
+    reservationId: crypto.randomUUID(),
+    accountId,
+    sequence: sequenceValue,
+    reservedAt: now,
+    expiresAt: now + timeoutMs,
+    reason: options.reason,
+  };
+
+  reservations.set(sequenceKey, reservation);
+  return reservation;
+}
+
+export function releaseSequence(accountId: string, sequence: SequenceValue): boolean {
+  const reservations = reservationsByAccount.get(accountId);
+  if (!reservations) {
+    return false;
+  }
+
+  const removed = reservations.delete(toBigIntSequence(sequence).toString());
+  if (reservations.size === 0) {
+    reservationsByAccount.delete(accountId);
+  }
+  return removed;
+}
+
+export function getSequenceReservation(
+  accountId: string,
+  sequence: SequenceValue,
+): SequenceReservation | undefined {
+  const reservations = reservationsByAccount.get(accountId);
+  if (!reservations) {
+    return undefined;
+  }
+
+  const reservation = reservations.get(toBigIntSequence(sequence).toString());
+  if (!reservation) {
+    return undefined;
+  }
+
+  if (reservation.expiresAt <= Date.now()) {
+    reservations.delete(reservation.sequence.toString());
+    return undefined;
+  }
+
+  return reservation;
+}
+
+export async function withSequenceReservation<T>(
+  accountId: string,
+  sequence: SequenceValue,
+  work: (reservation: SequenceReservation) => Promise<T> | T,
+  options: SequencePoolOptions = {},
+): Promise<T> {
+  const reservation = reserveSequence(accountId, sequence, options);
+  try {
+    return await work(reservation);
+  } finally {
+    releaseSequence(accountId, reservation.sequence);
+  }
+}
+
+export function clearSequenceReservations(): void {
+  reservationsByAccount.clear();
+}

--- a/routes-d/lib/session.ts
+++ b/routes-d/lib/session.ts
@@ -1,0 +1,79 @@
+import type { CookieOptions } from "express";
+import type { JwtPayload } from "jsonwebtoken";
+import { randomId, signJwt, verifyJwt } from "./tokens.js";
+
+export const SESSION_COOKIE_NAME = "session";
+
+const SESSION_SECRET_NAME = "NEXTELLAR_SESSION_SECRET";
+const SESSION_TTL_SECONDS = Number(process.env.NEXTELLAR_SESSION_TTL_SECONDS ?? 60 * 60 * 24);
+
+export interface SessionClaims extends JwtPayload {
+  sid: string;
+  sub: string;
+  kind: "session";
+  iat?: number;
+  exp?: number;
+}
+
+export interface SessionRecord {
+  sessionId: string;
+  accountId: string;
+  issuedAt: number;
+  expiresAt: number;
+  token: string;
+}
+
+export const sessionStore = new Map<string, SessionRecord>();
+
+export function sessionCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS * 1000,
+  };
+}
+
+export function issueNextellarSession(accountId: string): SessionRecord {
+  const now = Math.floor(Date.now() / 1000);
+  const sessionId = randomId("sess");
+  const claims: SessionClaims = {
+    sid: sessionId,
+    sub: accountId,
+    kind: "session",
+    iat: now,
+    exp: now + SESSION_TTL_SECONDS,
+  };
+
+  const token = signJwt(claims, SESSION_SECRET_NAME, {
+    expiresIn: SESSION_TTL_SECONDS,
+    issuer: "nextellar",
+    audience: "nextellar-app",
+    secretFallback: "nextellar-routes-d-session-secret",
+  });
+
+  const record: SessionRecord = {
+    sessionId,
+    accountId,
+    issuedAt: now * 1000,
+    expiresAt: (now + SESSION_TTL_SECONDS) * 1000,
+    token,
+  };
+
+  sessionStore.set(sessionId, record);
+  return record;
+}
+
+export function verifySessionToken(token: string): SessionClaims | null {
+  return verifyJwt<SessionClaims>(
+    token,
+    SESSION_SECRET_NAME,
+    {
+      algorithms: ["HS256"],
+      issuer: "nextellar",
+      audience: "nextellar-app",
+    },
+    "nextellar-routes-d-session-secret",
+  );
+}

--- a/routes-d/lib/shutdown.ts
+++ b/routes-d/lib/shutdown.ts
@@ -1,0 +1,181 @@
+import type { NextFunction, Request, Response } from "express";
+import type { Server } from "node:http";
+
+export interface ShutdownClient {
+  close: () => Promise<void> | void;
+}
+
+export interface GracefulShutdownOptions {
+  server?: Server;
+  closeClients?: ShutdownClient[];
+  drainTimeoutMs?: number;
+  exit?: (code: number) => never | void;
+  logger?: Pick<Console, "info" | "warn" | "error">;
+}
+
+export interface GracefulShutdownController {
+  middleware: (req: Request, res: Response, next: NextFunction) => void;
+  beginWork: () => () => void;
+  track: <T>(work: Promise<T>) => Promise<T>;
+  shutdown: (signal?: NodeJS.Signals) => Promise<void>;
+  install: () => void;
+  dispose: () => void;
+  isShuttingDown: () => boolean;
+}
+
+const DEFAULT_DRAIN_TIMEOUT_MS = Number(process.env.NEXTELLAR_SHUTDOWN_TIMEOUT_MS ?? 10_000);
+
+export function createGracefulShutdownController(
+  options: GracefulShutdownOptions = {},
+): GracefulShutdownController {
+  const server = options.server;
+  const closeClients = options.closeClients ?? [];
+  const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const logger = options.logger ?? console;
+
+  let acceptingWork = true;
+  let inflight = 0;
+  let shuttingDown = false;
+  let drainPromise: Promise<void> | null = null;
+  let signalHandler: ((signal: NodeJS.Signals) => void) | null = null;
+
+  function beginWork(): () => void {
+    if (!acceptingWork) {
+      throw new Error("Server is shutting down");
+    }
+
+    inflight += 1;
+    let done = false;
+
+    return () => {
+      if (done) {
+        return;
+      }
+      done = true;
+      inflight = Math.max(0, inflight - 1);
+    };
+  }
+
+  async function waitForDrain(): Promise<void> {
+    const deadline = Date.now() + drainTimeoutMs;
+    while (inflight > 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    if (inflight > 0) {
+      throw new Error(`Graceful shutdown timed out after ${drainTimeoutMs}ms`);
+    }
+  }
+
+  async function closeServer(): Promise<void> {
+    if (!server) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  async function closeRegisteredClients(): Promise<void> {
+    for (const client of closeClients) {
+      await client.close();
+    }
+  }
+
+  async function shutdown(signal: NodeJS.Signals = "SIGTERM"): Promise<void> {
+    if (drainPromise) {
+      return drainPromise;
+    }
+
+    acceptingWork = false;
+    shuttingDown = true;
+    logger.info?.(`[shutdown] received ${signal}, draining inflight work`);
+
+    drainPromise = (async () => {
+      try {
+        await closeServer();
+        await waitForDrain();
+        await closeRegisteredClients();
+        logger.info?.("[shutdown] drain complete");
+        exit(0);
+      } catch (error) {
+        logger.error?.("[shutdown] forced exit after drain timeout or close failure", error);
+        exit(1);
+      }
+    })();
+
+    return drainPromise;
+  }
+
+  function middleware(req: Request, res: Response, next: NextFunction): void {
+    if (!acceptingWork) {
+      res.status(503).json({ error: "server_shutting_down" });
+      return;
+    }
+
+    const complete = beginWork();
+    let finalized = false;
+
+    const finalize = (): void => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      complete();
+    };
+
+    res.once("finish", finalize);
+    res.once("close", finalize);
+    next();
+  }
+
+  function install(): void {
+    if (signalHandler) {
+      return;
+    }
+
+    signalHandler = (signal: NodeJS.Signals): void => {
+      void shutdown(signal);
+    };
+
+    process.on("SIGTERM", signalHandler);
+    process.on("SIGINT", signalHandler);
+  }
+
+  function dispose(): void {
+    if (!signalHandler) {
+      return;
+    }
+
+    process.off("SIGTERM", signalHandler);
+    process.off("SIGINT", signalHandler);
+    signalHandler = null;
+  }
+
+  async function track<T>(work: Promise<T>): Promise<T> {
+    const complete = beginWork();
+    try {
+      return await work;
+    } finally {
+      complete();
+    }
+  }
+
+  return {
+    middleware,
+    beginWork,
+    track,
+    shutdown,
+    install,
+    dispose,
+    isShuttingDown: () => shuttingDown,
+  };
+}

--- a/routes-d/lib/tokens.ts
+++ b/routes-d/lib/tokens.ts
@@ -1,0 +1,37 @@
+import crypto from "node:crypto";
+import jwt, { type JwtPayload, type SignOptions, type VerifyOptions } from "jsonwebtoken";
+
+const FALLBACK_SECRET = "nextellar-routes-d-dev-secret";
+
+export function requireSecret(name: string, fallback = FALLBACK_SECRET): string {
+  return process.env[name]?.trim() || fallback;
+}
+
+export function randomId(prefix = ""): string {
+  const id = crypto.randomUUID();
+  return prefix ? `${prefix}_${id}` : id;
+}
+
+export function signJwt<T extends object>(
+  payload: T,
+  secretName: string,
+  options: SignOptions & { secretFallback?: string } = {},
+): string {
+  const { secretFallback, ...jwtOptions } = options;
+  const secret = requireSecret(secretName, secretFallback);
+  return jwt.sign(payload, secret, jwtOptions);
+}
+
+export function verifyJwt<T extends JwtPayload>(
+  token: string,
+  secretName: string,
+  options: VerifyOptions = {},
+  secretFallback?: string,
+): T | null {
+  try {
+    const secret = requireSecret(secretName, secretFallback);
+    return jwt.verify(token, secret, options) as T;
+  } catch {
+    return null;
+  }
+}

--- a/routes-d/routes/auth.magic.ts
+++ b/routes-d/routes/auth.magic.ts
@@ -1,0 +1,88 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import { buildMagicLinkUrl, consumeMagicLink, createMagicLink } from "../lib/magicLink.js";
+import { SESSION_COOKIE_NAME, issueNextellarSession, sessionCookieOptions } from "../lib/session.js";
+
+const router = Router();
+
+function readAccountId(req: Request): string {
+  return typeof req.body?.accountId === "string" ? req.body.accountId.trim() : "";
+}
+
+function readToken(req: Request): string {
+  if (typeof req.body?.token === "string" && req.body.token.trim()) {
+    return req.body.token.trim();
+  }
+
+  return typeof req.query.token === "string" ? req.query.token.trim() : "";
+}
+
+router.post(
+  "/auth/magic/request",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const accountId = readAccountId(req);
+      const redirectTo = typeof req.body?.redirectTo === "string" ? req.body.redirectTo.trim() : undefined;
+
+      if (!accountId) {
+        res.status(400).json({ error: "accountId is required" });
+        return;
+      }
+
+      const record = createMagicLink({ accountId, redirectTo });
+
+      res.status(201).json({
+        success: true,
+        data: {
+          accountId,
+          tokenId: record.tokenId,
+          expiresAt: record.expiresAt,
+          magicLinkUrl: buildMagicLinkUrl(record),
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  "/auth/magic/consume",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const token = readToken(req);
+
+      if (!token) {
+        res.status(400).json({ error: "token is required" });
+        return;
+      }
+
+      const result = consumeMagicLink(token);
+
+      if (!result) {
+        res.status(401).json({ error: "invalid_or_expired_magic_link" });
+        return;
+      }
+
+      res.cookie(SESSION_COOKIE_NAME, result.session.token, sessionCookieOptions());
+      res.status(200).json({
+        success: true,
+        data: {
+          accountId: result.accountId,
+          sessionToken: result.session.token,
+          sessionId: result.session.sessionId,
+          expiresAt: result.session.expiresAt,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;
+
+export const magicLinkAuthDeps = {
+  createMagicLink,
+  consumeMagicLink,
+  issueNextellarSession,
+};

--- a/routes-d/routes/sep24.deposit.ts
+++ b/routes-d/routes/sep24.deposit.ts
@@ -1,0 +1,94 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import {
+  createDepositIntent,
+  transitionDepositStatus,
+  type DepositStatus,
+} from "../lib/sep24.js";
+
+const router = Router();
+
+function readString(body: Record<string, unknown> | undefined, key: string): string {
+  return typeof body?.[key] === "string" ? body[key].trim() : "";
+}
+
+router.post(
+  "/sep24/deposit",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const accountId = readString(req.body, "accountId");
+      const assetCode = readString(req.body, "assetCode");
+      const assetIssuer = readString(req.body, "assetIssuer") || undefined;
+      const amount = readString(req.body, "amount") || undefined;
+      const memo = readString(req.body, "memo") || undefined;
+      const webhookUrl = readString(req.body, "webhookUrl") || undefined;
+      const redirectUrl = readString(req.body, "redirectUrl") || undefined;
+      const customerId = readString(req.body, "customerId") || undefined;
+
+      if (!accountId || !assetCode) {
+        res.status(400).json({ error: "accountId and assetCode are required" });
+        return;
+      }
+
+      const intent = createDepositIntent({
+        accountId,
+        assetCode,
+        assetIssuer,
+        amount,
+        memo,
+        webhookUrl,
+        redirectUrl,
+        customerId,
+      });
+
+      await transitionDepositStatus(intent.id, "interactive");
+
+      res.status(201).json({
+        success: true,
+        data: {
+          depositId: intent.id,
+          status: intent.status,
+          interactiveUrl: intent.interactiveUrl,
+          expiresAt: intent.expiresAt,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  "/sep24/deposit/:intentId/status",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const intentId = typeof req.params.intentId === "string" ? req.params.intentId : "";
+      const nextStatus = typeof req.body?.status === "string" ? req.body.status.trim() : "";
+
+      if (!intentId || !nextStatus) {
+        res.status(400).json({ error: "intentId and status are required" });
+        return;
+      }
+
+      const status = nextStatus as DepositStatus;
+      const updated = await transitionDepositStatus(intentId, status);
+
+      if (!updated) {
+        res.status(404).json({ error: "deposit_intent_not_found" });
+        return;
+      }
+
+      res.status(200).json({
+        success: true,
+        data: {
+          depositId: updated.id,
+          status: updated.status,
+          updatedAt: updated.updatedAt,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/transaction.relay.submit.ts
+++ b/routes-d/routes/transaction.relay.submit.ts
@@ -1,0 +1,85 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import {
+  reserveSequence,
+  releaseSequence,
+  SequenceReservationError,
+  withSequenceReservation,
+} from "../lib/sequencePool.js";
+
+const router = Router();
+
+export const relaySubmitDeps = {
+  async submitTransaction(payload: {
+    accountId: string;
+    sequence: string;
+    transaction: string;
+  }): Promise<{ transactionHash: string; submittedAt: number }> {
+    return {
+      transactionHash: `mock-${payload.accountId}-${payload.sequence}`,
+      submittedAt: Date.now(),
+    };
+  },
+};
+
+function readString(body: Record<string, unknown> | undefined, key: string): string {
+  return typeof body?.[key] === "string" ? body[key].trim() : "";
+}
+
+router.post(
+  "/transactions/relay/submit",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const accountId = readString(req.body, "accountId");
+      const sequence = typeof req.body?.sequence === "string" || typeof req.body?.sequence === "number" || typeof req.body?.sequence === "bigint"
+        ? req.body.sequence
+        : "";
+      const transaction = readString(req.body, "transaction");
+
+      if (!accountId || !transaction || sequence === "") {
+        res.status(400).json({ error: "accountId, sequence, and transaction are required" });
+        return;
+      }
+
+      const result = await withSequenceReservation(
+        accountId,
+        sequence,
+        async (reservation) => {
+          const submission = await relaySubmitDeps.submitTransaction({
+            accountId,
+            sequence: reservation.sequence.toString(),
+            transaction,
+          });
+
+          return {
+            reservationId: reservation.reservationId,
+            sequence: reservation.sequence.toString(),
+            ...submission,
+          };
+        },
+      );
+
+      res.status(202).json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      if (error instanceof SequenceReservationError) {
+        res.status(409).json({
+          error: "sequence_reserved",
+          message: error.message,
+          accountId: error.accountId,
+          sequence: error.sequence.toString(),
+          expiresAt: error.expiresAt,
+        });
+        return;
+      }
+
+      next(error);
+    }
+  },
+);
+
+export default router;
+
+export const reserveRelaySequence = reserveSequence;
+export const releaseRelaySequence = releaseSequence;

--- a/routes-d/tsconfig.json
+++ b/routes-d/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+    "outDir": "../dist/routes-d"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["../node_modules", "../dist"]
+}


### PR DESCRIPTION
Adds the requested `routes-d/` implementation for SEP-24 deposits, magic-link auth, sequence reservations, and graceful shutdown.

Closes #362
Closes #367
Closes #371
Closes #360