### PR TITLE
feat(routes-d): add SMS dispatcher, outbox, scheduler, and Soroban storage inspector

### DIFF
--- a/routes-d/lib/outbox.ts
+++ b/routes-d/lib/outbox.ts
@@ -1,0 +1,89 @@
+import { randomBytes } from 'crypto';
+
+export type OutboxEventState = 'pending' | 'delivered' | 'failed';
+
+export interface OutboxEvent {
+  id: string;
+  url: string;
+  payload: unknown;
+  state: OutboxEventState;
+  attempts: number;
+  createdAt: number;
+  lastAttemptAt: number | null;
+  error: string | null;
+}
+
+const MAX_ATTEMPTS = 5;
+
+const outboxStore = new Map<string, OutboxEvent>();
+
+export function writeEvent(url: string, payload: unknown): OutboxEvent {
+  const event: OutboxEvent = {
+    id: randomBytes(16).toString('hex'),
+    url,
+    payload,
+    state: 'pending',
+    attempts: 0,
+    createdAt: Date.now(),
+    lastAttemptAt: null,
+    error: null,
+  };
+  outboxStore.set(event.id, event);
+  return event;
+}
+
+export function getEvent(id: string): OutboxEvent | undefined {
+  return outboxStore.get(id);
+}
+
+export function getPendingEvents(): OutboxEvent[] {
+  return Array.from(outboxStore.values()).filter((e) => e.state === 'pending');
+}
+
+export function getAllEvents(): OutboxEvent[] {
+  return Array.from(outboxStore.values());
+}
+
+export function clearOutbox(): void {
+  outboxStore.clear();
+}
+
+export const outboxDeps = {
+  async deliverWebhook(_url: string, _payload: unknown): Promise<void> {},
+};
+
+async function attemptDelivery(event: OutboxEvent): Promise<void> {
+  event.attempts += 1;
+  event.lastAttemptAt = Date.now();
+
+  try {
+    await outboxDeps.deliverWebhook(event.url, event.payload);
+    event.state = 'delivered';
+    event.error = null;
+  } catch (err) {
+    event.error = err instanceof Error ? err.message : String(err);
+    if (event.attempts >= MAX_ATTEMPTS) {
+      event.state = 'failed';
+    }
+  }
+}
+
+export async function relayPendingEvents(): Promise<{
+  delivered: number;
+  failed: number;
+  retrying: number;
+}> {
+  const pending = getPendingEvents();
+  let delivered = 0;
+  let failed = 0;
+  let retrying = 0;
+
+  for (const event of pending) {
+    await attemptDelivery(event);
+    if (event.state === 'delivered') delivered += 1;
+    else if (event.state === 'failed') failed += 1;
+    else retrying += 1;
+  }
+
+  return { delivered, failed, retrying };
+}

--- a/routes-d/lib/scheduler.ts
+++ b/routes-d/lib/scheduler.ts
@@ -1,0 +1,80 @@
+export type JobFn = () => Promise<void>;
+
+export interface JobRecord {
+  name: string;
+  intervalMs: number;
+  fn: JobFn;
+  lastRunAt: number | null;
+  running: boolean;
+  handle: ReturnType<typeof setInterval> | null;
+}
+
+const jobs = new Map<string, JobRecord>();
+
+export const schedulerDeps = {
+  async loadLastRunAt(_name: string): Promise<number | null> {
+    return null;
+  },
+  async saveLastRunAt(_name: string, _ts: number): Promise<void> {},
+};
+
+export async function registerJob(
+  name: string,
+  intervalMs: number,
+  fn: JobFn,
+): Promise<void> {
+  if (jobs.has(name)) return;
+
+  const lastRunAt = await schedulerDeps.loadLastRunAt(name);
+
+  const record: JobRecord = {
+    name,
+    intervalMs,
+    fn,
+    lastRunAt,
+    running: false,
+    handle: null,
+  };
+
+  jobs.set(name, record);
+
+  record.handle = setInterval(() => {
+    void runJob(name);
+  }, intervalMs);
+}
+
+export async function runJob(name: string): Promise<void> {
+  const record = jobs.get(name);
+  if (!record) return;
+
+  if (record.running) return;
+
+  record.running = true;
+  const now = Date.now();
+
+  try {
+    await record.fn();
+    record.lastRunAt = now;
+    await schedulerDeps.saveLastRunAt(name, now);
+  } finally {
+    record.running = false;
+  }
+}
+
+export function getJob(name: string): JobRecord | undefined {
+  return jobs.get(name);
+}
+
+export function stopJob(name: string): void {
+  const record = jobs.get(name);
+  if (!record || record.handle === null) return;
+  clearInterval(record.handle);
+  record.handle = null;
+}
+
+export function clearJobs(): void {
+  for (const name of jobs.keys()) {
+    stopJob(name);
+  }
+  jobs.clear();
+}

