### PR TITLE
feat(routes-d): co-signing, memo validation, refund, bulk update endpoints

### DIFF
--- a/routes-d/lib/memo.ts
+++ b/routes-d/lib/memo.ts
@@ -1,0 +1,165 @@
+// Stellar memo validation helper for routes-d (#281).
+//
+// Stellar transactions support five memo types: `none`, `text` (up to
+// 28 UTF-8 bytes), `id` (uint64), `hash` (32 raw bytes — accepted here
+// as a 64-char hex string), and `return` (same shape as `hash`). Every
+// route that builds an outgoing transaction envelope should run user
+// input through `validateMemo` first so we surface field-level errors
+// *before* we hit the SDK (which throws less descriptive errors).
+//
+// The helper is intentionally framework-agnostic: it takes a plain
+// `{ type, value }` shape and returns a discriminated result. Route
+// handlers translate `{ ok: false, errors }` into a 400 response.
+
+export type MemoType = "none" | "text" | "id" | "hash" | "return";
+
+export const MEMO_TYPES: readonly MemoType[] = Object.freeze([
+  "none",
+  "text",
+  "id",
+  "hash",
+  "return",
+]);
+
+/** Stellar's max TEXT memo size — 28 UTF-8 bytes, not characters. */
+export const MEMO_TEXT_MAX_BYTES = 28;
+
+/** Stellar HASH / RETURN memos are 32 raw bytes → 64 hex characters. */
+export const MEMO_HASH_HEX_LENGTH = 64;
+
+/** uint64 ceiling for ID memos. */
+const UINT64_MAX = 18446744073709551615n;
+
+export interface MemoInput {
+  type: unknown;
+  /** Optional for `type: "none"`; required otherwise. */
+  value?: unknown;
+}
+
+export interface FieldError {
+  field: "type" | "value";
+  message: string;
+}
+
+export type MemoValidationResult =
+  | { ok: true; memo: { type: MemoType; value?: string } }
+  | { ok: false; errors: FieldError[] };
+
+function isMemoType(value: unknown): value is MemoType {
+  return typeof value === "string" && (MEMO_TYPES as readonly string[]).includes(value);
+}
+
+function utf8ByteLength(s: string): number {
+  // `Buffer.byteLength` would also work, but `TextEncoder` keeps the
+  // helper portable to non-Node environments (edge runtimes, tests).
+  return new TextEncoder().encode(s).length;
+}
+
+function isHex(s: string): boolean {
+  return /^[0-9a-fA-F]+$/.test(s);
+}
+
+/**
+ * Validate `{ type, value }` per Stellar memo rules. Returns a
+ * normalised memo on success (value omitted for `type: "none"`,
+ * lowercase hex for `hash` / `return`, decimal string for `id`).
+ *
+ * Multiple field-level errors are collected so the caller can echo
+ * them all back instead of bouncing the client through a fix-one-
+ * at-a-time loop.
+ */
+export function validateMemo(input: MemoInput): MemoValidationResult {
+  const errors: FieldError[] = [];
+
+  if (!isMemoType(input.type)) {
+    errors.push({
+      field: "type",
+      message: `type must be one of: ${MEMO_TYPES.join(", ")}`,
+    });
+    return { ok: false, errors };
+  }
+
+  const type = input.type;
+
+  if (type === "none") {
+    if (input.value !== undefined && input.value !== null && input.value !== "") {
+      errors.push({ field: "value", message: "value must be empty when type is 'none'" });
+    }
+    if (errors.length > 0) return { ok: false, errors };
+    return { ok: true, memo: { type } };
+  }
+
+  // All non-none types require a value.
+  if (input.value === undefined || input.value === null || input.value === "") {
+    errors.push({ field: "value", message: `value is required when type is '${type}'` });
+    return { ok: false, errors };
+  }
+
+  if (type === "text") {
+    if (typeof input.value !== "string") {
+      errors.push({ field: "value", message: "text memo value must be a string" });
+      return { ok: false, errors };
+    }
+    const bytes = utf8ByteLength(input.value);
+    if (bytes > MEMO_TEXT_MAX_BYTES) {
+      errors.push({
+        field: "value",
+        message: `text memo exceeds ${MEMO_TEXT_MAX_BYTES} UTF-8 bytes (got ${bytes})`,
+      });
+      return { ok: false, errors };
+    }
+    return { ok: true, memo: { type, value: input.value } };
+  }
+
+  if (type === "id") {
+    // Accept string or number; reject anything else. We require a
+    // non-negative integer that fits in uint64.
+    const raw = typeof input.value === "number" ? input.value.toString() : input.value;
+    if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+      errors.push({ field: "value", message: "id memo must be a non-negative integer" });
+      return { ok: false, errors };
+    }
+    const asBig = BigInt(raw);
+    if (asBig > UINT64_MAX) {
+      errors.push({ field: "value", message: "id memo exceeds uint64 max" });
+      return { ok: false, errors };
+    }
+    return { ok: true, memo: { type, value: asBig.toString() } };
+  }
+
+  // hash / return — 32 raw bytes encoded as 64 hex chars.
+  if (typeof input.value !== "string") {
+    errors.push({ field: "value", message: `${type} memo must be a hex string` });
+    return { ok: false, errors };
+  }
+  if (input.value.length !== MEMO_HASH_HEX_LENGTH || !isHex(input.value)) {
+    errors.push({
+      field: "value",
+      message: `${type} memo must be ${MEMO_HASH_HEX_LENGTH} hex characters (32 bytes)`,
+    });
+    return { ok: false, errors };
+  }
+  return { ok: true, memo: { type, value: input.value.toLowerCase() } };
+}
+
+/**
+ * Sugar for routes that want to assert-or-throw rather than branch on
+ * a result discriminator. Throws `MemoValidationError` so callers can
+ * `catch` and translate to a 400.
+ */
+export class MemoValidationError extends Error {
+  readonly errors: FieldError[];
+  constructor(errors: FieldError[]) {
+    super(errors.map((e) => `${e.field}: ${e.message}`).join("; "));
+    this.name = "MemoValidationError";
+    this.errors = errors;
+  }
+}
+
+export function assertValidMemo(input: MemoInput): { type: MemoType; value?: string } {
+  const result = validateMemo(input);
+  if (!result.ok) {
+    throw new MemoValidationError(result.errors);
+  }
+  return result.memo;
+}

