### PR TITLE
feat: add payment webhook dispatcher with signing and retry

### DIFF
--- a/routes-d/lib/paymentWebhooks.ts
+++ b/routes-d/lib/paymentWebhooks.ts
@@ -1,0 +1,157 @@
+// Payment status webhook publisher.
+//
+// Signs payloads with HMAC-SHA256 and retries with exponential backoff
+// + jitter. Two transports:
+//   - `PaymentWebhookDispatcher` — keeps the secret, max-attempt budget,
+//     and an injected `fetch` for tests
+//
+// Network I/O is pluggable so tests can drive the retry loop without a
+// real HTTP server.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export type PaymentStatus = "pending" | "submitted" | "confirmed" | "failed";
+
+export interface PaymentWebhookPayload {
+  event: `payment.${PaymentStatus}`;
+  paymentId: string;
+  occurredAt: number;
+  data: Record<string, unknown>;
+}
+
+export interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+}
+
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<FetchResponseLike>;
+
+export interface DispatchOptions {
+  /** Maximum total attempts (initial + retries). Default 4. */
+  maxAttempts?: number;
+  /** Base delay between retries in ms. Default 250. */
+  baseDelayMs?: number;
+  /** Max delay cap, ms. Default 8000. */
+  maxDelayMs?: number;
+  /** Override sleep for tests; default `setTimeout` resolver. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Override fetch for tests. */
+  fetcher?: FetchLike;
+  /** Per-attempt jitter factor (0..1) applied to the backoff. Default 0. */
+  jitter?: () => number;
+}
+
+export interface DispatchResult {
+  ok: boolean;
+  attempts: number;
+  lastStatus?: number;
+  lastError?: string;
+}
+
+const SIGNATURE_HEADER = "X-Nextellar-Signature";
+const EVENT_HEADER = "X-Nextellar-Event";
+
+export function signPayload(secret: string, body: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
+export function verifySignature(secret: string, body: string, signature: string): boolean {
+  if (typeof signature !== "string" || signature.length === 0) return false;
+  const expected = signPayload(secret, body);
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(signature, "hex");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const defaultFetcher: FetchLike = async (url, init) => {
+  const resp = await fetch(url, init);
+  return { ok: resp.ok, status: resp.status };
+};
+
+function backoff(attempt: number, base: number, max: number, jitter: number): number {
+  const grow = Math.min(max, base * 2 ** attempt);
+  return Math.floor(grow * (1 + jitter));
+}
+
+export class PaymentWebhookDispatcher {
+  constructor(
+    private readonly endpoint: string,
+    private readonly secret: string,
+    private readonly options: DispatchOptions = {},
+  ) {}
+
+  /** Dispatch a single webhook with retry on transient failures. */
+  async dispatch(payload: PaymentWebhookPayload): Promise<DispatchResult> {
+    const maxAttempts = this.options.maxAttempts ?? 4;
+    const baseDelay = this.options.baseDelayMs ?? 250;
+    const maxDelay = this.options.maxDelayMs ?? 8000;
+    const sleep = this.options.sleep ?? defaultSleep;
+    const fetcher = this.options.fetcher ?? defaultFetcher;
+    const jitter = this.options.jitter ?? (() => 0);
+
+    const body = JSON.stringify(payload);
+    const signature = signPayload(this.secret, body);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      [SIGNATURE_HEADER]: signature,
+      [EVENT_HEADER]: payload.event,
+    };
+
+    let lastStatus: number | undefined;
+    let lastError: string | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        const resp = await fetcher(this.endpoint, { method: "POST", headers, body });
+        lastStatus = resp.status;
+        if (resp.ok) {
+          return { ok: true, attempts: attempt, lastStatus };
+        }
+        // 4xx (except 429) is a client misconfiguration — don't retry.
+        if (resp.status >= 400 && resp.status < 500 && resp.status !== 429) {
+          return { ok: false, attempts: attempt, lastStatus };
+        }
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+      if (attempt < maxAttempts) {
+        await sleep(backoff(attempt - 1, baseDelay, maxDelay, jitter()));
+      }
+    }
+    return { ok: false, attempts: maxAttempts, lastStatus, lastError };
+  }
+}
+
+/** Public dispatcher header constants for downstream verifiers. */
+export const WEBHOOK_HEADERS = Object.freeze({
+  signature: SIGNATURE_HEADER,
+  event: EVENT_HEADER,
+});
+
+/** Emit helpers — one per payment status transition. */
+export function makePaymentEvent(
+  status: PaymentStatus,
+  paymentId: string,
+  data: Record<string, unknown> = {},
+): PaymentWebhookPayload {
+  return {
+    event: `payment.${status}`,
+    paymentId,
+    occurredAt: Date.now(),
+    data,
+  };
+}
+
+export function isPaymentEvent(value: string): value is `payment.${PaymentStatus}` {
+  return (
+    value === "payment.pending" ||
+    value === "payment.submitted" ||
+    value === "payment.confirmed" ||
+    value === "payment.failed"
+  );
+}

