### PR TITLE
feat(routes-d): JWT validation middleware + token version revocation

### DIFF
--- a/routes-d/auth/tokenVersion.ts
+++ b/routes-d/auth/tokenVersion.ts
@@ -1,0 +1,72 @@
+// Per-user token version counter (#262).
+//
+// On password change the user's token version is bumped, which lets the
+// server reject any previously-issued token whose embedded `tv` claim is
+// older than the current counter. The session that performed the password
+// change can keep its current token because the rotation handler returns
+// the new token version and the caller is expected to re-sign that
+// session's JWT before the response goes out.
+
+export interface TokenVersionRecord {
+  userId: string;
+  version: number;
+  updatedAt: number;
+}
+
+export interface TokenVersionStoreOptions {
+  now?: () => number;
+}
+
+export class TokenVersionStore {
+  private readonly versions = new Map<string, TokenVersionRecord>();
+  private readonly now: () => number;
+
+  constructor(options: TokenVersionStoreOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  current(userId: string): number {
+    const id = this.normalize(userId);
+    return this.versions.get(id)?.version ?? 0;
+  }
+
+  /**
+   * Bump the user's token version. Returns the new version so the caller can
+   * immediately re-sign the active session's token without forcing a logout.
+   */
+  bump(userId: string): TokenVersionRecord {
+    const id = this.normalize(userId);
+    const existing = this.versions.get(id);
+    const next: TokenVersionRecord = {
+      userId: id,
+      version: (existing?.version ?? 0) + 1,
+      updatedAt: this.now(),
+    };
+    this.versions.set(id, next);
+    return next;
+  }
+
+  /**
+   * Returns true when `tv` matches the current version for the user (or the
+   * user has no recorded bumps yet, in which case the implicit version is 0).
+   */
+  isCurrent(userId: string, tv: number | undefined): boolean {
+    if (tv === undefined || Number.isNaN(tv)) {
+      return false;
+    }
+    return this.current(userId) === tv;
+  }
+
+  reset(): void {
+    this.versions.clear();
+  }
+
+  private normalize(userId: string): string {
+    if (typeof userId !== "string" || userId.trim() === "") {
+      throw new Error("invalid_user_id");
+    }
+    return userId.trim();
+  }
+}
+
+export const tokenVersionStore = new TokenVersionStore();

--- a/routes-d/middleware/jwt.ts
+++ b/routes-d/middleware/jwt.ts
@@ -1,0 +1,117 @@
+import type { Request, Response, NextFunction } from "express";
+import jwt, { type JwtPayload } from "jsonwebtoken";
+import { requireSecret } from "../lib/tokens.js";
+import { tokenVersionStore, type TokenVersionStore } from "../auth/tokenVersion.js";
+
+// JWT validation middleware (#261).
+//
+// - Verifies signature (HS256), expiry, issuer, and audience.
+// - Returns a fixed error shape `{ error: "unauthorized" }` for any failure
+//   so we don't leak whether the token was expired, malformed, or had a bad
+//   audience.
+// - Optional per-route scope requirements: route opts in by passing
+//   `requireJwt({ scopes: ["transfer:write"] })`.
+// - When `tokenVersionStore.current(sub)` is set, tokens carrying a stale
+//   `tv` claim are rejected (this wires up the password-change revocation
+//   from #262).
+
+const JWT_SECRET_NAME = "NEXTELLAR_JWT_SECRET";
+const JWT_FALLBACK_SECRET = "nextellar-routes-d-jwt-secret";
+
+const JWT_ISSUER = process.env.NEXTELLAR_JWT_ISSUER?.trim() || "nextellar";
+const JWT_AUDIENCE =
+  process.env.NEXTELLAR_JWT_AUDIENCE?.trim() || "nextellar-app";
+
+export interface JwtClaims extends JwtPayload {
+  sub: string;
+  scopes?: string[];
+  tv?: number;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      jwt?: JwtClaims;
+    }
+  }
+}
+
+export interface RequireJwtOptions {
+  scopes?: string[];
+  versionStore?: TokenVersionStore;
+  secretName?: string;
+  secretFallback?: string;
+  issuer?: string;
+  audience?: string;
+}
+
+function unauthorized(res: Response) {
+  return res.status(401).json({ error: "unauthorized" });
+}
+
+function extractToken(req: Request): string | null {
+  const header = req.headers.authorization;
+  if (typeof header === "string" && header.toLowerCase().startsWith("bearer ")) {
+    const token = header.slice(7).trim();
+    return token.length > 0 ? token : null;
+  }
+  return null;
+}
+
+export function verifyJwtToken(
+  token: string,
+  options: RequireJwtOptions = {},
+): JwtClaims | null {
+  try {
+    const secret = requireSecret(
+      options.secretName ?? JWT_SECRET_NAME,
+      options.secretFallback ?? JWT_FALLBACK_SECRET,
+    );
+    return jwt.verify(token, secret, {
+      algorithms: ["HS256"],
+      issuer: options.issuer ?? JWT_ISSUER,
+      audience: options.audience ?? JWT_AUDIENCE,
+    }) as JwtClaims;
+  } catch {
+    return null;
+  }
+}
+
+export function requireJwt(options: RequireJwtOptions = {}) {
+  const versionStore = options.versionStore ?? tokenVersionStore;
+  const requiredScopes = options.scopes ?? [];
+
+  return function jwtMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) {
+    const token = extractToken(req);
+    if (!token) {
+      return unauthorized(res);
+    }
+
+    const claims = verifyJwtToken(token, options);
+    if (!claims || typeof claims.sub !== "string" || claims.sub.length === 0) {
+      return unauthorized(res);
+    }
+
+    if (versionStore.current(claims.sub) > 0) {
+      if (!versionStore.isCurrent(claims.sub, claims.tv)) {
+        return unauthorized(res);
+      }
+    }
+
+    if (requiredScopes.length > 0) {
+      const granted = Array.isArray(claims.scopes) ? claims.scopes : [];
+      const allowed = requiredScopes.every((scope) => granted.includes(scope));
+      if (!allowed) {
+        return res.status(403).json({ error: "forbidden" });
+      }
+    }
+
+    req.jwt = claims;
+    return next();
+  };
+}

