### PR TITLE
feat: add routes-d helpers and order cancellation

### DIFF
--- a/routes-d/lib/cacheHeaders.ts
+++ b/routes-d/lib/cacheHeaders.ts
@@ -1,0 +1,57 @@
+// Cache header helper for routes-d (#349).
+//
+// Generates a stable ETag from the response payload and applies
+// CDN-friendly cache headers. If the caller presents a matching
+// `If-None-Match` value we short-circuit with a 304 response.
+
+import { createHash } from "node:crypto";
+import type { Response } from "express";
+
+export interface CacheHeadersOptions {
+  /** Cache lifetime in seconds. Default 60. */
+  maxAgeSeconds?: number;
+  /** Shared cache lifetime in seconds. Default 300. */
+  sMaxAgeSeconds?: number;
+  /** Marks the response as publicly cacheable. Default true. */
+  public?: boolean;
+}
+
+export interface CacheHeadersResult {
+  etag: string;
+  cacheControl: string;
+  notModified: boolean;
+}
+
+function normalizePayload(payload: unknown): string {
+  return typeof payload === "string" ? payload : JSON.stringify(payload);
+}
+
+export function createPayloadEtag(payload: unknown): string {
+  const normalized = normalizePayload(payload);
+  return `W/"${createHash("sha1").update(normalized).digest("hex")}"`;
+}
+
+export function applyCacheHeaders(
+  res: Pick<Response, "setHeader" | "status">,
+  payload: unknown,
+  reqHeaders: Record<string, string | string[] | undefined>,
+  options: CacheHeadersOptions = {},
+): CacheHeadersResult {
+  const etag = createPayloadEtag(payload);
+  const maxAgeSeconds = options.maxAgeSeconds ?? 60;
+  const sMaxAgeSeconds = options.sMaxAgeSeconds ?? 300;
+  const visibility = (options.public ?? true) ? "public" : "private";
+  const cacheControl = `${visibility}, max-age=${maxAgeSeconds}, s-maxage=${sMaxAgeSeconds}`;
+  const ifNoneMatch = reqHeaders["if-none-match"];
+  const incoming = Array.isArray(ifNoneMatch) ? ifNoneMatch.join(",") : ifNoneMatch;
+  const notModified = typeof incoming === "string" && incoming === etag;
+
+  res.setHeader("ETag", etag);
+  res.setHeader("Cache-Control", cacheControl);
+
+  if (notModified) {
+    res.status(304);
+  }
+
+  return { etag, cacheControl, notModified };
+}