--- a/routes-d/lib/smsDispatcher.ts
+++ b/routes-d/lib/smsDispatcher.ts
@@ -1,0 +1,94 @@
+export interface SmsPayload {
+  to: string;
+  body: string;
+}
+
+export interface SmsProvider {
+  send(to: string, body: string): Promise<void>;
+}
+
+export class SmsDispatcherError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'INVALID_NUMBER' | 'RATE_LIMITED' | 'SEND_FAILED',
+  ) {
+    super(message);
+    this.name = 'SmsDispatcherError';
+  }
+}
+
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+const DIGIT_RE = /\D/g;
+
+export function normalizeE164(raw: string): string {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new SmsDispatcherError(`Invalid phone number: ${raw}`, 'INVALID_NUMBER');
+  }
+
+  const trimmed = raw.trim();
+  const withPlus = trimmed.startsWith('+') ? trimmed : '+' + trimmed;
+  const prefix = '+';
+  const digits = withPlus.slice(1).replace(DIGIT_RE, '');
+  const normalized = prefix + digits;
+
+  if (!E164_RE.test(normalized)) {
+    throw new SmsDispatcherError(
+      `Phone number does not conform to E.164: ${raw}`,
+      'INVALID_NUMBER',
+    );
+  }
+
+  return normalized;
+}
+
+const SMS_RATE_LIMIT = 5;
+const SMS_RATE_WINDOW_MS = 60_000;
+
+type RateBucket = { count: number; resetAt: number };
+const rateBuckets = new Map<string, RateBucket>();
+
+function getBucket(number: string, now: number): RateBucket {
+  const existing = rateBuckets.get(number);
+  if (!existing || existing.resetAt <= now) {
+    const bucket: RateBucket = { count: 0, resetAt: now + SMS_RATE_WINDOW_MS };
+    rateBuckets.set(number, bucket);
+    return bucket;
+  }
+  return existing;
+}
+
+export const smsDispatcherDeps: { provider: SmsProvider } = {
+  provider: {
+    async send(_to: string, _body: string): Promise<void> {},
+  },
+};
+
+export async function dispatchSms(payload: SmsPayload): Promise<{ to: string }> {
+  const normalized = normalizeE164(payload.to);
+  const now = Date.now();
+  const bucket = getBucket(normalized, now);
+
+  if (bucket.count >= SMS_RATE_LIMIT) {
+    const retryAfter = Math.ceil((bucket.resetAt - now) / 1000);
+    throw new SmsDispatcherError(
+      `Rate limit exceeded for ${normalized}. Retry after ${retryAfter}s.`,
+      'RATE_LIMITED',
+    );
+  }
+
+  bucket.count += 1;
+
+  try {
+    await smsDispatcherDeps.provider.send(normalized, payload.body);
+  } catch (err) {
+    bucket.count -= 1;
+    const message = err instanceof Error ? err.message : String(err);
+    throw new SmsDispatcherError(`Send failed: ${message}`, 'SEND_FAILED');
+  }
+
+  return { to: normalized };
+}
+
+export function __resetSmsRateLimitState(): void {
+  rateBuckets.clear();
+}