--- a/routes-d/tests/jwt.test.ts
+++ b/routes-d/tests/jwt.test.ts
@@ -1,0 +1,113 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { requireJwt } from "../middleware/jwt.js";
+import { tokenVersionStore } from "../auth/tokenVersion.js";
+
+const SECRET = "nextellar-routes-d-jwt-secret";
+const ISSUER = "nextellar";
+const AUDIENCE = "nextellar-app";
+
+function sign(payload: object, opts: jwt.SignOptions = {}) {
+  return jwt.sign(payload, SECRET, {
+    algorithm: "HS256",
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    ...opts,
+  });
+}
+
+function buildApp(scopes?: string[]) {
+  const app = express();
+  app.get("/protected", requireJwt({ scopes }), (req, res) => {
+    res.status(200).json({ ok: true, sub: req.jwt?.sub });
+  });
+  return app;
+}
+
+beforeEach(() => {
+  tokenVersionStore.reset();
+});
+
+describe("JWT validation middleware (#261)", () => {
+  it("rejects requests without an Authorization header", async () => {
+    const res = await request(buildApp()).get("/protected");
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects an expired token with a generic 401", async () => {
+    const token = sign({ sub: "user-1" }, { expiresIn: "-1h" });
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects a tampered token", async () => {
+    const token = sign({ sub: "user-1" }) + "x";
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects a token signed with the wrong secret", async () => {
+    const token = jwt.sign({ sub: "user-1" }, "wrong-secret", {
+      algorithm: "HS256",
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a token with the wrong audience", async () => {
+    const token = sign({ sub: "user-1" }, { audience: "wrong-app" });
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a token with the wrong issuer", async () => {
+    const token = sign({ sub: "user-1" }, { issuer: "wrong" });
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts a valid token and exposes claims on req.jwt", async () => {
+    const token = sign({ sub: "user-1" });
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, sub: "user-1" });
+  });
+
+  it("returns 403 when required scopes are missing", async () => {
+    const token = sign({ sub: "user-1", scopes: ["read"] });
+    const res = await request(buildApp(["transfer:write"]))
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "forbidden" });
+  });
+
+  it("accepts a valid token when all required scopes are present", async () => {
+    const token = sign({
+      sub: "user-1",
+      scopes: ["read", "transfer:write"],
+    });
+    const res = await request(buildApp(["transfer:write"]))
+      .get("/protected")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/routes-d/tests/tokenVersion.test.ts
+++ b/routes-d/tests/tokenVersion.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { requireJwt } from "../middleware/jwt.js";
+import { tokenVersionStore } from "../auth/tokenVersion.js";
+
+const SECRET = "nextellar-routes-d-jwt-secret";
+const ISSUER = "nextellar";
+const AUDIENCE = "nextellar-app";
+
+function sign(payload: object) {
+  return jwt.sign(payload, SECRET, {
+    algorithm: "HS256",
+    issuer: ISSUER,
+    audience: AUDIENCE,
+  });
+}
+
+function buildApp() {
+  const app = express();
+  app.get("/me", requireJwt(), (req, res) =>
+    res.status(200).json({ ok: true, sub: req.jwt?.sub, tv: req.jwt?.tv }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  tokenVersionStore.reset();
+});
+
+describe("Token version store + JWT revocation on password change (#262)", () => {
+  it("starts at version 0 and bumps monotonically", () => {
+    expect(tokenVersionStore.current("user-1")).toBe(0);
+    expect(tokenVersionStore.bump("user-1").version).toBe(1);
+    expect(tokenVersionStore.bump("user-1").version).toBe(2);
+    expect(tokenVersionStore.current("user-1")).toBe(2);
+  });
+
+  it("rejects an invalid user id", () => {
+    expect(() => tokenVersionStore.bump("")).toThrow("invalid_user_id");
+  });
+
+  it("does not affect other users", () => {
+    tokenVersionStore.bump("user-1");
+    expect(tokenVersionStore.current("user-1")).toBe(1);
+    expect(tokenVersionStore.current("user-2")).toBe(0);
+  });
+
+  it("rejects an old token after the password is changed", async () => {
+    const oldToken = sign({ sub: "user-1", tv: 0 });
+
+    // Sanity-check: old token is accepted before any bump.
+    const before = await request(buildApp())
+      .get("/me")
+      .set("authorization", `Bearer ${oldToken}`);
+    expect(before.status).toBe(200);
+
+    // Password change → bump.
+    tokenVersionStore.bump("user-1");
+
+    const after = await request(buildApp())
+      .get("/me")
+      .set("authorization", `Bearer ${oldToken}`);
+    expect(after.status).toBe(401);
+    expect(after.body).toEqual({ error: "unauthorized" });
+  });
+
+  it("accepts a re-signed token that carries the new version", async () => {
+    tokenVersionStore.bump("user-1");
+    const fresh = sign({ sub: "user-1", tv: 1 });
+    const res = await request(buildApp())
+      .get("/me")
+      .set("authorization", `Bearer ${fresh}`);
+    expect(res.status).toBe(200);
+    expect(res.body.tv).toBe(1);
+  });
+
+  it("rejects a token missing tv after a bump", async () => {
+    tokenVersionStore.bump("user-1");
+    const noTv = sign({ sub: "user-1" });
+    const res = await request(buildApp())
+      .get("/me")
+      .set("authorization", `Bearer ${noTv}`);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Closes #261.
Closes #262.

## Summary
- `routes-d/middleware/jwt.ts` — `requireJwt(options)` verifies HS256 signature, expiry, issuer (`NEXTELLAR_JWT_ISSUER`, default `nextellar`), and audience (`NEXTELLAR_JWT_AUDIENCE`, default `nextellar-app`). All failure paths return a fixed `{ error: "unauthorized" }` so callers can't distinguish "expired" from "bad signature" from "wrong audience". Per-route required scopes are passed via `requireJwt({ scopes: ["transfer:write"] })`; missing scopes return `403 { error: "forbidden" }`.
- `routes-d/auth/tokenVersion.ts` — `TokenVersionStore` with `current(userId)`, `bump(userId)`, and `isCurrent(userId, tv)`. The middleware rejects any token whose `tv` claim is older than the user's current version, which is how password change revokes prior sessions. `bump()` returns the new version so the session that initiated the password change can re-sign its JWT inline without forcing a logout.
- `routes-d/tests/jwt.test.ts` — 9 cases: missing header, expired, tampered, wrong secret, wrong audience, wrong issuer, valid, missing-scope (403), and granted-scope (200).
- `routes-d/tests/tokenVersion.test.ts` — 6 cases: monotonic bumps, invalid user id rejection, per-user isolation, the change-then-old-token-rejected case from the issue, re-signed token accepted, and missing-`tv`-after-bump rejected.

## Scope
- All new files live under `routes-d/`. No files outside that folder are modified.

## Test plan
- [x] `npx jest routes-d/tests/jwt.test.ts routes-d/tests/tokenVersion.test.ts` — 15/15 passing locally.