--- a/routes-d/routes/orders.bulkUpdate.ts
+++ b/routes-d/routes/orders.bulkUpdate.ts
@@ -1,0 +1,167 @@
+// POST /orders/bulk-status — bulk order status update for admins (#303).
+//
+// The admin tooling needs to flip many orders at once (e.g. mark a
+// shipment batch as `shipped`). Doing this one HTTP call at a time is
+// slow and noisy in audit logs. This route takes an array of
+// `{ orderId, status }` items and returns a per-item result so a
+// partial failure does not abort the whole batch.
+//
+// Every transition is validated through the shared
+// `orderStateMachine.ts` so the rules stay in one place. Items that
+// fail validation, are missing, or are already in the target status
+// surface as `{ ok: false, error }` entries — the response is always
+// 200 with the per-item array; the HTTP layer only 4xx's on malformed
+// envelopes (not malformed items).
+
+import { Router, type Request, type Response } from "express";
+import {
+  IllegalTransitionError,
+  assertTransition,
+  isOrderStatus,
+  type OrderStatus,
+} from "../lib/orderStateMachine.js";
+
+export interface BulkOrderRecord {
+  id: string;
+  status: OrderStatus;
+  updatedAt: number;
+}
+
+export interface BulkOrderStore {
+  get(id: string): Promise<BulkOrderRecord | undefined>;
+  save(order: BulkOrderRecord): Promise<void>;
+}
+
+export interface BulkUpdateItemResult {
+  orderId: string;
+  ok: boolean;
+  status?: OrderStatus;
+  /** Present when `ok === false`. */
+  error?: string;
+  /** Present for illegal transitions so the client can render context. */
+  from?: OrderStatus;
+  to?: OrderStatus;
+}
+
+export interface BulkUpdateRouterOptions {
+  store: BulkOrderStore;
+  now?: () => number;
+  /** Hard cap on items per call. Defaults to 100 — large enough for
+   *  realistic batches, small enough to keep responses bounded. */
+  maxItems?: number;
+}
+
+interface InboundItem {
+  orderId: string;
+  status: OrderStatus;
+}
+
+interface BulkRequestBody {
+  items?: unknown;
+}
+
+/**
+ * Parse the request envelope into a typed list of items. Returns
+ * `{ error }` on any structural issue so the caller can 400; per-item
+ * status / id problems are deferred to the executor so they show up in
+ * the per-item result.
+ */
+function parseEnvelope(
+  body: unknown,
+  maxItems: number,
+): { items: InboundItem[] } | { error: string } {
+  if (!body || typeof body !== "object") return { error: "request body is required" };
+  const items = (body as BulkRequestBody).items;
+  if (!Array.isArray(items)) return { error: "items must be an array" };
+  if (items.length === 0) return { error: "items must not be empty" };
+  if (items.length > maxItems) {
+    return { error: `items exceeds maximum of ${maxItems}` };
+  }
+
+  const out: InboundItem[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const raw = items[i];
+    if (!raw || typeof raw !== "object") {
+      return { error: `items[${i}] must be an object` };
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r.orderId !== "string" || r.orderId.trim() === "") {
+      return { error: `items[${i}].orderId must be a non-empty string` };
+    }
+    if (!isOrderStatus(r.status)) {
+      return { error: `items[${i}].status must be a valid OrderStatus` };
+    }
+    out.push({ orderId: r.orderId, status: r.status });
+  }
+  return { items: out };
+}
+
+/**
+ * Apply a single item against the store. Returns a per-item result;
+ * never throws. Extracted so tests can exercise per-item branches
+ * without HTTP overhead.
+ */
+export async function applyBulkItem(
+  item: InboundItem,
+  store: BulkOrderStore,
+  now: () => number,
+): Promise<BulkUpdateItemResult> {
+  const existing = await store.get(item.orderId);
+  if (!existing) {
+    return { orderId: item.orderId, ok: false, error: `order ${item.orderId} not found` };
+  }
+  try {
+    assertTransition(existing.status, item.status);
+  } catch (err) {
+    if (err instanceof IllegalTransitionError) {
+      return {
+        orderId: item.orderId,
+        ok: false,
+        error: err.message,
+        from: err.from,
+        to: err.to,
+      };
+    }
+    throw err;
+  }
+
+  const updated: BulkOrderRecord = {
+    ...existing,
+    status: item.status,
+    updatedAt: now(),
+  };
+  await store.save(updated);
+  return { orderId: item.orderId, ok: true, status: item.status };
+}
+
+export function createOrdersBulkUpdateRouter(opts: BulkUpdateRouterOptions): Router {
+  const router = Router();
+  const now = opts.now ?? Date.now;
+  const maxItems = opts.maxItems ?? 100;
+
+  router.post("/bulk-status", async (req: Request, res: Response) => {
+    const parsed = parseEnvelope(req.body, maxItems);
+    if ("error" in parsed) {
+      res.status(400).json({ ok: false, error: parsed.error });
+      return;
+    }
+
+    // Sequential application keeps per-id ordering deterministic and
+    // avoids racing two updates against the same id within one batch.
+    const results: BulkUpdateItemResult[] = [];
+    for (const item of parsed.items) {
+      results.push(await applyBulkItem(item, opts.store, now));
+    }
+
+    const succeeded = results.filter((r) => r.ok).length;
+    res.status(200).json({
+      ok: true,
+      total: results.length,
+      succeeded,
+      failed: results.length - succeeded,
+      results,
+    });
+  });
+
+  return router;
+}