--- a/routes-d/lib/slowQueryLog.ts
+++ b/routes-d/lib/slowQueryLog.ts
@@ -1,0 +1,47 @@
+// Slow query logger for routes-d (#333).
+//
+// The logger is intentionally tiny and dependency-free: callers wrap
+// any async operation, and this helper emits a structured message only
+// when the duration crosses the configured threshold.
+
+export interface SlowQueryLogEntry {
+  target: string;
+  durationMs: number;
+  error?: string;
+}
+
+export interface SlowQueryLoggerOptions {
+  thresholdMs?: number;
+  log?: (entry: SlowQueryLogEntry) => void;
+  now?: () => number;
+}
+
+export async function withSlowQueryLogging<T>(
+  target: string,
+  task: () => Promise<T>,
+  options: SlowQueryLoggerOptions = {},
+): Promise<T> {
+  const thresholdMs = options.thresholdMs ?? 250;
+  const log = options.log ?? (() => undefined);
+  const now = options.now ?? Date.now;
+  const started = now();
+
+  try {
+    const result = await task();
+    const durationMs = now() - started;
+    if (durationMs >= thresholdMs) {
+      log({ target, durationMs });
+    }
+    return result;
+  } catch (err) {
+    const durationMs = now() - started;
+    if (durationMs >= thresholdMs) {
+      log({
+        target,
+        durationMs,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    throw err;
+  }
+}

--- a/routes-d/routes/orders.cancel.ts
+++ b/routes-d/routes/orders.cancel.ts
@@ -1,0 +1,86 @@
+// POST /orders/:id/cancel — cancellation endpoint for routes-d (#298).
+//
+// The route enforces the order lifecycle from `orderStateMachine.ts`,
+// persists the cancelled order, and optionally invokes downstream hooks
+// for webhook emission and refund processing.
+
+import { Router, type Request, type Response } from "express";
+import {
+  IllegalTransitionError,
+  assertTransition,
+  type OrderStatus,
+} from "../lib/orderStateMachine.js";
+
+export interface CancelableOrderRecord {
+  id: string;
+  status: OrderStatus;
+  updatedAt: number;
+  paymentCaptured?: boolean;
+}
+
+export interface CancelOrderStore {
+  get(id: string): Promise<CancelableOrderRecord | undefined>;
+  save(order: CancelableOrderRecord): Promise<void>;
+}
+
+export interface OrdersCancelRouterOptions {
+  store: CancelOrderStore;
+  now?: () => number;
+  onCancel?: (order: CancelableOrderRecord, previous: OrderStatus) => void | Promise<void>;
+  onRefund?: (order: CancelableOrderRecord, previous: OrderStatus) => void | Promise<void>;
+}
+
+export function createOrdersCancelRouter(opts: OrdersCancelRouterOptions): Router {
+  const router = Router();
+  const now = opts.now ?? Date.now;
+
+  router.post("/:id/cancel", async (req: Request, res: Response) => {
+    const { id } = req.params as { id: string };
+    const existing = await opts.store.get(id);
+
+    if (!existing) {
+      res.status(404).json({ ok: false, error: `order ${id} not found` });
+      return;
+    }
+
+    try {
+      assertTransition(existing.status, "cancelled");
+    } catch (err) {
+      if (err instanceof IllegalTransitionError) {
+        res.status(409).json({
+          ok: false,
+          error: err.message,
+          from: err.from,
+          to: err.to,
+        });
+        return;
+      }
+      throw err;
+    }
+
+    const previous = existing.status;
+    const updated: CancelableOrderRecord = {
+      ...existing,
+      status: "cancelled",
+      updatedAt: now(),
+    };
+
+    await opts.store.save(updated);
+
+    if (opts.onCancel) {
+      await opts.onCancel(updated, previous);
+    }
+
+    if (existing.paymentCaptured && opts.onRefund) {
+      await opts.onRefund(updated, previous);
+    }
+
+    res.status(200).json({
+      ok: true,
+      order: updated,
+      refunded: Boolean(existing.paymentCaptured),
+    });
+  });
+
+  return router;
+}

--- a/routes-d/tests/cacheHeaders.test.ts
+++ b/routes-d/tests/cacheHeaders.test.ts
@@ -1,0 +1,47 @@
+import type { Response } from "express";
+import { applyCacheHeaders, createPayloadEtag } from "../lib/cacheHeaders.js";
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name] = value;
+    }),
+    status: jest.fn(),
+  } as unknown as Pick<Response, "setHeader" | "status">;
+  return { res, headers };
+}
+
+describe("cacheHeaders", () => {
+  it("creates a stable ETag from the payload", () => {
+    expect(createPayloadEtag({ a: 1, b: "x" })).toBe(createPayloadEtag({ a: 1, b: "x" }));
+  });
+
+  it("applies cache headers and returns 200 when the ETag does not match", () => {
+    const { res, headers } = makeRes();
+    const result = applyCacheHeaders(res, { hello: "world" }, {}, { maxAgeSeconds: 10, sMaxAgeSeconds: 20 });
+
+    expect(result.notModified).toBe(false);
+    expect(headers["ETag"]).toBe(result.etag);
+    expect(headers["Cache-Control"]).toBe("public, max-age=10, s-maxage=20");
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 304 when If-None-Match matches the generated ETag", () => {
+    const { res } = makeRes();
+    const payload = { hello: "world" };
+    const etag = createPayloadEtag(payload);
+
+    const result = applyCacheHeaders(res, payload, { "if-none-match": etag });
+
+    expect(result.notModified).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(304);
+  });
+
+  it("treats a missing If-None-Match header as a cache miss", () => {
+    const { res } = makeRes();
+    const result = applyCacheHeaders(res, "payload", {});
+    expect(result.notModified).toBe(false);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/routes-d/tests/orders.cancel.test.ts
+++ b/routes-d/tests/orders.cancel.test.ts
@@ -1,0 +1,67 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import { createOrdersCancelRouter, type CancelableOrderRecord, type CancelOrderStore } from "../routes/orders.cancel.js";
+
+function buildStore(initial: CancelableOrderRecord[] = []): CancelOrderStore {
+  const map = new Map<string, CancelableOrderRecord>(initial.map((o) => [o.id, o]));
+  return {
+    async get(id) {
+      return map.get(id);
+    },
+    async save(order) {
+      map.set(order.id, order);
+    },
+  };
+}
+
+function buildApp(store: CancelOrderStore, hooks: { onCancel?: jest.Mock; onRefund?: jest.Mock } = {}): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/orders",
+    createOrdersCancelRouter({
+      store,
+      now: () => 1000,
+      onCancel: hooks.onCancel,
+      onRefund: hooks.onRefund,
+    }),
+  );
+  return app;
+}
+
+describe("POST /orders/:id/cancel", () => {
+  it("cancels a pending order without refund", async () => {
+    const store = buildStore([{ id: "1", status: "pending", updatedAt: 0 }]);
+    const onCancel = jest.fn();
+    const onRefund = jest.fn();
+    const res = await request(buildApp(store, { onCancel, onRefund })).post("/orders/1/cancel");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, refunded: false, order: { id: "1", status: "cancelled", updatedAt: 1000 } });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onRefund).not.toHaveBeenCalled();
+  });
+
+  it("triggers refund flow when payment was already captured", async () => {
+    const store = buildStore([{ id: "1", status: "paid", updatedAt: 0, paymentCaptured: true }]);
+    const onRefund = jest.fn();
+    const res = await request(buildApp(store, { onRefund })).post("/orders/1/cancel");
+
+    expect(res.status).toBe(200);
+    expect(res.body.refunded).toBe(true);
+    expect(onRefund).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects cancellation from an illegal terminal state", async () => {
+    const store = buildStore([{ id: "1", status: "cancelled", updatedAt: 0 }]);
+    const res = await request(buildApp(store)).post("/orders/1/cancel");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/terminal/);
+  });
+
+  it("returns 404 when the order does not exist", async () => {
+    const res = await request(buildApp(buildStore())).post("/orders/missing/cancel");
+    expect(res.status).toBe(404);
+  });
+});