--- a/routes-d/lib/sorobanStorageDecoder.ts
+++ b/routes-d/lib/sorobanStorageDecoder.ts
@@ -1,0 +1,83 @@
+export type ScValKind =
+  | 'scvBool'
+  | 'scvVoid'
+  | 'scvU32'
+  | 'scvI32'
+  | 'scvU64'
+  | 'scvI64'
+  | 'scvBytes'
+  | 'scvString'
+  | 'scvSymbol'
+  | 'scvAddress'
+  | 'scvVec'
+  | 'scvMap';
+
+export type ScValMapEntry = { key: ScValShape; val: ScValShape };
+
+export interface ScValShape {
+  type: ScValKind | string;
+  value?: unknown;
+}
+
+export type DecodedScVal =
+  | boolean
+  | null
+  | number
+  | string
+  | DecodedScVal[]
+  | Record<string, DecodedScVal>
+  | { _unknown: string; raw: unknown };
+
+export function decodeScVal(scv: ScValShape): DecodedScVal {
+  switch (scv.type) {
+    case 'scvBool':
+      return Boolean(scv.value);
+
+    case 'scvVoid':
+      return null;
+
+    case 'scvU32':
+    case 'scvI32':
+      return Number(scv.value);
+
+    case 'scvU64':
+    case 'scvI64':
+      return String(scv.value);
+
+    case 'scvBytes':
+      if (Buffer.isBuffer(scv.value)) return scv.value.toString('hex');
+      if (scv.value instanceof Uint8Array)
+        return Buffer.from(scv.value).toString('hex');
+      return String(scv.value);
+
+    case 'scvString':
+      if (Buffer.isBuffer(scv.value)) return scv.value.toString('utf-8');
+      if (scv.value instanceof Uint8Array)
+        return Buffer.from(scv.value).toString('utf-8');
+      return String(scv.value);
+
+    case 'scvSymbol':
+    case 'scvAddress':
+      return String(scv.value);
+
+    case 'scvVec': {
+      const items = scv.value;
+      if (!Array.isArray(items)) return [];
+      return items.map((item) => decodeScVal(item as ScValShape));
+    }
+
+    case 'scvMap': {
+      const entries = scv.value;
+      if (!Array.isArray(entries)) return {};
+      const result: Record<string, DecodedScVal> = {};
+      for (const entry of entries as ScValMapEntry[]) {
+        const k = String(decodeScVal(entry.key));
+        result[k] = decodeScVal(entry.val);
+      }
+      return result;
+    }
+
+    default:
+      return { _unknown: scv.type, raw: scv.value ?? null };
+  }
+}