--- a/routes-d/routes/payments.refund.ts
+++ b/routes-d/routes/payments.refund.ts
@@ -1,0 +1,170 @@
+// POST /payments/:id/refund — refund a failed Nextellar payment by
+// initiating a reverse transfer (#294).
+//
+// Rules:
+//   1. The original payment must exist and be in a refundable state
+//      (`failed` or `captured`, never `pending` or `refunded`).
+//   2. The request is *idempotent*: a caller can retry safely. We key
+//      idempotency on `(paymentId, idempotencyKey)` where the key
+//      defaults to the payment id. The first successful refund is
+//      remembered and subsequent calls return it unchanged.
+//   3. Only the original payer (or an admin) can request the refund —
+//      callers must supply a `requesterId`; the route returns 403 if it
+//      mismatches `payment.payerId` unless `requesterRole === "admin"`.
+//
+// Persistence is pluggable via `PaymentStore` and `RefundStore` so the
+// route is testable in isolation.
+
+import { Router, type Request, type Response } from "express";
+
+export type PaymentStatus = "pending" | "captured" | "failed" | "refunded";
+
+export interface PaymentRecord {
+  id: string;
+  payerId: string;
+  amount: number;
+  currency: string;
+  status: PaymentStatus;
+}
+
+export interface RefundRecord {
+  refundId: string;
+  paymentId: string;
+  amount: number;
+  currency: string;
+  createdAt: number;
+  /** Echoes the idempotency key that produced this refund. */
+  idempotencyKey: string;
+}
+
+export interface PaymentStore {
+  get(id: string): Promise<PaymentRecord | undefined>;
+  /** Mark the payment refunded in the same atomic step as the refund
+   *  record write — implementations may use a transaction. */
+  markRefunded(id: string): Promise<void>;
+}
+
+export interface RefundStore {
+  /** Returns an existing refund for the (paymentId, idempotencyKey)
+   *  tuple, or undefined when this is the first attempt. */
+  findByIdempotency(paymentId: string, idempotencyKey: string): Promise<RefundRecord | undefined>;
+  save(refund: RefundRecord): Promise<void>;
+}
+
+export interface RefundDispatcher {
+  /** Issue the actual reverse transfer. Returns the provider-side id
+   *  used as `refundId`. May throw to indicate a transient failure;
+   *  the route translates that into a 502. */
+  refund(payment: PaymentRecord): Promise<{ refundId: string }>;
+}
+
+export interface RefundRouterOptions {
+  payments: PaymentStore;
+  refunds: RefundStore;
+  dispatcher: RefundDispatcher;
+  now?: () => number;
+  /** Generate a refund id when the dispatcher does not. Defaults to a
+   *  timestamp-based id; tests inject a deterministic generator. */
+  newRefundId?: () => string;
+}
+
+/** Statuses that may transition to `refunded`. */
+const REFUNDABLE_STATUSES: ReadonlySet<PaymentStatus> = new Set(["failed", "captured"]);
+
+interface RefundRequestBody {
+  requesterId?: unknown;
+  requesterRole?: unknown;
+  idempotencyKey?: unknown;
+}
+
+function readBody(body: unknown): {
+  requesterId: string;
+  requesterRole: string;
+  idempotencyKey?: string;
+} | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as RefundRequestBody;
+  if (typeof b.requesterId !== "string" || b.requesterId.trim() === "") return null;
+  if (typeof b.requesterRole !== "string" || b.requesterRole.trim() === "") return null;
+  const idempotencyKey =
+    typeof b.idempotencyKey === "string" && b.idempotencyKey.trim() !== ""
+      ? b.idempotencyKey.trim()
+      : undefined;
+  return {
+    requesterId: b.requesterId.trim(),
+    requesterRole: b.requesterRole.trim(),
+    idempotencyKey,
+  };
+}
+
+export function createRefundRouter(opts: RefundRouterOptions): Router {
+  const router = Router();
+  const now = opts.now ?? Date.now;
+  const newRefundId = opts.newRefundId ?? (() => `rf_${now()}`);
+
+  router.post("/:id/refund", async (req: Request, res: Response) => {
+    const { id } = req.params as { id: string };
+    const parsed = readBody(req.body);
+    if (!parsed) {
+      res.status(400).json({
+        ok: false,
+        error: "requesterId and requesterRole are required",
+      });
+      return;
+    }
+
+    const payment = await opts.payments.get(id);
+    if (!payment) {
+      res.status(404).json({ ok: false, error: `payment ${id} not found` });
+      return;
+    }
+
+    const isAdmin = parsed.requesterRole === "admin";
+    if (!isAdmin && parsed.requesterId !== payment.payerId) {
+      res.status(403).json({ ok: false, error: "not authorised to refund this payment" });
+      return;
+    }
+
+    const idempotencyKey = parsed.idempotencyKey ?? payment.id;
+    const existing = await opts.refunds.findByIdempotency(payment.id, idempotencyKey);
+    if (existing) {
+      // Idempotent replay — return the original refund unchanged.
+      res.status(200).json({ ok: true, refund: existing, idempotent: true });
+      return;
+    }
+
+    if (!REFUNDABLE_STATUSES.has(payment.status)) {
+      res.status(409).json({
+        ok: false,
+        error: `payment in status '${payment.status}' is not refundable`,
+        status: payment.status,
+      });
+      return;
+    }
+
+    let providerId: string;
+    try {
+      const result = await opts.dispatcher.refund(payment);
+      providerId = result.refundId || newRefundId();
+    } catch {
+      res.status(502).json({ ok: false, error: "refund dispatcher failed" });
+      return;
+    }
+
+    const refund: RefundRecord = {
+      refundId: providerId,
+      paymentId: payment.id,
+      amount: payment.amount,
+      currency: payment.currency,
+      createdAt: now(),
+      idempotencyKey,
+    };
+
+    await opts.refunds.save(refund);
+    await opts.payments.markRefunded(payment.id);
+
+    res.status(201).json({ ok: true, refund, idempotent: false });
+  });
+
+  return router;
+}

