### PR TITLE
feat(routes-d): cached Stellar balance route + invalidation

### DIFF
--- a/routes-d/lib/balanceCache.ts
+++ b/routes-d/lib/balanceCache.ts
@@ -1,0 +1,81 @@
+// In-memory TTL cache for Horizon account balance lookups.
+//
+// Reduces Horizon load by serving recent balances from memory until the
+// per-entry TTL expires. Callers can bypass with `forceRefresh: true`, and
+// the cache exposes an explicit invalidation hook for outbound payments.
+
+export interface CachedBalance {
+  accountId: string;
+  balances: BalanceEntry[];
+  fetchedAt: number;
+  expiresAt: number;
+}
+
+export interface BalanceEntry {
+  assetType: string;
+  assetCode?: string;
+  assetIssuer?: string;
+  balance: string;
+}
+
+export interface BalanceFetcher {
+  (accountId: string): Promise<BalanceEntry[]>;
+}
+
+export interface BalanceCacheOptions {
+  ttlMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_TTL_MS = Number(
+  process.env.NEXTELLAR_BALANCE_CACHE_TTL_MS ?? 30_000,
+);
+
+export class BalanceCache {
+  private readonly entries = new Map<string, CachedBalance>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: BalanceCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  async get(
+    accountId: string,
+    fetcher: BalanceFetcher,
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<{ value: CachedBalance; fromCache: boolean }> {
+    if (!options.forceRefresh) {
+      const cached = this.entries.get(accountId);
+      if (cached && cached.expiresAt > this.now()) {
+        return { value: cached, fromCache: true };
+      }
+    }
+
+    const balances = await fetcher(accountId);
+    const fetchedAt = this.now();
+    const entry: CachedBalance = {
+      accountId,
+      balances,
+      fetchedAt,
+      expiresAt: fetchedAt + this.ttlMs,
+    };
+    this.entries.set(accountId, entry);
+    return { value: entry, fromCache: false };
+  }
+
+  invalidate(accountId: string): boolean {
+    return this.entries.delete(accountId);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  peek(accountId: string): CachedBalance | undefined {
+    return this.entries.get(accountId);
+  }
+}
+
+export const balanceCache = new BalanceCache();

--- a/routes-d/routes/stellar.balance.ts
+++ b/routes-d/routes/stellar.balance.ts
@@ -1,0 +1,106 @@
+import { Router, Request, Response, NextFunction } from "express";
+import {
+  balanceCache,
+  type BalanceEntry,
+  type BalanceFetcher,
+} from "../lib/balanceCache.js";
+
+const HORIZON_BASE =
+  process.env.NEXTELLAR_HORIZON_URL?.trim() || "https://horizon.stellar.org";
+
+const STELLAR_ACCOUNT_PATTERN = /^G[A-Z2-7]{55}$/;
+
+const defaultFetcher: BalanceFetcher = async (accountId) => {
+  const url = `${HORIZON_BASE.replace(/\/$/, "")}/accounts/${encodeURIComponent(
+    accountId,
+  )}`;
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`horizon_account_lookup_failed_${response.status}`);
+  }
+  const payload = (await response.json()) as { balances?: BalanceEntry[] };
+  return payload.balances ?? [];
+};
+
+interface BalanceRouterOptions {
+  fetcher?: BalanceFetcher;
+}
+
+export function createStellarBalanceRouter(
+  options: BalanceRouterOptions = {},
+): Router {
+  const router = Router();
+  const fetcher = options.fetcher ?? defaultFetcher;
+
+  router.get(
+    "/stellar/balance/:accountId",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const accountId = req.params.accountId?.trim();
+        if (!accountId || !STELLAR_ACCOUNT_PATTERN.test(accountId)) {
+          return res.status(400).json({ error: "invalid_account_id" });
+        }
+
+        const forceRefresh =
+          typeof req.query.refresh === "string" &&
+          ["1", "true", "yes"].includes(req.query.refresh.toLowerCase());
+
+        const { value, fromCache } = await balanceCache.get(
+          accountId,
+          fetcher,
+          { forceRefresh },
+        );
+
+        return res.status(200).json({
+          success: true,
+          data: {
+            accountId: value.accountId,
+            balances: value.balances,
+            fetchedAt: value.fetchedAt,
+            expiresAt: value.expiresAt,
+            fromCache,
+          },
+        });
+      } catch (err) {
+        return next(err);
+      }
+    },
+  );
+
+  router.post(
+    "/stellar/balance/:accountId/invalidate",
+    (req: Request, res: Response) => {
+      const accountId = req.params.accountId?.trim();
+      if (!accountId || !STELLAR_ACCOUNT_PATTERN.test(accountId)) {
+        return res.status(400).json({ error: "invalid_account_id" });
+      }
+      const removed = balanceCache.invalidate(accountId);
+      return res.status(200).json({
+        success: true,
+        data: { accountId, removed },
+      });
+    },
+  );
+
+  // Webhook-style endpoint: an outgoing payment from `from` invalidates that
+  // account's cached balances so subsequent reads observe the new ledger state.
+  router.post(
+    "/stellar/balance/invalidate-on-payment",
+    (req: Request, res: Response) => {
+      const from =
+        typeof req.body?.from === "string" ? req.body.from.trim() : "";
+      if (!from || !STELLAR_ACCOUNT_PATTERN.test(from)) {
+        return res.status(400).json({ error: "invalid_from_account" });
+      }
+      const removed = balanceCache.invalidate(from);
+      return res.status(200).json({
+        success: true,
+        data: { from, removed },
+      });
+    },
+  );
+
+  return router;
+}
+
+export default createStellarBalanceRouter();