--- a/routes-d/tests/slowQueryLog.test.ts
+++ b/routes-d/tests/slowQueryLog.test.ts
@@ -1,0 +1,53 @@
+import { withSlowQueryLogging } from "../lib/slowQueryLog.js";
+
+describe("withSlowQueryLogging", () => {
+  it("does not log fast queries", async () => {
+    const log = jest.fn();
+    const now = jest.fn()
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(10);
+
+    const result = await withSlowQueryLogging(
+      "horizon",
+      async () => "ok",
+      { thresholdMs: 50, log, now },
+    );
+
+    expect(result).toBe("ok");
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("logs slow queries with the target and duration", async () => {
+    const log = jest.fn();
+    const now = jest.fn()
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(75);
+
+    await withSlowQueryLogging(
+      "soroban",
+      async () => "ok",
+      { thresholdMs: 50, log, now },
+    );
+
+    expect(log).toHaveBeenCalledWith({ target: "soroban", durationMs: 75 });
+  });
+
+  it("logs slow failures and rethrows the original error", async () => {
+    const log = jest.fn();
+    const now = jest.fn()
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(100);
+
+    await expect(
+      withSlowQueryLogging(
+        "database",
+        async () => {
+          throw new Error("boom");
+        },
+        { thresholdMs: 50, log, now },
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(log).toHaveBeenCalledWith({ target: "database", durationMs: 100, error: "boom" });
+  });
+});


### PR DESCRIPTION
## Description
Adds the new routes-d cache header helper, slow query logger, and order cancellation endpoint, all scoped to the routes-d tree.

Closes #353
Closes #349
Closes #333
Closes #298

## Changes proposed

### What were you told to do?
Implement the four Nextellar issues in one PR and target the upstream repository.

### What did I do?
#### routes-d helpers
- Added outes-d/lib/cacheHeaders.ts for ETag generation and 304 handling.
- Added outes-d/lib/slowQueryLog.ts for threshold-based slow operation logging.

#### order cancellation
- Added outes-d/routes/orders.cancel.ts to enforce order lifecycle rules for cancellation.
- Added hooks for cancel and refund flows so downstream behavior can be wired in cleanly.

#### tests
- Added unit coverage for cache headers, slow query logging, and cancellation behavior.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [ ] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
TypeScript/Jest verification was attempted, but the repo's existing Jest setup currently points to jest.setup.js while the workspace's test bootstrap is inconsistent. I did confirm the new files were added cleanly and the branch was pushed.