--- a/routes-d/tests/paymentWebhooks.test.ts
+++ b/routes-d/tests/paymentWebhooks.test.ts
@@ -1,0 +1,259 @@
+// Tests for the payment status webhook publisher. Covers
+// emit, signature verification, and retry-with-backoff behaviour.
+
+import { jest } from "@jest/globals";
+import {
+  PaymentWebhookDispatcher,
+  WEBHOOK_HEADERS,
+  isPaymentEvent,
+  makePaymentEvent,
+  signPayload,
+  verifySignature,
+  type FetchLike,
+  type PaymentWebhookPayload,
+} from "../lib/paymentWebhooks.js";
+
+function payload(overrides: Partial<PaymentWebhookPayload> = {}): PaymentWebhookPayload {
+  return {
+    event: "payment.pending",
+    paymentId: "pay_1",
+    occurredAt: 1700000000000,
+    data: { amount: 100 },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+describe("signPayload / verifySignature", () => {
+  it("verifies a freshly signed body", () => {
+    const body = JSON.stringify(payload());
+    const sig = signPayload("topsecret", body);
+    expect(verifySignature("topsecret", body, sig)).toBe(true);
+  });
+
+  it("rejects when the body differs", () => {
+    const sig = signPayload("topsecret", JSON.stringify(payload()));
+    expect(verifySignature("topsecret", JSON.stringify(payload({ paymentId: "pay_2" })), sig)).toBe(false);
+  });
+
+  it("rejects when the secret differs", () => {
+    const body = JSON.stringify(payload());
+    const sig = signPayload("topsecret", body);
+    expect(verifySignature("wrong", body, sig)).toBe(false);
+  });
+
+  it("rejects malformed signatures", () => {
+    const body = JSON.stringify(payload());
+    expect(verifySignature("topsecret", body, "not-hex")).toBe(false);
+    expect(verifySignature("topsecret", body, "")).toBe(false);
+  });
+});
+
+describe("isPaymentEvent", () => {
+  it("accepts all four payment statuses", () => {
+    expect(isPaymentEvent("payment.pending")).toBe(true);
+    expect(isPaymentEvent("payment.submitted")).toBe(true);
+    expect(isPaymentEvent("payment.confirmed")).toBe(true);
+    expect(isPaymentEvent("payment.failed")).toBe(true);
+  });
+
+  it("rejects unrelated events", () => {
+    expect(isPaymentEvent("order.fulfilled")).toBe(false);
+    expect(isPaymentEvent("payment.unknown")).toBe(false);
+    expect(isPaymentEvent("")).toBe(false);
+  });
+});
+
+describe("makePaymentEvent", () => {
+  it("builds a payload with the correct event name", () => {
+    const evt = makePaymentEvent("confirmed", "pay_42", { txHash: "abc" });
+    expect(evt.event).toBe("payment.confirmed");
+    expect(evt.paymentId).toBe("pay_42");
+    expect(evt.data).toEqual({ txHash: "abc" });
+    expect(typeof evt.occurredAt).toBe("number");
+  });
+
+  it("defaults data to an empty object", () => {
+    const evt = makePaymentEvent("failed", "pay_99");
+    expect(evt.data).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher tests
+// ---------------------------------------------------------------------------
+
+describe("PaymentWebhookDispatcher.dispatch", () => {
+  it("signs the body with HMAC-SHA256 and sends the event header", async () => {
+    const seen: { headers: Record<string, string>; body: string }[] = [];
+    const fetcher: FetchLike = async (_url, init) => {
+      seen.push({ headers: init.headers, body: init.body });
+      return { ok: true, status: 200 };
+    };
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", { fetcher });
+    const p = payload({ event: "payment.confirmed" });
+    const result = await d.dispatch(p);
+
+    expect(result).toEqual({ ok: true, attempts: 1, lastStatus: 200 });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.headers[WEBHOOK_HEADERS.event]).toBe("payment.confirmed");
+    const sig = seen[0]!.headers[WEBHOOK_HEADERS.signature]!;
+    expect(verifySignature("shh", seen[0]!.body, sig)).toBe(true);
+  });
+
+  it("emits on each of the four payment status transitions", async () => {
+    const statuses = ["payment.pending", "payment.submitted", "payment.confirmed", "payment.failed"] as const;
+    for (const event of statuses) {
+      const seen: string[] = [];
+      const fetcher: FetchLike = async (_url, init) => {
+        seen.push(init.headers[WEBHOOK_HEADERS.event]!);
+        return { ok: true, status: 200 };
+      };
+      const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", { fetcher });
+      const result = await d.dispatch(payload({ event }));
+      expect(result.ok).toBe(true);
+      expect(seen[0]).toBe(event);
+    }
+  });
+
+  it("retries on 5xx and succeeds on a later attempt", async () => {
+    let attempt = 0;
+    const fetcher: FetchLike = async () => {
+      attempt += 1;
+      if (attempt < 3) return { ok: false, status: 503 };
+      return { ok: true, status: 200 };
+    };
+    const sleep = jest.fn(async () => {});
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", {
+      fetcher,
+      sleep,
+      maxAttempts: 5,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+    });
+    const result = await d.dispatch(payload());
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect((sleep.mock.calls[0] as unknown as [number])[0]).toBeGreaterThanOrEqual(10);
+    expect((sleep.mock.calls[1] as unknown as [number])[0]).toBeGreaterThanOrEqual(20);
+  });
+
+  it("gives up after maxAttempts on persistent 5xx", async () => {
+    const fetcher: FetchLike = async () => ({ ok: false, status: 503 });
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", {
+      fetcher,
+      sleep: async () => {},
+      maxAttempts: 3,
+      baseDelayMs: 1,
+    });
+    const result = await d.dispatch(payload());
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.lastStatus).toBe(503);
+  });
+
+  it("does NOT retry on 4xx (except 429) — fast-fail on misconfiguration", async () => {
+    const fetcherMock = jest.fn(async () => ({
+      ok: false as const,
+      status: 400,
+    }));
+    const fetcher = fetcherMock as unknown as FetchLike;
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", {
+      fetcher,
+      sleep: async () => {},
+      maxAttempts: 5,
+    });
+    const result = await d.dispatch(payload());
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(fetcherMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("DOES retry on 429 (rate limit)", async () => {
+    let attempt = 0;
+    const fetcher: FetchLike = async () => {
+      attempt += 1;
+      return { ok: false, status: 429 };
+    };
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", {
+      fetcher,
+      sleep: async () => {},
+      maxAttempts: 3,
+    });
+    const result = await d.dispatch(payload());
+    expect(attempt).toBe(3);
+    expect(result.ok).toBe(false);
+  });
+
+  it("records transport errors and retries", async () => {
+    let attempt = 0;
+    const fetcher: FetchLike = async () => {
+      attempt += 1;
+      if (attempt < 2) throw new Error("ECONNREFUSED");
+      return { ok: true, status: 200 };
+    };
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", "shh", {
+      fetcher,
+      sleep: async () => {},
+      maxAttempts: 3,
+    });
+    const result = await d.dispatch(payload());
+    expect(result.ok).toBe(true);
+    expect(attempt).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test — full round-trip: build event → dispatch → verify
+// ---------------------------------------------------------------------------
+
+describe("integration: makePaymentEvent → dispatch → verifySignature", () => {
+  it("subscriber can verify the signature on a dispatched payload", async () => {
+    const secret = "integration-secret";
+    let capturedBody = "";
+    let capturedSig = "";
+
+    const fetcher: FetchLike = async (_url, init) => {
+      capturedBody = init.body;
+      capturedSig = init.headers[WEBHOOK_HEADERS.signature]!;
+      return { ok: true, status: 200 };
+    };
+
+    const d = new PaymentWebhookDispatcher("https://example.test/hook", secret, { fetcher });
+    const evt = makePaymentEvent("submitted", "pay_int_1", { currency: "XLM" });
+    const result = await d.dispatch(evt);
+
+    expect(result.ok).toBe(true);
+    expect(verifySignature(secret, capturedBody, capturedSig)).toBe(true);
+    const parsed = JSON.parse(capturedBody) as PaymentWebhookPayload;
+    expect(parsed.event).toBe("payment.submitted");
+    expect(parsed.paymentId).toBe("pay_int_1");
+  });
+
+  it("covers all four status transitions end-to-end", async () => {
+    const secret = "int-secret-2";
+    const statuses = ["pending", "submitted", "confirmed", "failed"] as const;
+
+    for (const status of statuses) {
+      let capturedBody = "";
+      let capturedSig = "";
+      const fetcher: FetchLike = async (_url, init) => {
+        capturedBody = init.body;
+        capturedSig = init.headers[WEBHOOK_HEADERS.signature]!;
+        return { ok: true, status: 200 };
+      };
+
+      const d = new PaymentWebhookDispatcher("https://example.test/hook", secret, { fetcher });
+      const evt = makePaymentEvent(status, `pay_${status}`);
+      await d.dispatch(evt);
+
+      expect(verifySignature(secret, capturedBody, capturedSig)).toBe(true);
+      const parsed = JSON.parse(capturedBody) as PaymentWebhookPayload;
+      expect(parsed.event).toBe(`payment.${status}`);
+    }
+  });
+});


### PR DESCRIPTION
 Add payment webhook dispatcher (routes-d/lib/paymentWebhooks.ts)
  
  Publishes payment status changes to subscriber URLs via a signed webhook
  dispatcher.
  
  What's included:
  
  - PaymentWebhookDispatcher — POSTs signed payloads to a configured endpoint,
  retries on 5xx/429 with exponential backoff, fast-fails on 4xx
  - signPayload / verifySignature — HMAC-SHA256 signing with timing-safe
  comparison
  - makePaymentEvent — builds typed payloads for all four transitions: pending,
  submitted, confirmed, failed
  - WEBHOOK_HEADERS — exported header name constants (X-Nextellar-Signature,
  X-Nextellar-Event)
  
  Tests (17 passing):
  
  - Signature: correct, wrong body, wrong secret, malformed input
  - Event helpers: isPaymentEvent, makePaymentEvent for all statuses
  - Dispatcher: emit with correct headers, retry on 5xx, exponential backoff
  timing, give-up after maxAttempts, no-retry on 4xx, retry on 429, transport
  error recovery
  - Integration: full round-trip makePaymentEvent → dispatch → verifySignature
   for all four status transitions
  
  Scope: all new files under routes-d/ only — no changes outside that folder.
closes #289