--- a/routes-d/tests/stellar.balance.test.ts
+++ b/routes-d/tests/stellar.balance.test.ts
@@ -1,0 +1,100 @@
+import request from "supertest";
+import express from "express";
+import { createStellarBalanceRouter } from "../routes/stellar.balance.js";
+import { balanceCache, type BalanceEntry } from "../lib/balanceCache.js";
+
+const VALID_ACCOUNT =
+  "GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ234";
+
+function buildApp(fetcher: (id: string) => Promise<BalanceEntry[]>) {
+  const app = express();
+  app.use(express.json());
+  app.use(createStellarBalanceRouter({ fetcher }));
+  return app;
+}
+
+beforeEach(() => {
+  balanceCache.clear();
+});
+
+describe("Cached Stellar balance route (#274)", () => {
+  it("returns 400 for an invalid account id", async () => {
+    const app = buildApp(async () => []);
+    const res = await request(app).get("/stellar/balance/not-an-account");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "invalid_account_id" });
+  });
+
+  it("populates the cache on first hit (miss) and serves from cache on second (hit)", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return [
+        { assetType: "native", balance: "100.0000000" },
+      ];
+    };
+    const app = buildApp(fetcher);
+
+    const miss = await request(app).get(`/stellar/balance/${VALID_ACCOUNT}`);
+    expect(miss.status).toBe(200);
+    expect(miss.body.data.fromCache).toBe(false);
+
+    const hit = await request(app).get(`/stellar/balance/${VALID_ACCOUNT}`);
+    expect(hit.status).toBe(200);
+    expect(hit.body.data.fromCache).toBe(true);
+
+    expect(calls).toBe(1);
+  });
+
+  it("bypasses the cache when refresh=true", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return [{ assetType: "native", balance: String(calls) }];
+    };
+    const app = buildApp(fetcher);
+
+    await request(app).get(`/stellar/balance/${VALID_ACCOUNT}`);
+    const refreshed = await request(app).get(
+      `/stellar/balance/${VALID_ACCOUNT}?refresh=true`,
+    );
+
+    expect(refreshed.body.data.fromCache).toBe(false);
+    expect(refreshed.body.data.balances[0].balance).toBe("2");
+    expect(calls).toBe(2);
+  });
+
+  it("invalidates on outbound payment then refetches", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return [{ assetType: "native", balance: String(calls) }];
+    };
+    const app = buildApp(fetcher);
+
+    // Prime cache
+    await request(app).get(`/stellar/balance/${VALID_ACCOUNT}`);
+
+    // Outbound payment from this account → invalidate
+    const inv = await request(app)
+      .post("/stellar/balance/invalidate-on-payment")
+      .send({ from: VALID_ACCOUNT });
+    expect(inv.status).toBe(200);
+    expect(inv.body.data.removed).toBe(true);
+
+    const afterInvalidate = await request(app).get(
+      `/stellar/balance/${VALID_ACCOUNT}`,
+    );
+    expect(afterInvalidate.body.data.fromCache).toBe(false);
+    expect(calls).toBe(2);
+  });
+
+  it("invalidate-on-payment returns 400 for an invalid sender", async () => {
+    const app = buildApp(async () => []);
+    const res = await request(app)
+      .post("/stellar/balance/invalidate-on-payment")
+      .send({ from: "not-an-account" });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "invalid_from_account" });
+  });
+});


### PR DESCRIPTION
Closes #274.

## Summary
- `routes-d/lib/balanceCache.ts` — in-memory TTL cache for Horizon account balances. TTL defaults to 30s (configurable via `NEXTELLAR_BALANCE_CACHE_TTL_MS`) and the class exposes `invalidate`, `clear`, and `peek` for callers and tests.
- `routes-d/routes/stellar.balance.ts` — `GET /stellar/balance/:accountId` serves from cache; `?refresh=true|1|yes` bypasses. `POST /stellar/balance/invalidate-on-payment` drops the sender's cached entry so the next read refetches from Horizon (the outbound-payment invalidation contract from the issue). `POST /stellar/balance/:accountId/invalidate` lets explicit callers drop one entry. Account ids are validated against the Stellar `G…` ed25519 pattern; non-matching ids return `400 invalid_account_id`.
- `routes-d/tests/stellar.balance.test.ts` — jest + supertest coverage for hit, miss, refresh, invalidation on outbound payment, and the invalid-sender error path. All 5 pass locally.

## Scope
- All new files live under `routes-d/`. No existing files outside that folder are modified.

## Test plan
- [x] `npx jest routes-d/tests/stellar.balance.test.ts` — 5/5 passing locally.