--- a/routes-d/routes/stellar.tx.cosign.ts
+++ b/routes-d/routes/stellar.tx.cosign.ts
@@ -1,0 +1,164 @@
+// POST /stellar/tx/cosign — server co-signature endpoint for routes-d
+// (#280).
+//
+// Some Nextellar flows (e.g. multi-sig recovery, treasury-gated trades)
+// require the server to add its signature before the client signs and
+// submits. The route validates the operations in the supplied envelope
+// against a configurable allowlist and only co-signs envelopes whose
+// every operation type is allowed.
+//
+// The signer is injected at router construction time so tests can
+// substitute a deterministic mock without ever loading a real key. In
+// production the host wires `loadCosignerFromEnv` (or a custom variant
+// that reads from a secret manager) once at startup. The key is never
+// logged — only its derived public account id ever leaves this module.
+
+import { Router, type Request, type Response } from "express";
+
+/**
+ * A transaction operation as it appears on the inbound payload. We only
+ * care about `type` for allowlisting — the actual signing payload is the
+ * pre-built envelope XDR / base64 string.
+ */
+export interface CosignOperation {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface CosignEnvelope {
+  /** Base64 / XDR-encoded transaction envelope. */
+  envelope: string;
+  /** Operations the envelope contains, supplied by the client so the
+   *  server can allowlist without re-parsing XDR. */
+  operations: CosignOperation[];
+}
+
+export interface CosignerSigner {
+  /** Public account id (G...) the signer represents — safe to log. */
+  publicKey: string;
+  /** Produces a base64 signature for `envelope`. Implementations must
+   *  never log the secret key. */
+  sign(envelope: string): Promise<string> | string;
+}
+
+export interface CosignRouterOptions {
+  signer: CosignerSigner;
+  /** Operation types the server will co-sign. Anything else → 403. */
+  allowedOperations: Iterable<string>;
+}
+
+export class CosignDisallowedError extends Error {
+  readonly disallowed: string[];
+  constructor(disallowed: string[]) {
+    super(`disallowed operation type(s): ${disallowed.join(", ")}`);
+    this.name = "CosignDisallowedError";
+    this.disallowed = disallowed;
+  }
+}
+
+function readEnvelope(body: unknown): CosignEnvelope | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  if (typeof b.envelope !== "string" || b.envelope.trim() === "") return null;
+  if (!Array.isArray(b.operations) || b.operations.length === 0) return null;
+  for (const op of b.operations) {
+    if (!op || typeof op !== "object" || typeof (op as { type?: unknown }).type !== "string") {
+      return null;
+    }
+  }
+  return {
+    envelope: b.envelope,
+    operations: b.operations as CosignOperation[],
+  };
+}
+
+/**
+ * Inspect an envelope against an allow-set. Returns the list of
+ * disallowed operation types (empty when everything is allowed).
+ * Pure — extracted so the test suite can exercise it without HTTP.
+ */
+export function findDisallowedOperations(
+  operations: readonly CosignOperation[],
+  allowed: ReadonlySet<string>,
+): string[] {
+  const bad: string[] = [];
+  for (const op of operations) {
+    if (!allowed.has(op.type)) bad.push(op.type);
+  }
+  return bad;
+}
+
+/**
+ * Load a cosigner from the process environment. The secret key is read
+ * from `STELLAR_COSIGNER_SECRET` and the public key from
+ * `STELLAR_COSIGNER_PUBLIC`. Both must be set; missing values throw
+ * with a non-leaking message so a misconfigured deploy fails fast.
+ *
+ * The default `sign` implementation here is a placeholder that delegates
+ * to a `signerFn` the host wires in — keeping the cryptographic
+ * dependency out of routes-d so the package stays portable.
+ */
+export function loadCosignerFromEnv(
+  signerFn: (secret: string, envelope: string) => string | Promise<string>,
+  env: NodeJS.ProcessEnv = process.env,
+): CosignerSigner {
+  const publicKey = env.STELLAR_COSIGNER_PUBLIC;
+  const secret = env.STELLAR_COSIGNER_SECRET;
+  if (!publicKey || !secret) {
+    throw new Error(
+      "STELLAR_COSIGNER_PUBLIC and STELLAR_COSIGNER_SECRET must be set to enable cosigning",
+    );
+  }
+  return {
+    publicKey,
+    sign: (envelope) => signerFn(secret, envelope),
+  };
+}
+
+export function createCosignRouter(opts: CosignRouterOptions): Router {
+  const allowed = new Set<string>(opts.allowedOperations);
+  if (allowed.size === 0) {
+    throw new Error("createCosignRouter: allowedOperations must be non-empty");
+  }
+
+  const router = Router();
+
+  router.post("/cosign", async (req: Request, res: Response) => {
+    const payload = readEnvelope(req.body);
+    if (!payload) {
+      res.status(400).json({
+        ok: false,
+        error: "envelope (string) and operations (non-empty array of {type}) are required",
+      });
+      return;
+    }
+
+    const disallowed = findDisallowedOperations(payload.operations, allowed);
+    if (disallowed.length > 0) {
+      res.status(403).json({
+        ok: false,
+        error: new CosignDisallowedError(disallowed).message,
+        disallowed,
+      });
+      return;
+    }
+
+    let signature: string;
+    try {
+      signature = await opts.signer.sign(payload.envelope);
+    } catch {
+      // Surface a generic message — the underlying error may carry the
+      // secret in its stack on some signer implementations.
+      res.status(500).json({ ok: false, error: "cosigner failed to sign" });
+      return;
+    }
+
+    res.status(200).json({
+      ok: true,
+      signature,
+      signer: opts.signer.publicKey,
+    });
+  });
+
+  return router;
+}