--- a/routes-d/routes/soroban.storage.ts
+++ b/routes-d/routes/soroban.storage.ts
@@ -1,0 +1,95 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  decodeScVal,
+  ScValShape,
+  DecodedScVal,
+} from '../lib/sorobanStorageDecoder.js';
+
+const router = Router();
+
+const CACHE_TTL_MS = 10_000;
+
+interface CacheEntry {
+  value: DecodedScVal;
+  expiresAt: number;
+}
+
+const storageCache = new Map<string, CacheEntry>();
+
+export type StorageFetcher = (
+  contractId: string,
+  key: string,
+) => Promise<ScValShape | null>;
+
+export const sorobanStorageDeps: { fetchStorage: StorageFetcher } = {
+  async fetchStorage(_contractId: string, _key: string): Promise<ScValShape | null> {
+    return null;
+  },
+};
+
+function cacheKey(contractId: string, key: string): string {
+  return `${contractId}:${key}`;
+}
+
+export function __clearSorobanStorageCache(): void {
+  storageCache.clear();
+}
+
+/**
+ * GET /soroban/storage/:contractId?key=<ledger-key>
+ *
+ * Returns a decoded JSON representation of the contract storage entry.
+ * Responses are cached for 10 seconds.
+ */
+router.get(
+  '/soroban/storage/:contractId',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const contractId =
+        typeof req.params.contractId === 'string'
+          ? req.params.contractId.trim()
+          : '';
+      const key =
+        typeof req.query.key === 'string' ? req.query.key.trim() : '';
+
+      if (!contractId) {
+        return res.status(400).json({ error: 'contractId is required' });
+      }
+
+      if (!key) {
+        return res.status(400).json({ error: 'key query parameter is required' });
+      }
+
+      const ck = cacheKey(contractId, key);
+      const now = Date.now();
+      const cached = storageCache.get(ck);
+
+      if (cached && cached.expiresAt > now) {
+        return res.status(200).json({
+          success: true,
+          cached: true,
+          data: cached.value,
+        });
+      }
+
+      const scv = await sorobanStorageDeps.fetchStorage(contractId, key);
+
+      if (scv === null) {
+        return res.status(404).json({ error: 'Storage entry not found' });
+      }
+
+      const decoded = decodeScVal(scv);
+      storageCache.set(ck, { value: decoded, expiresAt: now + CACHE_TTL_MS });
+
+      return res.status(200).json({
+        success: true,
+        cached: false,
+        data: decoded,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/outbox.test.ts
+++ b/routes-d/tests/outbox.test.ts
@@ -1,0 +1,148 @@
+import {
+  writeEvent,
+  getEvent,
+  getPendingEvents,
+  relayPendingEvents,
+  clearOutbox,
+  outboxDeps,
+} from '../lib/outbox.js';
+
+beforeEach(() => {
+  clearOutbox();
+  outboxDeps.deliverWebhook = jest.fn().mockResolvedValue(undefined);
+});
+
+describe('writeEvent', () => {
+  it('creates a pending event with the given url and payload', () => {
+    const payload = { type: 'payment', amount: 100 };
+    const event = writeEvent('https://example.com/hook', payload);
+
+    expect(event.id).toBeTruthy();
+    expect(event.url).toBe('https://example.com/hook');
+    expect(event.payload).toEqual(payload);
+    expect(event.state).toBe('pending');
+    expect(event.attempts).toBe(0);
+    expect(event.lastAttemptAt).toBeNull();
+    expect(event.error).toBeNull();
+  });
+
+  it('persists the event in the store', () => {
+    const event = writeEvent('https://example.com/hook', {});
+    expect(getEvent(event.id)).toBe(event);
+  });
+
+  it('writes multiple events transactionally (each gets a unique id)', () => {
+    const a = writeEvent('https://example.com/a', { n: 1 });
+    const b = writeEvent('https://example.com/b', { n: 2 });
+
+    expect(a.id).not.toBe(b.id);
+    expect(getPendingEvents()).toHaveLength(2);
+  });
+});
+
+describe('relayPendingEvents - deliver', () => {
+  it('dispatches pending events to the webhook url', async () => {
+    const event = writeEvent('https://example.com/hook', { x: 1 });
+    const result = await relayPendingEvents();
+
+    expect(result.delivered).toBe(1);
+    expect(event.state).toBe('delivered');
+    expect(event.error).toBeNull();
+    expect(outboxDeps.deliverWebhook).toHaveBeenCalledWith(
+      'https://example.com/hook',
+      { x: 1 },
+    );
+  });
+
+  it('marks the event delivered and sets lastAttemptAt', async () => {
+    const before = Date.now();
+    const event = writeEvent('https://example.com/hook', {});
+    await relayPendingEvents();
+
+    expect(event.lastAttemptAt).toBeGreaterThanOrEqual(before);
+    expect(event.state).toBe('delivered');
+  });
+
+  it('does not re-process already-delivered events', async () => {
+    writeEvent('https://example.com/hook', {});
+    await relayPendingEvents();
+    await relayPendingEvents();
+
+    expect(outboxDeps.deliverWebhook).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('relayPendingEvents - retry', () => {
+  it('keeps the event pending after a transient failure', async () => {
+    (outboxDeps.deliverWebhook as jest.Mock).mockRejectedValue(
+      new Error('timeout'),
+    );
+
+    const event = writeEvent('https://example.com/hook', {});
+    const result = await relayPendingEvents();
+
+    expect(result.retrying).toBe(1);
+    expect(event.state).toBe('pending');
+    expect(event.attempts).toBe(1);
+    expect(event.error).toBe('timeout');
+  });
+
+  it('increments attempts on each relay call', async () => {
+    (outboxDeps.deliverWebhook as jest.Mock).mockRejectedValue(
+      new Error('fail'),
+    );
+
+    const event = writeEvent('https://example.com/hook', {});
+    await relayPendingEvents();
+    await relayPendingEvents();
+
+    expect(event.attempts).toBe(2);
+  });
+
+  it('marks event failed after MAX_ATTEMPTS (5) consecutive failures', async () => {
+    (outboxDeps.deliverWebhook as jest.Mock).mockRejectedValue(
+      new Error('persistent failure'),
+    );
+
+    const event = writeEvent('https://example.com/hook', {});
+    for (let i = 0; i < 5; i++) {
+      await relayPendingEvents();
+    }
+
+    const result = await relayPendingEvents();
+    expect(result.failed).toBe(0); // already marked failed, no longer pending
+    expect(event.state).toBe('failed');
+    expect(event.attempts).toBe(5);
+  });
+});
+
+describe('crash recovery', () => {
+  it('pending events survive a relay restart (remain in store)', () => {
+    (outboxDeps.deliverWebhook as jest.Mock).mockRejectedValue(
+      new Error('crash'),
+    );
+
+    const event = writeEvent('https://example.com/hook', { important: true });
+
+    expect(getPendingEvents()).toContain(event);
+    expect(event.state).toBe('pending');
+  });
+
+  it('resumes delivery after a crash (state preserved between relay calls)', async () => {
+    let callCount = 0;
+    (outboxDeps.deliverWebhook as jest.Mock).mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 1) throw new Error('crash on first attempt');
+    });
+
+    const event = writeEvent('https://example.com/hook', {});
+
+    const first = await relayPendingEvents();
+    expect(first.retrying).toBe(1);
+    expect(event.state).toBe('pending');
+
+    const second = await relayPendingEvents();
+    expect(second.delivered).toBe(1);
+    expect(event.state).toBe('delivered');
+  });
+});

--- a/routes-d/tests/scheduler.test.ts
+++ b/routes-d/tests/scheduler.test.ts
@@ -1,0 +1,146 @@
+import {
+  registerJob,
+  runJob,
+  getJob,
+  clearJobs,
+  schedulerDeps,
+} from '../lib/scheduler.js';
+
+beforeEach(() => {
+  clearJobs();
+  schedulerDeps.loadLastRunAt = jest.fn().mockResolvedValue(null);
+  schedulerDeps.saveLastRunAt = jest.fn().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  clearJobs();
+});
+
+describe('registerJob', () => {
+  it('registers a job and stores the record', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('cleanup', 60_000, fn);
+
+    const record = getJob('cleanup');
+    expect(record).toBeDefined();
+    expect(record!.name).toBe('cleanup');
+    expect(record!.intervalMs).toBe(60_000);
+  });
+
+  it('loads lastRunAt from persistence on registration', async () => {
+    const savedTs = Date.now() - 5_000;
+    (schedulerDeps.loadLastRunAt as jest.Mock).mockResolvedValue(savedTs);
+
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('report', 60_000, fn);
+
+    expect(getJob('report')!.lastRunAt).toBe(savedTs);
+    expect(schedulerDeps.loadLastRunAt).toHaveBeenCalledWith('report');
+  });
+
+  it('does not register the same job twice', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('dedupe', 60_000, fn);
+    await registerJob('dedupe', 30_000, fn);
+
+    expect(getJob('dedupe')!.intervalMs).toBe(60_000);
+  });
+});
+
+describe('runJob', () => {
+  it('executes the job function and updates lastRunAt', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    const before = Date.now();
+    await registerJob('task', 60_000, fn);
+    await runJob('task');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(getJob('task')!.lastRunAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('persists lastRunAt after a successful run', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('persist-test', 60_000, fn);
+    await runJob('persist-test');
+
+    expect(schedulerDeps.saveLastRunAt).toHaveBeenCalledWith(
+      'persist-test',
+      expect.any(Number),
+    );
+  });
+
+  it('does nothing for an unknown job name', async () => {
+    await expect(runJob('nonexistent')).resolves.toBeUndefined();
+  });
+});
+
+describe('skip-overlap', () => {
+  it('skips a second run if the previous instance is still active', async () => {
+    let resolveFirst!: () => void;
+    const first = new Promise<void>((res) => {
+      resolveFirst = res;
+    });
+
+    const fn = jest.fn().mockReturnValue(first);
+    await registerJob('overlap', 60_000, fn);
+
+    const run1 = runJob('overlap');
+    const run2 = runJob('overlap');
+
+    resolveFirst();
+    await run1;
+    await run2;
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new run after the previous one completes', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('sequential', 60_000, fn);
+
+    await runJob('sequential');
+    await runJob('sequential');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the running flag even when the job throws', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+    await registerJob('throws', 60_000, fn);
+
+    await runJob('throws').catch(() => {});
+    await runJob('throws');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(getJob('throws')!.running).toBe(false);
+  });
+});
+
+describe('persistence', () => {
+  it('restores lastRunAt from a previous session on register', async () => {
+    const previousRun = Date.now() - 120_000;
+    (schedulerDeps.loadLastRunAt as jest.Mock).mockResolvedValue(previousRun);
+
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('restore', 60_000, fn);
+
+    expect(getJob('restore')!.lastRunAt).toBe(previousRun);
+  });
+
+  it('overwrites lastRunAt in persistence after each run', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined);
+    await registerJob('overwrite', 60_000, fn);
+
+    await runJob('overwrite');
+    const firstTs = (schedulerDeps.saveLastRunAt as jest.Mock).mock.calls[0][1];
+
+    await runJob('overwrite');
+    const secondTs = (schedulerDeps.saveLastRunAt as jest.Mock).mock.calls[1][1];
+
+    expect(secondTs).toBeGreaterThanOrEqual(firstTs);
+    expect(schedulerDeps.saveLastRunAt).toHaveBeenCalledTimes(2);
+  });
+});

--- a/routes-d/tests/smsDispatcher.test.ts
+++ b/routes-d/tests/smsDispatcher.test.ts
@@ -1,0 +1,122 @@
+import {
+  dispatchSms,
+  smsDispatcherDeps,
+  normalizeE164,
+  SmsDispatcherError,
+  __resetSmsRateLimitState,
+} from '../lib/smsDispatcher.js';
+
+beforeEach(() => {
+  __resetSmsRateLimitState();
+  smsDispatcherDeps.provider = {
+    send: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('normalizeE164', () => {
+  it('keeps a valid E.164 number unchanged', () => {
+    expect(normalizeE164('+14155552671')).toBe('+14155552671');
+  });
+
+  it('strips spaces and dashes, prepends + when missing', () => {
+    expect(normalizeE164('1 415 555 2671')).toBe('+14155552671');
+  });
+
+  it('strips parentheses and hyphens', () => {
+    expect(normalizeE164('+1 (415) 555-2671')).toBe('+14155552671');
+  });
+
+  it('throws INVALID_NUMBER for a number that is too short', () => {
+    expect(() => normalizeE164('+123')).toThrow(SmsDispatcherError);
+    try {
+      normalizeE164('+123');
+    } catch (err) {
+      expect((err as SmsDispatcherError).code).toBe('INVALID_NUMBER');
+    }
+  });
+
+  it('throws INVALID_NUMBER for empty string', () => {
+    expect(() => normalizeE164('')).toThrow(SmsDispatcherError);
+  });
+
+  it('throws INVALID_NUMBER for a non-digit string', () => {
+    expect(() => normalizeE164('not-a-phone')).toThrow(SmsDispatcherError);
+  });
+});
+
+describe('dispatchSms', () => {
+  it('sends SMS through the provider and returns normalized number', async () => {
+    const result = await dispatchSms({ to: '+14155552671', body: 'Hello' });
+
+    expect(result.to).toBe('+14155552671');
+    expect(smsDispatcherDeps.provider.send).toHaveBeenCalledWith(
+      '+14155552671',
+      'Hello',
+    );
+  });
+
+  it('normalizes the number before sending', async () => {
+    await dispatchSms({ to: '1 415 555 2671', body: 'Hi' });
+
+    expect(smsDispatcherDeps.provider.send).toHaveBeenCalledWith(
+      '+14155552671',
+      'Hi',
+    );
+  });
+
+  it('throws INVALID_NUMBER for a bad number and does not call the provider', async () => {
+    await expect(dispatchSms({ to: 'bad', body: 'x' })).rejects.toThrow(
+      SmsDispatcherError,
+    );
+    expect(smsDispatcherDeps.provider.send).not.toHaveBeenCalled();
+  });
+
+  it('throws SEND_FAILED when the provider rejects and does not count the attempt', async () => {
+    (smsDispatcherDeps.provider.send as jest.Mock).mockRejectedValue(
+      new Error('network error'),
+    );
+
+    await expect(
+      dispatchSms({ to: '+14155552671', body: 'x' }),
+    ).rejects.toMatchObject({ code: 'SEND_FAILED' });
+
+    // attempt was rolled back so the same number can still send up to the limit
+    const successes: string[] = [];
+    (smsDispatcherDeps.provider.send as jest.Mock).mockResolvedValue(undefined);
+    for (let i = 0; i < 5; i++) {
+      const r = await dispatchSms({ to: '+14155552671', body: 'ok' });
+      successes.push(r.to);
+    }
+    expect(successes).toHaveLength(5);
+  });
+
+  describe('rate limiting', () => {
+    it('allows up to 5 sends per window', async () => {
+      for (let i = 0; i < 5; i++) {
+        await expect(
+          dispatchSms({ to: '+14155552671', body: `msg ${i}` }),
+        ).resolves.toBeDefined();
+      }
+    });
+
+    it('throttles after 5 sends within the window', async () => {
+      for (let i = 0; i < 5; i++) {
+        await dispatchSms({ to: '+14155552671', body: `msg ${i}` });
+      }
+
+      await expect(
+        dispatchSms({ to: '+14155552671', body: 'over limit' }),
+      ).rejects.toMatchObject({ code: 'RATE_LIMITED' });
+    });
+
+    it('rate limits per destination independently', async () => {
+      for (let i = 0; i < 5; i++) {
+        await dispatchSms({ to: '+14155552671', body: `msg ${i}` });
+      }
+
+      await expect(
+        dispatchSms({ to: '+447911123456', body: 'different number' }),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/routes-d/tests/soroban.storage.test.ts
+++ b/routes-d/tests/soroban.storage.test.ts
@@ -1,0 +1,161 @@
+import express from 'express';
+import request from 'supertest';
+import sorobanStorageRouter, {
+  sorobanStorageDeps,
+  __clearSorobanStorageCache,
+} from '../routes/soroban.storage.js';
+import { decodeScVal } from '../lib/sorobanStorageDecoder.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(sorobanStorageRouter);
+  return app;
+}
+
+const CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+
+beforeEach(() => {
+  __clearSorobanStorageCache();
+  sorobanStorageDeps.fetchStorage = jest.fn().mockResolvedValue(null);
+});
+
+describe('GET /soroban/storage/:contractId', () => {
+  const app = buildApp();
+
+  it('returns 400 when key query param is missing', async () => {
+    const res = await request(app).get(`/soroban/storage/${CONTRACT_ID}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/key/i);
+  });
+
+  it('returns 404 when the storage entry does not exist', async () => {
+    const res = await request(app)
+      .get(`/soroban/storage/${CONTRACT_ID}`)
+      .query({ key: 'balance' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it('returns decoded value for an existing entry', async () => {
+    (sorobanStorageDeps.fetchStorage as jest.Mock).mockResolvedValue({
+      type: 'scvU64',
+      value: BigInt('9007199254740992'),
+    });
+
+    const res = await request(app)
+      .get(`/soroban/storage/${CONTRACT_ID}`)
+      .query({ key: 'balance' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.cached).toBe(false);
+    expect(res.body.data).toBe('9007199254740992');
+  });
+
+  it('returns cached response within the TTL window', async () => {
+    (sorobanStorageDeps.fetchStorage as jest.Mock).mockResolvedValue({
+      type: 'scvBool',
+      value: true,
+    });
+
+    await request(app)
+      .get(`/soroban/storage/${CONTRACT_ID}`)
+      .query({ key: 'flag' });
+
+    const res = await request(app)
+      .get(`/soroban/storage/${CONTRACT_ID}`)
+      .query({ key: 'flag' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(true);
+    expect(sorobanStorageDeps.fetchStorage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('decodeScVal', () => {
+  it('decodes scvBool true', () => {
+    expect(decodeScVal({ type: 'scvBool', value: true })).toBe(true);
+  });
+
+  it('decodes scvBool false', () => {
+    expect(decodeScVal({ type: 'scvBool', value: false })).toBe(false);
+  });
+
+  it('decodes scvVoid as null', () => {
+    expect(decodeScVal({ type: 'scvVoid' })).toBeNull();
+  });
+
+  it('decodes scvU32', () => {
+    expect(decodeScVal({ type: 'scvU32', value: 42 })).toBe(42);
+  });
+
+  it('decodes scvI32 negative value', () => {
+    expect(decodeScVal({ type: 'scvI32', value: -7 })).toBe(-7);
+  });
+
+  it('decodes scvU64 as string to preserve precision', () => {
+    const big = '18446744073709551615';
+    expect(decodeScVal({ type: 'scvU64', value: BigInt(big) })).toBe(big);
+  });
+
+  it('decodes scvI64 as string', () => {
+    expect(decodeScVal({ type: 'scvI64', value: BigInt(-1) })).toBe('-1');
+  });
+
+  it('decodes scvBytes as hex string', () => {
+    const buf = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    expect(decodeScVal({ type: 'scvBytes', value: buf })).toBe('deadbeef');
+  });
+
+  it('decodes scvString as utf-8', () => {
+    const buf = Buffer.from('hello', 'utf-8');
+    expect(decodeScVal({ type: 'scvString', value: buf })).toBe('hello');
+  });
+
+  it('decodes scvSymbol as string', () => {
+    expect(decodeScVal({ type: 'scvSymbol', value: 'TOKEN' })).toBe('TOKEN');
+  });
+
+  it('decodes scvAddress as string', () => {
+    expect(
+      decodeScVal({ type: 'scvAddress', value: 'GABC...XYZ' }),
+    ).toBe('GABC...XYZ');
+  });
+
+  it('decodes scvVec recursively', () => {
+    const scv = {
+      type: 'scvVec' as const,
+      value: [
+        { type: 'scvU32', value: 1 },
+        { type: 'scvU32', value: 2 },
+      ],
+    };
+    expect(decodeScVal(scv)).toEqual([1, 2]);
+  });
+
+  it('decodes scvMap into a JS object', () => {
+    const scv = {
+      type: 'scvMap' as const,
+      value: [
+        {
+          key: { type: 'scvSymbol', value: 'name' },
+          val: { type: 'scvString', value: 'nextellar' },
+        },
+        {
+          key: { type: 'scvSymbol', value: 'version' },
+          val: { type: 'scvU32', value: 1 },
+        },
+      ],
+    };
+    expect(decodeScVal(scv)).toEqual({ name: 'nextellar', version: 1 });
+  });
+
+  it('returns a _unknown wrapper for unrecognised ScVal kinds', () => {
+    const result = decodeScVal({ type: 'scvFuture', value: 99 }) as {
+      _unknown: string;
+    };
+    expect(result._unknown).toBe('scvFuture');
+  });
+});


### PR DESCRIPTION
## Summary

Implements four features under `routes-d/` as separate, self-contained modules with full unit test coverage (53 tests, all passing).

### SMS notification dispatcher (closes #377)
- `routes-d/lib/smsDispatcher.ts` — pluggable `SmsProvider` interface; `normalizeE164` strips formatting and validates against E.164 regex before any send attempt; in-memory rate-limit bucket (5 sends per 60 s per destination); failed sends roll back the attempt counter so the budget is not consumed on transient errors.
- `routes-d/tests/smsDispatcher.test.ts` — covers send success, number normalization, bad-number rejection, send failure, rate-limit enforcement, and per-destination independence.

### Outbox pattern for reliable webhook delivery (closes #373)
- `routes-d/lib/outbox.ts` — `writeEvent` appends a pending event to the in-memory store transactionally; `relayPendingEvents` processes all pending rows and calls the pluggable `deliverWebhook` dep; rows transition to `delivered` on success or remain `pending` (retrying) until `MAX_ATTEMPTS` (5) is reached, after which they are marked `failed`; attempt count and `lastAttemptAt` are tracked on every pass.
- `routes-d/tests/outbox.test.ts` — covers write, deliver, retry with transient failures, exhausted retries, and crash-recovery (state survives between relay calls).

### Background job scheduler (closes #372)
- `routes-d/lib/scheduler.ts` — `registerJob` loads the persisted `lastRunAt` via `schedulerDeps.loadLastRunAt` on first registration; `setInterval` drives execution; `runJob` guards re-entrancy with a `running` flag so overlapping invocations are skipped without queuing; `schedulerDeps.saveLastRunAt` is called after every successful run; the `running` flag is cleared in a `finally` block so a throwing job does not permanently lock the slot.
- `routes-d/tests/scheduler.test.ts` — covers schedule, persistence restore, dedup registration, skip-overlap (concurrent runs), sequential runs after completion, throw recovery, and timestamp overwrite.

### Soroban contract storage inspector (closes #365)
- `routes-d/lib/sorobanStorageDecoder.ts` — `decodeScVal` handles all common `ScValKind` discriminants: `scvBool`, `scvVoid`, `scvU32`, `scvI32`, `scvU64`/`scvI64` (as strings to preserve precision), `scvBytes` (hex), `scvString` (UTF-8), `scvSymbol`, `scvAddress`, `scvVec` (recursive), `scvMap` (key→value record); unknown kinds return a `{ _unknown, raw }` envelope.
- `routes-d/routes/soroban.storage.ts` — `GET /soroban/storage/:contractId?key=<key>` route; fetches via pluggable `sorobanStorageDeps.fetchStorage`; caches decoded results with a 10 s TTL; returns `{ success, cached, data }`.
- `routes-d/tests/soroban.storage.test.ts` — covers missing key param, cache miss (404), successful decode, cache hit (single upstream call), and one decode assertion per ScVal kind.

## Test plan

- [ ] Run `npm test -- routes-d/tests/smsDispatcher.test.ts routes-d/tests/outbox.test.ts routes-d/tests/scheduler.test.ts routes-d/tests/soroban.storage.test.ts` — all 53 tests should pass
- [ ] Run the full test suite (`npm test`) and confirm no regressions in existing suites
- [ ] Confirm all new files are strictly inside `routes-d/`; no files outside that folder were modified