--- a/routes-d/tests/memo.test.ts
+++ b/routes-d/tests/memo.test.ts
@@ -1,0 +1,169 @@
+// Tests for the Stellar memo validation helper (#281).
+
+import {
+  MEMO_HASH_HEX_LENGTH,
+  MEMO_TEXT_MAX_BYTES,
+  MemoValidationError,
+  assertValidMemo,
+  validateMemo,
+} from "../lib/memo.js";
+
+describe("validateMemo", () => {
+  describe("type discrimination", () => {
+    it("rejects unknown types with a field-level error", () => {
+      const result = validateMemo({ type: "garbage", value: "x" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors).toEqual([
+          { field: "type", message: expect.stringMatching(/type must be one of/) },
+        ]);
+      }
+    });
+
+    it("rejects non-string type", () => {
+      const result = validateMemo({ type: 42 as unknown, value: "x" });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("type: none", () => {
+    it("accepts an absent value", () => {
+      expect(validateMemo({ type: "none" })).toEqual({ ok: true, memo: { type: "none" } });
+    });
+
+    it("accepts an empty-string value", () => {
+      expect(validateMemo({ type: "none", value: "" })).toEqual({
+        ok: true,
+        memo: { type: "none" },
+      });
+    });
+
+    it("rejects a non-empty value for type: none", () => {
+      const result = validateMemo({ type: "none", value: "hi" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors[0].field).toBe("value");
+      }
+    });
+  });
+
+  describe("type: text", () => {
+    it("accepts a short ASCII string", () => {
+      const result = validateMemo({ type: "text", value: "hello" });
+      expect(result).toEqual({ ok: true, memo: { type: "text", value: "hello" } });
+    });
+
+    it("accepts exactly the max byte length", () => {
+      const value = "a".repeat(MEMO_TEXT_MAX_BYTES);
+      expect(validateMemo({ type: "text", value })).toEqual({
+        ok: true,
+        memo: { type: "text", value },
+      });
+    });
+
+    it("rejects strings whose UTF-8 length exceeds the max", () => {
+      const value = "a".repeat(MEMO_TEXT_MAX_BYTES + 1);
+      const result = validateMemo({ type: "text", value });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errors[0].message).toMatch(/exceeds 28 UTF-8 bytes/);
+    });
+
+    it("counts multi-byte chars by bytes, not characters", () => {
+      // Each "𝟘" is 4 UTF-8 bytes — eight of them is 32 bytes, over the limit.
+      const value = "𝟘".repeat(8);
+      const result = validateMemo({ type: "text", value });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects non-string text values", () => {
+      const result = validateMemo({ type: "text", value: 123 });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects missing value for text", () => {
+      const result = validateMemo({ type: "text" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errors[0].message).toMatch(/required/);
+    });
+  });
+
+  describe("type: id", () => {
+    it("accepts a numeric string", () => {
+      expect(validateMemo({ type: "id", value: "42" })).toEqual({
+        ok: true,
+        memo: { type: "id", value: "42" },
+      });
+    });
+
+    it("accepts a number and normalises to a decimal string", () => {
+      expect(validateMemo({ type: "id", value: 7 })).toEqual({
+        ok: true,
+        memo: { type: "id", value: "7" },
+      });
+    });
+
+    it("rejects negative ids", () => {
+      const result = validateMemo({ type: "id", value: "-1" });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects non-integer ids", () => {
+      const result = validateMemo({ type: "id", value: "1.5" });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects ids above uint64 max", () => {
+      const result = validateMemo({ type: "id", value: "18446744073709551616" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errors[0].message).toMatch(/uint64/);
+    });
+  });
+
+  describe("type: hash and return", () => {
+    const valid = "a".repeat(MEMO_HASH_HEX_LENGTH);
+
+    it("accepts a valid 64-char hex for hash", () => {
+      expect(validateMemo({ type: "hash", value: valid })).toEqual({
+        ok: true,
+        memo: { type: "hash", value: valid },
+      });
+    });
+
+    it("accepts a valid 64-char hex for return and lowercases it", () => {
+      const upper = "F".repeat(MEMO_HASH_HEX_LENGTH);
+      expect(validateMemo({ type: "return", value: upper })).toEqual({
+        ok: true,
+        memo: { type: "return", value: upper.toLowerCase() },
+      });
+    });
+
+    it("rejects wrong-length hex", () => {
+      const result = validateMemo({ type: "hash", value: "abcd" });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects non-hex chars", () => {
+      const result = validateMemo({ type: "hash", value: "z".repeat(MEMO_HASH_HEX_LENGTH) });
+      expect(result.ok).toBe(false);
+    });
+  });
+});
+
+describe("assertValidMemo", () => {
+  it("returns the normalised memo on success", () => {
+    expect(assertValidMemo({ type: "text", value: "ok" })).toEqual({
+      type: "text",
+      value: "ok",
+    });
+  });
+
+  it("throws MemoValidationError on failure with structured errors", () => {
+    expect.assertions(2);
+    try {
+      assertValidMemo({ type: "hash", value: "nope" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(MemoValidationError);
+      expect((err as MemoValidationError).errors[0].field).toBe("value");
+    }
+  });
+});

--- a/routes-d/tests/orders.bulkUpdate.test.ts
+++ b/routes-d/tests/orders.bulkUpdate.test.ts
@@ -1,0 +1,192 @@
+// Tests for the bulk order status update endpoint (#303).
+//
+// Covers all-success, mixed result (some succeed, some fail with
+// distinct reasons), total failure, envelope validation, and the
+// per-item state-machine gate.
+
+import express, { type Express } from "express";
+import request from "supertest";
+import type { OrderStatus } from "../lib/orderStateMachine.js";
+import {
+  type BulkOrderRecord,
+  type BulkOrderStore,
+  applyBulkItem,
+  createOrdersBulkUpdateRouter,
+} from "../routes/orders.bulkUpdate.js";
+
+function buildStore(initial: BulkOrderRecord[] = []): BulkOrderStore & {
+  inspect(): Map<string, BulkOrderRecord>;
+} {
+  const map = new Map<string, BulkOrderRecord>(initial.map((o) => [o.id, o]));
+  return {
+    async get(id) {
+      return map.get(id);
+    },
+    async save(order) {
+      map.set(order.id, order);
+    },
+    inspect: () => map,
+  };
+}
+
+function buildApp(store: BulkOrderStore, maxItems?: number): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/orders",
+    createOrdersBulkUpdateRouter({ store, now: () => 9000, maxItems }),
+  );
+  return app;
+}
+
+const seed: BulkOrderRecord[] = [
+  { id: "o1", status: "pending", updatedAt: 0 },
+  { id: "o2", status: "paid", updatedAt: 0 },
+  { id: "o3", status: "fulfilled", updatedAt: 0 },
+  { id: "o4", status: "cancelled", updatedAt: 0 }, // terminal
+];
+
+describe("applyBulkItem (pure)", () => {
+  it("succeeds on a legal transition and persists the update", async () => {
+    const store = buildStore([{ id: "o1", status: "pending", updatedAt: 0 }]);
+    const result = await applyBulkItem(
+      { orderId: "o1", status: "paid" as OrderStatus },
+      store,
+      () => 1234,
+    );
+    expect(result).toEqual({ orderId: "o1", ok: true, status: "paid" });
+    expect(store.inspect().get("o1")).toEqual({ id: "o1", status: "paid", updatedAt: 1234 });
+  });
+
+  it("returns not-found error without throwing", async () => {
+    const store = buildStore();
+    const result = await applyBulkItem(
+      { orderId: "ghost", status: "paid" as OrderStatus },
+      store,
+      () => 0,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/);
+  });
+
+  it("returns from/to on illegal transitions", async () => {
+    const store = buildStore([{ id: "o4", status: "cancelled", updatedAt: 0 }]);
+    const result = await applyBulkItem(
+      { orderId: "o4", status: "paid" as OrderStatus },
+      store,
+      () => 0,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.from).toBe("cancelled");
+    expect(result.to).toBe("paid");
+  });
+});
+
+describe("POST /orders/bulk-status", () => {
+  it("returns ok=true for every item on an all-success batch", async () => {
+    const store = buildStore(seed);
+    const res = await request(buildApp(store))
+      .post("/orders/bulk-status")
+      .send({
+        items: [
+          { orderId: "o1", status: "paid" },
+          { orderId: "o2", status: "fulfilled" },
+          { orderId: "o3", status: "shipped" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      total: 3,
+      succeeded: 3,
+      failed: 0,
+    });
+    expect(res.body.results.every((r: { ok: boolean }) => r.ok)).toBe(true);
+    expect(store.inspect().get("o1")?.status).toBe("paid");
+    expect(store.inspect().get("o2")?.status).toBe("fulfilled");
+    expect(store.inspect().get("o3")?.status).toBe("shipped");
+  });
+
+  it("returns a mixed result: per-item ok/error without 4xx-ing the batch", async () => {
+    const store = buildStore(seed);
+    const res = await request(buildApp(store))
+      .post("/orders/bulk-status")
+      .send({
+        items: [
+          { orderId: "o1", status: "paid" }, // legal
+          { orderId: "ghost", status: "paid" }, // not found
+          { orderId: "o4", status: "paid" }, // illegal (terminal)
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.succeeded).toBe(1);
+    expect(res.body.failed).toBe(2);
+
+    const byId: Record<string, { ok: boolean; error?: string }> = {};
+    for (const r of res.body.results as Array<{ orderId: string; ok: boolean; error?: string }>) {
+      byId[r.orderId] = r;
+    }
+    expect(byId["o1"].ok).toBe(true);
+    expect(byId["ghost"]).toMatchObject({ ok: false, error: expect.stringMatching(/not found/) });
+    expect(byId["o4"]).toMatchObject({ ok: false, error: expect.stringMatching(/terminal/) });
+
+    // The successful update must persist; the failed ones must not.
+    expect(store.inspect().get("o1")?.status).toBe("paid");
+    expect(store.inspect().get("o4")?.status).toBe("cancelled");
+  });
+
+  it("returns total failure as per-item errors (still 200)", async () => {
+    const store = buildStore(seed);
+    const res = await request(buildApp(store))
+      .post("/orders/bulk-status")
+      .send({
+        items: [
+          { orderId: "o4", status: "paid" },
+          { orderId: "ghost-1", status: "paid" },
+          { orderId: "ghost-2", status: "paid" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.succeeded).toBe(0);
+    expect(res.body.failed).toBe(3);
+    expect(res.body.results.every((r: { ok: boolean }) => r.ok === false)).toBe(true);
+  });
+
+  it("400s on a missing items field", async () => {
+    const res = await request(buildApp(buildStore(seed)))
+      .post("/orders/bulk-status")
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on an empty items array", async () => {
+    const res = await request(buildApp(buildStore(seed)))
+      .post("/orders/bulk-status")
+      .send({ items: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when an item status is not a known OrderStatus", async () => {
+    const res = await request(buildApp(buildStore(seed)))
+      .post("/orders/bulk-status")
+      .send({ items: [{ orderId: "o1", status: "exploded" }] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/OrderStatus/);
+  });
+
+  it("400s when items exceeds maxItems", async () => {
+    const items = Array.from({ length: 3 }, (_, i) => ({
+      orderId: `o${i + 1}`,
+      status: "paid" as OrderStatus,
+    }));
+    const res = await request(buildApp(buildStore(seed), 2))
+      .post("/orders/bulk-status")
+      .send({ items });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/exceeds maximum/);
+  });
+});

--- a/routes-d/tests/payments.refund.test.ts
+++ b/routes-d/tests/payments.refund.test.ts
@@ -1,0 +1,219 @@
+// Tests for the failed-payment refund endpoint (#294).
+//
+// Covers the happy path, idempotent replay (single dispatcher call
+// across multiple HTTP attempts), unauthorised access, double-refund
+// rejection via state, and dispatcher failures.
+
+import express, { type Express } from "express";
+import request from "supertest";
+import {
+  type PaymentRecord,
+  type PaymentStore,
+  type RefundDispatcher,
+  type RefundRecord,
+  type RefundStore,
+  createRefundRouter,
+} from "../routes/payments.refund.js";
+
+function buildPaymentStore(initial: PaymentRecord[] = []): PaymentStore & {
+  inspect(): Map<string, PaymentRecord>;
+} {
+  const map = new Map<string, PaymentRecord>(initial.map((p) => [p.id, p]));
+  return {
+    async get(id) {
+      return map.get(id);
+    },
+    async markRefunded(id) {
+      const p = map.get(id);
+      if (p) map.set(id, { ...p, status: "refunded" });
+    },
+    inspect: () => map,
+  };
+}
+
+function buildRefundStore(): RefundStore & { inspect(): RefundRecord[] } {
+  const list: RefundRecord[] = [];
+  return {
+    async findByIdempotency(paymentId, idempotencyKey) {
+      return list.find(
+        (r) => r.paymentId === paymentId && r.idempotencyKey === idempotencyKey,
+      );
+    },
+    async save(refund) {
+      list.push(refund);
+    },
+    inspect: () => list,
+  };
+}
+
+function buildApp(
+  payments: PaymentStore,
+  refunds: RefundStore,
+  dispatcher: RefundDispatcher,
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/payments",
+    createRefundRouter({
+      payments,
+      refunds,
+      dispatcher,
+      now: () => 5000,
+      newRefundId: () => "rf_fixed",
+    }),
+  );
+  return app;
+}
+
+describe("POST /payments/:id/refund", () => {
+  const failed: PaymentRecord = {
+    id: "p1",
+    payerId: "alice",
+    amount: 100,
+    currency: "USDC",
+    status: "failed",
+  };
+
+  it("refunds a failed payment on the happy path", async () => {
+    const payments = buildPaymentStore([failed]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn().mockResolvedValue({ refundId: "prov_1" });
+    const app = buildApp(payments, refunds, { refund });
+
+    const res = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "alice", requesterRole: "user" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.idempotent).toBe(false);
+    expect(res.body.refund).toMatchObject({
+      refundId: "prov_1",
+      paymentId: "p1",
+      amount: 100,
+      currency: "USDC",
+      createdAt: 5000,
+    });
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(payments.inspect().get("p1")?.status).toBe("refunded");
+    expect(refunds.inspect()).toHaveLength(1);
+  });
+
+  it("is idempotent against duplicate refund requests", async () => {
+    const payments = buildPaymentStore([failed]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn().mockResolvedValue({ refundId: "prov_dup" });
+    const app = buildApp(payments, refunds, { refund });
+
+    const first = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "alice", requesterRole: "user", idempotencyKey: "key-1" });
+    const second = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "alice", requesterRole: "user", idempotencyKey: "key-1" });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(200);
+    expect(second.body.idempotent).toBe(true);
+    expect(second.body.refund).toEqual(first.body.refund);
+    // The dispatcher must only have been called once across both attempts.
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(refunds.inspect()).toHaveLength(1);
+  });
+
+  it("rejects a refund from a non-payer non-admin requester", async () => {
+    const payments = buildPaymentStore([failed]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn();
+    const app = buildApp(payments, refunds, { refund });
+
+    const res = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "mallory", requesterRole: "user" });
+
+    expect(res.status).toBe(403);
+    expect(refund).not.toHaveBeenCalled();
+    expect(refunds.inspect()).toHaveLength(0);
+  });
+
+  it("allows admins to refund on behalf of the payer", async () => {
+    const payments = buildPaymentStore([failed]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn().mockResolvedValue({ refundId: "prov_admin" });
+    const app = buildApp(payments, refunds, { refund });
+
+    const res = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "ops", requesterRole: "admin" });
+
+    expect(res.status).toBe(201);
+    expect(refund).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 when payment is in a non-refundable status", async () => {
+    const pending: PaymentRecord = { ...failed, status: "pending" };
+    const payments = buildPaymentStore([pending]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn();
+    const app = buildApp(payments, refunds, { refund });
+
+    const res = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "alice", requesterRole: "user" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.status).toBe("pending");
+    expect(refund).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when payment is already refunded", async () => {
+    const already: PaymentRecord = { ...failed, status: "refunded" };
+    const payments = buildPaymentStore([already]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn();
+    const app = buildApp(payments, refunds, { refund });
+
+    const res = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "alice", requesterRole: "user" });
+
+    // Without a prior idempotency record, a fully-refunded payment must
+    // not be refunded a second time.
+    expect(res.status).toBe(409);
+    expect(refund).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when payment does not exist", async () => {
+    const app = buildApp(buildPaymentStore(), buildRefundStore(), {
+      refund: jest.fn(),
+    });
+    const res = await request(app)
+      .post("/payments/missing/refund")
+      .send({ requesterId: "alice", requesterRole: "user" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when requester fields are missing", async () => {
+    const app = buildApp(buildPaymentStore([failed]), buildRefundStore(), {
+      refund: jest.fn(),
+    });
+    const res = await request(app).post("/payments/p1/refund").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 502 when dispatcher throws", async () => {
+    const payments = buildPaymentStore([failed]);
+    const refunds = buildRefundStore();
+    const refund = jest.fn().mockRejectedValue(new Error("network"));
+    const app = buildApp(payments, refunds, { refund });
+
+    const res = await request(app)
+      .post("/payments/p1/refund")
+      .send({ requesterId: "alice", requesterRole: "user" });
+
+    expect(res.status).toBe(502);
+    expect(refunds.inspect()).toHaveLength(0);
+    expect(payments.inspect().get("p1")?.status).toBe("failed");
+  });
+});

--- a/routes-d/tests/stellar.tx.cosign.test.ts
+++ b/routes-d/tests/stellar.tx.cosign.test.ts
@@ -1,0 +1,176 @@
+// Tests for the Stellar transaction co-signing route (#280).
+//
+// Covers the allowlist gate (allowed vs disallowed operation sets),
+// payload validation, and the env loader's missing-key behaviour. The
+// signer is mocked so no real key material is touched.
+
+import express, { type Express } from "express";
+import request from "supertest";
+import {
+  CosignDisallowedError,
+  type CosignerSigner,
+  createCosignRouter,
+  findDisallowedOperations,
+  loadCosignerFromEnv,
+} from "../routes/stellar.tx.cosign.js";
+
+function buildSigner(overrides: Partial<CosignerSigner> = {}): CosignerSigner {
+  return {
+    publicKey: "GTESTPUBLICKEY",
+    sign: (envelope) => `sig-for-${envelope}`,
+    ...overrides,
+  };
+}
+
+function buildApp(
+  signer: CosignerSigner,
+  allowed: string[] = ["payment", "manageData"],
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/stellar/tx",
+    createCosignRouter({ signer, allowedOperations: allowed }),
+  );
+  return app;
+}
+
+describe("findDisallowedOperations", () => {
+  it("returns empty when every op is allowed", () => {
+    expect(
+      findDisallowedOperations(
+        [{ type: "payment" }, { type: "manageData" }],
+        new Set(["payment", "manageData"]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("collects every disallowed op type, preserving order", () => {
+    expect(
+      findDisallowedOperations(
+        [{ type: "payment" }, { type: "setOptions" }, { type: "accountMerge" }],
+        new Set(["payment"]),
+      ),
+    ).toEqual(["setOptions", "accountMerge"]);
+  });
+});
+
+describe("POST /stellar/tx/cosign", () => {
+  it("returns 200 + signature when every operation is allowed", async () => {
+    const sign = jest.fn().mockReturnValue("sig-abc");
+    const app = buildApp(buildSigner({ sign }));
+
+    const res = await request(app)
+      .post("/stellar/tx/cosign")
+      .send({
+        envelope: "AAA==",
+        operations: [{ type: "payment" }, { type: "manageData" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      signature: "sig-abc",
+      signer: "GTESTPUBLICKEY",
+    });
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(sign).toHaveBeenCalledWith("AAA==");
+  });
+
+  it("returns 403 when any operation is disallowed and does not sign", async () => {
+    const sign = jest.fn();
+    const app = buildApp(buildSigner({ sign }));
+
+    const res = await request(app)
+      .post("/stellar/tx/cosign")
+      .send({
+        envelope: "AAA==",
+        operations: [{ type: "payment" }, { type: "accountMerge" }],
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.disallowed).toEqual(["accountMerge"]);
+    expect(sign).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on a missing envelope", async () => {
+    const res = await request(buildApp(buildSigner()))
+      .post("/stellar/tx/cosign")
+      .send({ operations: [{ type: "payment" }] });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on an empty operations array", async () => {
+    const res = await request(buildApp(buildSigner()))
+      .post("/stellar/tx/cosign")
+      .send({ envelope: "AAA==", operations: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when an operation entry lacks a string type", async () => {
+    const res = await request(buildApp(buildSigner()))
+      .post("/stellar/tx/cosign")
+      .send({ envelope: "AAA==", operations: [{ kind: "payment" }] });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 with a generic message when the signer throws", async () => {
+    const sign = jest.fn().mockImplementation(() => {
+      throw new Error("would leak secret");
+    });
+    const res = await request(buildApp(buildSigner({ sign })))
+      .post("/stellar/tx/cosign")
+      .send({ envelope: "AAA==", operations: [{ type: "payment" }] });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("cosigner failed to sign");
+    // The original error message must not leak through.
+    expect(JSON.stringify(res.body)).not.toMatch(/leak secret/);
+  });
+});
+
+describe("createCosignRouter", () => {
+  it("throws when allowedOperations is empty", () => {
+    expect(() =>
+      createCosignRouter({ signer: buildSigner(), allowedOperations: [] }),
+    ).toThrow(/non-empty/);
+  });
+});
+
+describe("loadCosignerFromEnv", () => {
+  it("throws when STELLAR_COSIGNER_PUBLIC is missing", () => {
+    expect(() =>
+      loadCosignerFromEnv(() => "sig", { STELLAR_COSIGNER_SECRET: "S..." }),
+    ).toThrow(/must be set/);
+  });
+
+  it("throws when STELLAR_COSIGNER_SECRET is missing", () => {
+    expect(() =>
+      loadCosignerFromEnv(() => "sig", { STELLAR_COSIGNER_PUBLIC: "G..." }),
+    ).toThrow(/must be set/);
+  });
+
+  it("delegates signing to the supplied signerFn without logging the secret", async () => {
+    const calls: Array<{ secret: string; envelope: string }> = [];
+    const cosigner = loadCosignerFromEnv(
+      (secret, envelope) => {
+        calls.push({ secret, envelope });
+        return "sig-zz";
+      },
+      { STELLAR_COSIGNER_PUBLIC: "GPUB", STELLAR_COSIGNER_SECRET: "SSECRET" },
+    );
+
+    expect(cosigner.publicKey).toBe("GPUB");
+    expect(await cosigner.sign("env-xyz")).toBe("sig-zz");
+    expect(calls).toEqual([{ secret: "SSECRET", envelope: "env-xyz" }]);
+  });
+});
+
+describe("CosignDisallowedError", () => {
+  it("includes the disallowed types in its message", () => {
+    const err = new CosignDisallowedError(["a", "b"]);
+    expect(err.message).toMatch(/a, b/);
+    expect(err.disallowed).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds four self-contained pieces to the `routes-d/` workspace, each following the existing pattern (express Router factory + injectable store/dispatcher/signer + supertest unit + integration tests).

- `lib/memo.ts` — Stellar memo validation helper with field-level errors for every memo type (text/id/hash/return/none).
- `routes/stellar.tx.cosign.ts` — co-signing route that allowlists operation types and signs via an injected signer; env loader keeps the secret out of logs.
- `routes/payments.refund.ts` — refund endpoint with idempotency keyed on `(paymentId, idempotencyKey)`, payer/admin authorisation, and a 502 path for dispatcher failures.
- `routes/orders.bulkUpdate.ts` — admin bulk transition endpoint that returns a per-item success/failure array, with every transition gated by the shared `orderStateMachine.ts`.

All changes live strictly under `routes-d/`. No existing files were modified.

closes #280
closes #281
closes #294
closes #303

## Test plan

- [ ] `cd routes-d && npm install && npm test` runs the new specs alongside the existing suite (could not run locally — relying on CI).
- [ ] Verify the `routes-d` package still type-checks under its own `tsconfig.json`.
- [ ] Confirm no files outside `routes-d/` were touched.

## Notes

- Tooling could not be run locally; CI is the source of truth.
- Pre-existing `build:content` / `check:links` failures on `main` are unrelated to this change.