### PR TITLE
feat(routes-d): login route with rate limiting + TOTP 2FA endpoints

### DIFF
--- a/routes-d/lib/totp.ts
+++ b/routes-d/lib/totp.ts
@@ -1,0 +1,330 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  randomBytes,
+  scryptSync,
+} from 'node:crypto';
+
+/**
+ * TOTP (RFC 6238) + secret storage helpers used by the routes-d second-
+ * factor endpoints (Issue #258).
+ *
+ * The module provides three things kept narrow on purpose:
+ *
+ *   1. `generateTotpSecret` / `formatOtpAuthUrl` — issuance side, including
+ *      base32 (RFC 4648) encoding because otpauth:// URIs require it.
+ *   2. `generateTotp` / `verifyTotp` — the HMAC-SHA1 OTP itself. We allow
+ *      a small drift window (default ±1 step) so a code generated right
+ *      at a boundary still verifies, but we also record consumed codes so
+ *      the same OTP cannot be replayed inside the verification window.
+ *   3. `encryptSecret` / `decryptSecret` — AES-256-GCM around the shared
+ *      secret so the at-rest representation of an enrolled secret is not
+ *      directly usable if the database is exfiltrated. The key is derived
+ *      from `NEXTELLAR_TOTP_ENC_KEY` (with a clearly-marked dev fallback so
+ *      tests don't need to plumb env vars but a misconfigured prod is
+ *      obvious in audit).
+ *
+ * Storage of enrolled records lives in `TotpSecretStore`, an in-memory
+ * default that mirrors how `passwordTokenStore` is set up elsewhere in
+ * routes-d — production deployments swap it for a persistent store with
+ * the same surface.
+ */
+
+export const TOTP_PERIOD_SECONDS = 30;
+export const TOTP_DIGITS = 6;
+export const TOTP_DEFAULT_DRIFT_STEPS = 1;
+
+const TOTP_ENC_KEY_NAME = 'NEXTELLAR_TOTP_ENC_KEY';
+const TOTP_ENC_FALLBACK_PASSPHRASE =
+  'nextellar-routes-d-totp-dev-passphrase';
+const TOTP_ENC_SALT = Buffer.from('nextellar-routes-d-totp-salt', 'utf8');
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/* -------------------------------------------------------------------------- */
+/* base32                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export function base32Encode(buf: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 0x1f];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f];
+  }
+  return out;
+}
+
+export function base32Decode(input: string): Buffer {
+  const cleaned = input.replace(/=+$/g, '').replace(/\s+/g, '').toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of cleaned) {
+    const idx = BASE32_ALPHABET.indexOf(ch);
+    if (idx === -1) throw new Error('invalid base32 character');
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(out);
+}
+
+/* -------------------------------------------------------------------------- */
+/* TOTP                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export function generateTotpSecret(byteLength = 20): {
+  raw: Buffer;
+  base32: string;
+} {
+  const raw = randomBytes(byteLength);
+  return { raw, base32: base32Encode(raw) };
+}
+
+function computeHotp(secret: Buffer, counter: number): string {
+  const buf = Buffer.alloc(8);
+  // 64-bit counter, big-endian. JS bitwise ops are 32-bit, so split.
+  buf.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  buf.writeUInt32BE(counter >>> 0, 4);
+
+  const hmac = createHmac('sha1', secret).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return (code % 10 ** TOTP_DIGITS).toString().padStart(TOTP_DIGITS, '0');
+}
+
+export function generateTotp(
+  secret: Buffer,
+  timestampMs: number = Date.now(),
+): string {
+  const counter = Math.floor(timestampMs / 1000 / TOTP_PERIOD_SECONDS);
+  return computeHotp(secret, counter);
+}
+
+export interface VerifyTotpResult {
+  ok: boolean;
+  /** The counter that matched, useful for replay tracking. */
+  counter?: number;
+}
+
+/**
+ * Verify a presented OTP. Accepts a small drift window so a code captured
+ * right at the boundary still validates. Returns the matching counter so
+ * the caller can refuse to honour the same counter twice.
+ *
+ * Uses a constant-time comparison per step so timing does not leak which
+ * window position matched.
+ */
+export function verifyTotp(
+  secret: Buffer,
+  code: string,
+  options: {
+    timestampMs?: number;
+    driftSteps?: number;
+  } = {},
+): VerifyTotpResult {
+  const ts = options.timestampMs ?? Date.now();
+  const drift = options.driftSteps ?? TOTP_DEFAULT_DRIFT_STEPS;
+  const baseCounter = Math.floor(ts / 1000 / TOTP_PERIOD_SECONDS);
+
+  // Normalise the presented code so callers can pass " 123 456 " or similar.
+  const normalised = code.replace(/\s+/g, '');
+  if (!/^\d{6}$/.test(normalised)) return { ok: false };
+
+  let matched: number | undefined;
+  for (let delta = -drift; delta <= drift; delta++) {
+    const counter = baseCounter + delta;
+    if (counter < 0) continue;
+    const expected = computeHotp(secret, counter);
+    // Constant-time compare on equal-length strings.
+    if (constantTimeEq(expected, normalised) && matched === undefined) {
+      matched = counter;
+    }
+  }
+  return matched === undefined ? { ok: false } : { ok: true, counter: matched };
+}
+
+function constantTimeEq(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* otpauth                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export function formatOtpAuthUrl(input: {
+  secretBase32: string;
+  accountName: string;
+  issuer?: string;
+}): string {
+  const issuer = (input.issuer ?? 'Nextellar').trim();
+  const label = encodeURIComponent(`${issuer}:${input.accountName}`);
+  const params = new URLSearchParams({
+    secret: input.secretBase32,
+    issuer,
+    algorithm: 'SHA1',
+    digits: String(TOTP_DIGITS),
+    period: String(TOTP_PERIOD_SECONDS),
+  });
+  return `otpauth://totp/${label}?${params.toString()}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* at-rest encryption                                                         */
+/* -------------------------------------------------------------------------- */
+
+function deriveKey(): Buffer {
+  const passphrase =
+    process.env[TOTP_ENC_KEY_NAME]?.trim() || TOTP_ENC_FALLBACK_PASSPHRASE;
+  return scryptSync(passphrase, TOTP_ENC_SALT, 32);
+}
+
+export interface EncryptedSecret {
+  iv: string; // base64
+  ciphertext: string; // base64
+  authTag: string; // base64
+}
+
+export function encryptSecret(plaintext: Buffer): EncryptedSecret {
+  const key = deriveKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return {
+    iv: iv.toString('base64'),
+    ciphertext: ciphertext.toString('base64'),
+    authTag: authTag.toString('base64'),
+  };
+}
+
+export function decryptSecret(payload: EncryptedSecret): Buffer {
+  const key = deriveKey();
+  const iv = Buffer.from(payload.iv, 'base64');
+  const ciphertext = Buffer.from(payload.ciphertext, 'base64');
+  const authTag = Buffer.from(payload.authTag, 'base64');
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* enrollment store                                                           */
+/* -------------------------------------------------------------------------- */
+
+export type EnrollmentState = 'pending' | 'active';
+
+export interface TotpEnrollmentRecord {
+  userId: string;
+  encrypted: EncryptedSecret;
+  state: EnrollmentState;
+  /** Counter of the most recently consumed OTP — used to reject replays. */
+  lastUsedCounter?: number;
+  createdAt: number;
+}
+
+export type VerifyConsumeResult =
+  | { ok: true }
+  | { ok: false; reason: 'unknown' | 'invalid' | 'replay' };
+
+/**
+ * In-memory enrolment store. The encrypted secret is stored alongside the
+ * `lastUsedCounter` so the same window's code cannot be replayed even
+ * within the drift window.
+ */
+export class TotpSecretStore {
+  private readonly byUser = new Map<string, TotpEnrollmentRecord>();
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  /** Begin enrolment. Overwrites any previous pending or active record. */
+  startEnrollment(userId: string): {
+    record: TotpEnrollmentRecord;
+    secretBase32: string;
+  } {
+    const { raw, base32 } = generateTotpSecret();
+    const record: TotpEnrollmentRecord = {
+      userId,
+      encrypted: encryptSecret(raw),
+      state: 'pending',
+      createdAt: this.now(),
+    };
+    this.byUser.set(userId, record);
+    return { record, secretBase32: base32 };
+  }
+
+  /**
+   * Verify a code and, on success, transition a pending enrolment to
+   * active. Returning a typed `reason` lets the route translate to a
+   * stable status code without exposing internal state.
+   */
+  verifyAndConsume(
+    userId: string,
+    code: string,
+    options: { timestampMs?: number } = {},
+  ): VerifyConsumeResult {
+    const record = this.byUser.get(userId);
+    if (!record) return { ok: false, reason: 'unknown' };
+
+    const secret = decryptSecret(record.encrypted);
+    const result = verifyTotp(secret, code, options);
+    if (!result.ok || result.counter === undefined) {
+      return { ok: false, reason: 'invalid' };
+    }
+    if (
+      record.lastUsedCounter !== undefined &&
+      result.counter <= record.lastUsedCounter
+    ) {
+      return { ok: false, reason: 'replay' };
+    }
+    record.lastUsedCounter = result.counter;
+    if (record.state === 'pending') {
+      record.state = 'active';
+    }
+    return { ok: true };
+  }
+
+  /** Whether an account currently requires TOTP on login. */
+  isActive(userId: string): boolean {
+    return this.byUser.get(userId)?.state === 'active';
+  }
+
+  /** Disable TOTP for a user. The caller is expected to have re-authed. */
+  disable(userId: string): boolean {
+    return this.byUser.delete(userId);
+  }
+
+  /** Test/debug helper. */
+  inspect(userId: string): TotpEnrollmentRecord | undefined {
+    return this.byUser.get(userId);
+  }
+
+  /** Test helper. */
+  clear(): void {
+    this.byUser.clear();
+  }
+}
+
+export const totpSecretStore = new TotpSecretStore();

--- a/routes-d/middleware/rateLimit.ts
+++ b/routes-d/middleware/rateLimit.ts
@@ -1,0 +1,210 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * In-process sliding-window rate limiter used to slow brute-force attempts
+ * against the login route (Issue #256).
+ *
+ * Two keys are tracked independently so an attacker cannot defeat the limit
+ * by spraying many IPs at a single account, nor by rotating accounts behind
+ * a single IP:
+ *
+ *   - per IP        — caps total login attempts from a single source.
+ *   - per IP+email  — caps attempts against a specific account from a
+ *                     single source so a leaked password list still gets
+ *                     slowed even when the IPs are distributed.
+ *
+ * Thresholds are configurable via env vars; the constructor accepts an
+ * options bag so tests can drive the limiter deterministically.
+ *
+ * This is intentionally an in-memory implementation — production
+ * deployments are expected to swap in a Redis-backed store that exposes
+ * the same `hit` shape. Keeping the surface narrow makes that swap a
+ * one-file change.
+ */
+
+export interface RateLimitOptions {
+  /** Max attempts per window per key. */
+  limit: number;
+  /** Window size in milliseconds. */
+  windowMs: number;
+  /** Injectable clock so tests can advance time deterministically. */
+  now?: () => number;
+}
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  /** Number of remaining attempts in the current window after this hit. */
+  remaining: number;
+  /** Milliseconds until the oldest in-window attempt rolls off. */
+  retryAfterMs: number;
+}
+
+interface Bucket {
+  /** Timestamps (ms) of attempts that fall inside the window. */
+  hits: number[];
+}
+
+export class SlidingWindowLimiter {
+  private readonly buckets = new Map<string, Bucket>();
+
+  constructor(private readonly options: RateLimitOptions) {
+    if (options.limit <= 0) {
+      throw new Error('rate limit must be > 0');
+    }
+    if (options.windowMs <= 0) {
+      throw new Error('rate limit windowMs must be > 0');
+    }
+  }
+
+  /**
+   * Record an attempt for `key` and return whether it should be allowed.
+   * The hit is recorded regardless of the verdict — that way a caller who
+   * keeps retrying past the limit only pushes their retry-after further
+   * out, instead of being granted a fresh quota the moment one hit falls
+   * off the window.
+   */
+  hit(key: string): RateLimitDecision {
+    const now = this.now();
+    const cutoff = now - this.options.windowMs;
+    const bucket = this.buckets.get(key) ?? { hits: [] };
+
+    // Drop attempts that are older than the window.
+    bucket.hits = bucket.hits.filter((t) => t > cutoff);
+    bucket.hits.push(now);
+    this.buckets.set(key, bucket);
+
+    const allowed = bucket.hits.length <= this.options.limit;
+    const remaining = Math.max(0, this.options.limit - bucket.hits.length);
+    const oldest = bucket.hits[0] ?? now;
+    const retryAfterMs = allowed
+      ? 0
+      : Math.max(0, oldest + this.options.windowMs - now);
+
+    return { allowed, remaining, retryAfterMs };
+  }
+
+  /** Test helper — wipe state between cases. */
+  reset(): void {
+    this.buckets.clear();
+  }
+
+  private now(): number {
+    return this.options.now ? this.options.now() : Date.now();
+  }
+}
+
+const DEFAULT_IP_LIMIT = 20;
+const DEFAULT_IP_EMAIL_LIMIT = 5;
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Build a limiter pair from environment variables. Designed so the route
+ * file is a one-liner — `loginRateLimit()` — with sensible defaults that
+ * still work in CI where the env vars aren't set.
+ */
+export function rateLimitConfigFromEnv(): {
+  ipLimiter: SlidingWindowLimiter;
+  ipEmailLimiter: SlidingWindowLimiter;
+} {
+  const windowMs = parsePositiveInt(
+    process.env.NEXTELLAR_LOGIN_RATE_WINDOW_MS,
+    DEFAULT_WINDOW_MS,
+  );
+  const ipLimit = parsePositiveInt(
+    process.env.NEXTELLAR_LOGIN_RATE_IP_LIMIT,
+    DEFAULT_IP_LIMIT,
+  );
+  const ipEmailLimit = parsePositiveInt(
+    process.env.NEXTELLAR_LOGIN_RATE_IP_EMAIL_LIMIT,
+    DEFAULT_IP_EMAIL_LIMIT,
+  );
+  return {
+    ipLimiter: new SlidingWindowLimiter({ limit: ipLimit, windowMs }),
+    ipEmailLimiter: new SlidingWindowLimiter({ limit: ipEmailLimit, windowMs }),
+  };
+}
+
+export interface LoginRateLimitOptions {
+  ipLimiter?: SlidingWindowLimiter;
+  ipEmailLimiter?: SlidingWindowLimiter;
+  /** Pull a normalised email from the request body. */
+  getEmail?: (req: Request) => string;
+  /** Pull a stable client IP. */
+  getIp?: (req: Request) => string;
+}
+
+function defaultGetEmail(req: Request): string {
+  const value = (req.body as { email?: unknown } | undefined)?.email;
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function defaultGetIp(req: Request): string {
+  // Trust the Express-resolved IP (which honours `app.set('trust proxy', …)`
+  // when the deployment configures it). Fall back to the socket address so a
+  // misconfigured proxy still produces *some* key rather than collapsing
+  // every caller into the empty string.
+  return req.ip || req.socket?.remoteAddress || 'unknown';
+}
+
+/**
+ * Express middleware enforcing the login rate limit. Returns 429 with
+ * `Retry-After` (seconds, per RFC 7231) when either bucket overflows.
+ */
+export function loginRateLimit(
+  options: LoginRateLimitOptions = {},
+): RequestHandler {
+  const { ipLimiter, ipEmailLimiter } = (() => {
+    if (options.ipLimiter && options.ipEmailLimiter) {
+      return {
+        ipLimiter: options.ipLimiter,
+        ipEmailLimiter: options.ipEmailLimiter,
+      };
+    }
+    const built = rateLimitConfigFromEnv();
+    return {
+      ipLimiter: options.ipLimiter ?? built.ipLimiter,
+      ipEmailLimiter: options.ipEmailLimiter ?? built.ipEmailLimiter,
+    };
+  })();
+
+  const getEmail = options.getEmail ?? defaultGetEmail;
+  const getIp = options.getIp ?? defaultGetIp;
+
+  return function rateLimitMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    const ip = getIp(req);
+    const email = getEmail(req);
+
+    const ipDecision = ipLimiter.hit(`ip:${ip}`);
+    // Only key per-email when the request actually carries one — an empty
+    // email key would otherwise lump all bodyless requests together.
+    const ipEmailDecision = email
+      ? ipEmailLimiter.hit(`ip:${ip}|email:${email}`)
+      : { allowed: true, remaining: Number.POSITIVE_INFINITY, retryAfterMs: 0 };
+
+    if (!ipDecision.allowed || !ipEmailDecision.allowed) {
+      const retryAfterMs = Math.max(
+        ipDecision.retryAfterMs,
+        ipEmailDecision.retryAfterMs,
+      );
+      const retryAfterSec = Math.max(1, Math.ceil(retryAfterMs / 1000));
+      res.setHeader('Retry-After', String(retryAfterSec));
+      res.status(429).json({
+        error: 'too many requests',
+        retryAfter: retryAfterSec,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/routes-d/routes/auth.login.ts
+++ b/routes-d/routes/auth.login.ts
@@ -1,0 +1,129 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  loginRateLimit,
+  type LoginRateLimitOptions,
+} from '../middleware/rateLimit.js';
+
+/**
+ * Login route with rate limiting baked in (Issue #256).
+ *
+ * The credential check and token issuance are injected via `loginDeps` so
+ * the route file stays storage-agnostic — a production wiring replaces the
+ * defaults, which throw on call so a misconfigured deployment fails loud
+ * rather than silently accepting requests.
+ */
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+
+export interface LoginVerificationResult {
+  /** Stable user identifier on success. */
+  userId: string;
+  /**
+   * Set when the account has TOTP enabled. The caller must complete the
+   * step-up via the TOTP routes (Issue #258) before being granted a full
+   * session.
+   */
+  totpRequired?: boolean;
+}
+
+export interface LoginDeps {
+  /**
+   * Verify a (email, password) pair. Return `null` on any failure — never
+   * differentiate between "no such user" and "wrong password" so callers
+   * can't probe for valid accounts.
+   */
+  verifyCredentials: (input: {
+    email: string;
+    password: string;
+  }) => Promise<LoginVerificationResult | null>;
+  /** Issue the session token for an authenticated user. */
+  issueSession: (input: {
+    userId: string;
+    email: string;
+  }) => Promise<{ token: string; expiresAt: number }>;
+}
+
+export const loginDeps: LoginDeps = {
+  verifyCredentials: async () => {
+    throw new Error('loginDeps.verifyCredentials not configured');
+  },
+  issueSession: async () => {
+    throw new Error('loginDeps.issueSession not configured');
+  },
+};
+
+export interface CreateLoginRouterOptions {
+  rateLimit?: LoginRateLimitOptions;
+  deps?: LoginDeps;
+}
+
+/**
+ * Build a router instance. Exposed so tests can supply fake deps and a
+ * deterministic limiter without monkey-patching the module-level singleton.
+ */
+export function createLoginRouter(
+  options: CreateLoginRouterOptions = {},
+): Router {
+  const router = Router();
+  const deps = options.deps ?? loginDeps;
+  const limiter = loginRateLimit(options.rateLimit);
+
+  router.post(
+    '/auth/login',
+    limiter,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const email =
+          typeof req.body?.email === 'string'
+            ? req.body.email.trim().toLowerCase()
+            : '';
+        const password =
+          typeof req.body?.password === 'string' ? req.body.password : '';
+
+        if (!email || !EMAIL_PATTERN.test(email)) {
+          return res.status(400).json({ error: 'Invalid email address' });
+        }
+        if (!password || password.length < MIN_PASSWORD_LENGTH) {
+          return res
+            .status(400)
+            .json({
+              error: `password must be at least ${MIN_PASSWORD_LENGTH} characters`,
+            });
+        }
+
+        const verified = await deps.verifyCredentials({ email, password });
+        if (!verified) {
+          return res.status(401).json({ error: 'invalid credentials' });
+        }
+
+        if (verified.totpRequired) {
+          // The credential pair is good but the account has a second factor
+          // enabled. We deliberately do not issue a usable session here —
+          // the client must POST to /auth/totp/verify next.
+          return res.status(200).json({
+            userId: verified.userId,
+            totpRequired: true,
+          });
+        }
+
+        const session = await deps.issueSession({
+          userId: verified.userId,
+          email,
+        });
+        return res.status(200).json({
+          userId: verified.userId,
+          token: session.token,
+          expiresAt: session.expiresAt,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    },
+  );
+
+  return router;
+}
+
+/** Default router wired against the singleton deps. */
+export default createLoginRouter();

--- a/routes-d/routes/auth.totp.ts
+++ b/routes-d/routes/auth.totp.ts
@@ -1,0 +1,160 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  TotpSecretStore,
+  formatOtpAuthUrl,
+  totpSecretStore as defaultStore,
+} from '../lib/totp.js';
+
+/**
+ * TOTP two-factor endpoints (Issue #258).
+ *
+ *   POST /auth/totp/enroll  — start enrolment, returns secret + otpauth URI.
+ *                             Caller is expected to be already authenticated
+ *                             by an upstream session middleware; the route
+ *                             only enforces presence of a user identifier.
+ *   POST /auth/totp/verify  — verify a code. First successful verify on a
+ *                             pending enrolment transitions it to active.
+ *                             Subsequent verifies act as the login step-up.
+ *   POST /auth/totp/disable — disable TOTP for the user, gated on a current
+ *                             code so a stolen session alone can't turn it
+ *                             off.
+ *
+ * The "current user" is resolved through `userResolver`. The default reads
+ * `req.body.userId` so the file stays decoupled from the session/JWT
+ * middleware already in routes-d — production wiring replaces the resolver
+ * with one that reads `req.jwt.sub`.
+ */
+
+export type UserResolver = (req: Request) => string | undefined;
+
+const defaultUserResolver: UserResolver = (req) => {
+  const value = (req.body as { userId?: unknown } | undefined)?.userId;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+function extractCode(req: Request): string {
+  const value = (req.body as { code?: unknown } | undefined)?.code;
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export interface CreateTotpRouterOptions {
+  store?: TotpSecretStore;
+  userResolver?: UserResolver;
+  issuer?: string;
+  /** Resolve an account label (typically an email) for the otpauth URI. */
+  getAccountName?: (req: Request, userId: string) => string;
+}
+
+export function createTotpRouter(
+  options: CreateTotpRouterOptions = {},
+): Router {
+  const router = Router();
+  const store = options.store ?? defaultStore;
+  const userResolver = options.userResolver ?? defaultUserResolver;
+  const getAccountName =
+    options.getAccountName ??
+    ((req, userId) => {
+      const email = (req.body as { email?: unknown } | undefined)?.email;
+      return typeof email === 'string' && email.length > 0 ? email : userId;
+    });
+  const issuer = options.issuer ?? 'Nextellar';
+
+  router.post(
+    '/auth/totp/enroll',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = userResolver(req);
+        if (!userId) {
+          return res.status(401).json({ error: 'unauthorized' });
+        }
+
+        const { secretBase32 } = store.startEnrollment(userId);
+        const otpauthUrl = formatOtpAuthUrl({
+          secretBase32,
+          accountName: getAccountName(req, userId),
+          issuer,
+        });
+
+        // Returning the raw base32 secret is part of the enrolment UX —
+        // the client renders it as a QR plus a manual-entry fallback. The
+        // value is single-use in the sense that calling enroll again
+        // overwrites it; the active record only persists after the user
+        // proves possession via /verify.
+        return res.status(200).json({
+          secret: secretBase32,
+          otpauthUrl,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    },
+  );
+
+  router.post(
+    '/auth/totp/verify',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = userResolver(req);
+        if (!userId) {
+          return res.status(401).json({ error: 'unauthorized' });
+        }
+        const code = extractCode(req);
+        if (!/^\d{6}$/.test(code)) {
+          return res.status(400).json({ error: 'code must be 6 digits' });
+        }
+
+        const result = store.verifyAndConsume(userId, code);
+        if (!result.ok) {
+          // 401 across the board so a probing caller can't distinguish
+          // "no enrolment" from "wrong code" from "replay". The `reason`
+          // field is included for legitimate clients/observability.
+          return res
+            .status(401)
+            .json({ error: 'invalid totp code', reason: result.reason });
+        }
+
+        return res
+          .status(200)
+          .json({ success: true, active: store.isActive(userId) });
+      } catch (err) {
+        return next(err);
+      }
+    },
+  );
+
+  router.post(
+    '/auth/totp/disable',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = userResolver(req);
+        if (!userId) {
+          return res.status(401).json({ error: 'unauthorized' });
+        }
+        if (!store.isActive(userId)) {
+          return res.status(404).json({ error: 'totp not enrolled' });
+        }
+        const code = extractCode(req);
+        if (!/^\d{6}$/.test(code)) {
+          return res
+            .status(400)
+            .json({ error: 'code must be 6 digits to disable totp' });
+        }
+        const result = store.verifyAndConsume(userId, code);
+        if (!result.ok) {
+          return res
+            .status(401)
+            .json({ error: 'invalid totp code', reason: result.reason });
+        }
+
+        store.disable(userId);
+        return res.status(200).json({ success: true });
+      } catch (err) {
+        return next(err);
+      }
+    },
+  );
+
+  return router;
+}
+
+export default createTotpRouter();

--- a/routes-d/tests/auth.login.test.ts
+++ b/routes-d/tests/auth.login.test.ts
@@ -1,0 +1,228 @@
+import express from 'express';
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import {
+  createLoginRouter,
+  type LoginDeps,
+  type LoginVerificationResult,
+} from '../routes/auth.login.js';
+import { SlidingWindowLimiter } from '../middleware/rateLimit.js';
+
+function buildDeps(overrides: Partial<LoginDeps> = {}): LoginDeps {
+  return {
+    verifyCredentials: jest.fn(
+      async (): Promise<LoginVerificationResult | null> => ({
+        userId: 'user-1',
+      }),
+    ) as LoginDeps['verifyCredentials'],
+    issueSession: jest.fn(async () => ({
+      token: 'session-token',
+      expiresAt: 9_999_999,
+    })) as LoginDeps['issueSession'],
+    ...overrides,
+  };
+}
+
+function buildApp(deps: LoginDeps, opts?: { now?: () => number }) {
+  // Fresh limiters per app so cases don't leak state into each other.
+  const ipLimiter = new SlidingWindowLimiter({
+    limit: 5,
+    windowMs: 60_000,
+    now: opts?.now,
+  });
+  const ipEmailLimiter = new SlidingWindowLimiter({
+    limit: 3,
+    windowMs: 60_000,
+    now: opts?.now,
+  });
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createLoginRouter({
+      deps,
+      rateLimit: { ipLimiter, ipEmailLimiter },
+    }),
+  );
+  return { app, ipLimiter, ipEmailLimiter };
+}
+
+describe('SlidingWindowLimiter', () => {
+  it('allows up to `limit` hits and rejects the next one', () => {
+    const limiter = new SlidingWindowLimiter({ limit: 3, windowMs: 1000 });
+    expect(limiter.hit('k').allowed).toBe(true);
+    expect(limiter.hit('k').allowed).toBe(true);
+    expect(limiter.hit('k').allowed).toBe(true);
+    const fourth = limiter.hit('k');
+    expect(fourth.allowed).toBe(false);
+    expect(fourth.remaining).toBe(0);
+    expect(fourth.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('reports a retry-after that counts down toward the oldest in-window hit', () => {
+    let now = 1_000_000;
+    const limiter = new SlidingWindowLimiter({
+      limit: 1,
+      windowMs: 1000,
+      now: () => now,
+    });
+
+    expect(limiter.hit('k').allowed).toBe(true);
+
+    now += 500; // still inside window
+    const second = limiter.hit('k');
+    expect(second.allowed).toBe(false);
+    expect(second.retryAfterMs).toBe(500);
+
+    now += 200; // still inside window
+    const third = limiter.hit('k');
+    expect(third.allowed).toBe(false);
+    // The oldest in-window hit is fixed at t=0 relative to start, so the
+    // retry-after shrinks as real time advances — even though the caller
+    // is being rate-limited the whole time.
+    expect(third.retryAfterMs).toBe(300);
+  });
+
+  it('forgets hits older than the window', () => {
+    let now = 1_000_000;
+    const limiter = new SlidingWindowLimiter({
+      limit: 1,
+      windowMs: 1000,
+      now: () => now,
+    });
+    expect(limiter.hit('k').allowed).toBe(true);
+    now += 1500;
+    expect(limiter.hit('k').allowed).toBe(true);
+  });
+
+  it('rejects nonsensical configuration', () => {
+    expect(
+      () => new SlidingWindowLimiter({ limit: 0, windowMs: 1 }),
+    ).toThrow();
+    expect(
+      () => new SlidingWindowLimiter({ limit: 1, windowMs: 0 }),
+    ).toThrow();
+  });
+});
+
+describe('POST /auth/login validation', () => {
+  it('rejects a missing or malformed email', async () => {
+    const { app } = buildApp(buildDeps());
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'not-an-email', password: 'hunter2!secure' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/email/i);
+  });
+
+  it('rejects a short password', async () => {
+    const { app } = buildApp(buildDeps());
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', password: 'short' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/password/i);
+  });
+});
+
+describe('POST /auth/login credentials', () => {
+  it('returns 401 with a generic message on wrong credentials', async () => {
+    const deps = buildDeps({
+      verifyCredentials: jest.fn(
+        async () => null,
+      ) as LoginDeps['verifyCredentials'],
+    });
+    const { app } = buildApp(deps);
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', password: 'hunter2!secure' });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid credentials' });
+  });
+
+  it('returns a session token when credentials are valid and TOTP is not required', async () => {
+    const deps = buildDeps();
+    const { app } = buildApp(deps);
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', password: 'hunter2!secure' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      userId: 'user-1',
+      token: 'session-token',
+      expiresAt: 9_999_999,
+    });
+    expect(deps.issueSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('signals TOTP step-up without issuing a session when required', async () => {
+    const deps = buildDeps({
+      verifyCredentials: jest.fn(async () => ({
+        userId: 'user-1',
+        totpRequired: true,
+      })) as LoginDeps['verifyCredentials'],
+    });
+    const { app } = buildApp(deps);
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', password: 'hunter2!secure' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ userId: 'user-1', totpRequired: true });
+    expect(deps.issueSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/login rate limiting', () => {
+  it('returns 429 with Retry-After once the per-email cap is exceeded', async () => {
+    const deps = buildDeps({
+      verifyCredentials: jest.fn(
+        async () => null,
+      ) as LoginDeps['verifyCredentials'],
+    });
+    const { app } = buildApp(deps);
+
+    // Per-email limit is 3 (see buildApp). 4th attempt against the same
+    // email from the same IP must be rejected before the route handler
+    // runs.
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app)
+        .post('/auth/login')
+        .send({ email: 'user@example.com', password: 'hunter2!secure' });
+      expect(res.status).toBe(401);
+    }
+
+    const tripped = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', password: 'hunter2!secure' });
+    expect(tripped.status).toBe(429);
+    expect(tripped.body).toMatchObject({ error: 'too many requests' });
+    expect(tripped.headers['retry-after']).toBeDefined();
+    const retryAfter = Number(tripped.headers['retry-after']);
+    expect(retryAfter).toBeGreaterThanOrEqual(1);
+    // Verifier should not have run on the rate-limited attempt.
+    expect(deps.verifyCredentials).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns 429 with Retry-After once the per-IP cap is exceeded across emails', async () => {
+    const deps = buildDeps({
+      verifyCredentials: jest.fn(
+        async () => null,
+      ) as LoginDeps['verifyCredentials'],
+    });
+    const { app } = buildApp(deps);
+
+    // Per-IP limit is 5. Rotate the email each time so the per-(IP,email)
+    // bucket never trips first — only the per-IP bucket should fire.
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app)
+        .post('/auth/login')
+        .send({ email: `u${i}@example.com`, password: 'hunter2!secure' });
+      expect(res.status).toBe(401);
+    }
+
+    const tripped = await request(app)
+      .post('/auth/login')
+      .send({ email: 'u-final@example.com', password: 'hunter2!secure' });
+    expect(tripped.status).toBe(429);
+    expect(tripped.headers['retry-after']).toBeDefined();
+  });
+});

--- a/routes-d/tests/auth.totp.test.ts
+++ b/routes-d/tests/auth.totp.test.ts
@@ -1,0 +1,297 @@
+import express from 'express';
+import request from 'supertest';
+import {
+  TotpSecretStore,
+  base32Decode,
+  base32Encode,
+  decryptSecret,
+  encryptSecret,
+  formatOtpAuthUrl,
+  generateTotp,
+  verifyTotp,
+} from '../lib/totp.js';
+import { createTotpRouter } from '../routes/auth.totp.js';
+
+function buildApp(store: TotpSecretStore) {
+  const app = express();
+  app.use(express.json());
+  app.use(createTotpRouter({ store, issuer: 'Nextellar' }));
+  return app;
+}
+
+describe('base32 round-trip', () => {
+  it('encodes and decodes back to the original bytes', () => {
+    const buf = Buffer.from('test-vector-bytes', 'utf8');
+    const encoded = base32Encode(buf);
+    expect(encoded).toMatch(/^[A-Z2-7]+$/);
+    expect(base32Decode(encoded)).toEqual(buf);
+  });
+
+  it('rejects invalid characters', () => {
+    expect(() => base32Decode('NOT_BASE32!')).toThrow();
+  });
+});
+
+describe('encryptSecret / decryptSecret', () => {
+  it('round-trips arbitrary bytes', () => {
+    const plain = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const encrypted = encryptSecret(plain);
+    expect(encrypted.iv).toBeTruthy();
+    expect(encrypted.ciphertext).toBeTruthy();
+    expect(encrypted.authTag).toBeTruthy();
+    expect(decryptSecret(encrypted)).toEqual(plain);
+  });
+
+  it('produces a different ciphertext on every call (random IV)', () => {
+    const plain = Buffer.from('same input');
+    const a = encryptSecret(plain);
+    const b = encryptSecret(plain);
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(a.iv).not.toBe(b.iv);
+  });
+
+  it('rejects tampered ciphertexts', () => {
+    const encrypted = encryptSecret(Buffer.from('secret'));
+    const tampered = {
+      ...encrypted,
+      ciphertext: Buffer.from(
+        Buffer.from(encrypted.ciphertext, 'base64')
+          .map((b, i) => (i === 0 ? b ^ 0x01 : b)),
+      ).toString('base64'),
+    };
+    expect(() => decryptSecret(tampered)).toThrow();
+  });
+});
+
+describe('generateTotp / verifyTotp', () => {
+  it('generates a 6-digit code that verifies at the same instant', () => {
+    const secret = Buffer.from('12345678901234567890', 'utf8');
+    const code = generateTotp(secret, 59_000);
+    expect(code).toMatch(/^\d{6}$/);
+    expect(verifyTotp(secret, code, { timestampMs: 59_000 })).toEqual({
+      ok: true,
+      counter: Math.floor(59 / 30),
+    });
+  });
+
+  it('accepts a code generated one step in the past (drift)', () => {
+    const secret = Buffer.from('drift-test-secret');
+    const codeAtPrev = generateTotp(secret, 0);
+    const result = verifyTotp(secret, codeAtPrev, { timestampMs: 30_000 });
+    expect(result.ok).toBe(true);
+    expect(result.counter).toBe(0);
+  });
+
+  it('rejects codes outside the drift window', () => {
+    const secret = Buffer.from('drift-test-secret');
+    const codeAtPrev = generateTotp(secret, 0);
+    // 5 steps later — outside default ±1 drift.
+    const result = verifyTotp(secret, codeAtPrev, {
+      timestampMs: 150_000,
+      driftSteps: 1,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects malformed input', () => {
+    const secret = Buffer.from('secret');
+    expect(verifyTotp(secret, 'abcdef').ok).toBe(false);
+    expect(verifyTotp(secret, '12345').ok).toBe(false);
+  });
+});
+
+describe('formatOtpAuthUrl', () => {
+  it('encodes label and required query params', () => {
+    const url = formatOtpAuthUrl({
+      secretBase32: 'JBSWY3DPEHPK3PXP',
+      accountName: 'user@example.com',
+      issuer: 'Nextellar',
+    });
+    expect(url).toMatch(/^otpauth:\/\/totp\/Nextellar%3Auser%40example\.com\?/);
+    expect(url).toMatch(/secret=JBSWY3DPEHPK3PXP/);
+    expect(url).toMatch(/issuer=Nextellar/);
+    expect(url).toMatch(/algorithm=SHA1/);
+    expect(url).toMatch(/digits=6/);
+    expect(url).toMatch(/period=30/);
+  });
+});
+
+describe('TotpSecretStore', () => {
+  it('starts an enrolment as pending and activates on first verify', () => {
+    const store = new TotpSecretStore();
+    const { record, secretBase32 } = store.startEnrollment('user-1');
+    expect(record.state).toBe('pending');
+    expect(secretBase32).toMatch(/^[A-Z2-7]+$/);
+    expect(store.isActive('user-1')).toBe(false);
+
+    const secret = decryptSecret(record.encrypted);
+    const code = generateTotp(secret);
+    expect(store.verifyAndConsume('user-1', code)).toEqual({ ok: true });
+    expect(store.isActive('user-1')).toBe(true);
+  });
+
+  it('rejects an unknown user', () => {
+    const store = new TotpSecretStore();
+    expect(store.verifyAndConsume('ghost', '123456')).toEqual({
+      ok: false,
+      reason: 'unknown',
+    });
+  });
+
+  it('rejects a wrong code', () => {
+    const store = new TotpSecretStore();
+    store.startEnrollment('user-1');
+    expect(store.verifyAndConsume('user-1', '000000')).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  it('rejects replay of the same OTP', () => {
+    const store = new TotpSecretStore();
+    const { record } = store.startEnrollment('user-1');
+    const secret = decryptSecret(record.encrypted);
+    const code = generateTotp(secret);
+
+    expect(store.verifyAndConsume('user-1', code)).toEqual({ ok: true });
+    // Same code presented again inside the same step → must be rejected
+    // as a replay, not silently accepted.
+    expect(store.verifyAndConsume('user-1', code)).toEqual({
+      ok: false,
+      reason: 'replay',
+    });
+  });
+
+  it('disable() forgets the record so a fresh enrolment can begin', () => {
+    const store = new TotpSecretStore();
+    const { record } = store.startEnrollment('user-1');
+    const secret = decryptSecret(record.encrypted);
+    store.verifyAndConsume('user-1', generateTotp(secret));
+    expect(store.isActive('user-1')).toBe(true);
+
+    expect(store.disable('user-1')).toBe(true);
+    expect(store.isActive('user-1')).toBe(false);
+    expect(store.disable('user-1')).toBe(false);
+  });
+});
+
+describe('POST /auth/totp/enroll', () => {
+  it('returns 401 when no user can be resolved', async () => {
+    const store = new TotpSecretStore();
+    const app = buildApp(store);
+    const res = await request(app).post('/auth/totp/enroll').send({});
+    expect(res.status).toBe(401);
+  });
+
+  it('returns a base32 secret and an otpauth URI', async () => {
+    const store = new TotpSecretStore();
+    const app = buildApp(store);
+    const res = await request(app)
+      .post('/auth/totp/enroll')
+      .send({ userId: 'user-1', email: 'user@example.com' });
+    expect(res.status).toBe(200);
+    expect(res.body.secret).toMatch(/^[A-Z2-7]+$/);
+    expect(res.body.otpauthUrl).toMatch(
+      /^otpauth:\/\/totp\/Nextellar%3Auser%40example\.com\?/,
+    );
+    expect(store.inspect('user-1')?.state).toBe('pending');
+  });
+});
+
+describe('POST /auth/totp/verify', () => {
+  it('400s on a non-6-digit code', async () => {
+    const store = new TotpSecretStore();
+    store.startEnrollment('user-1');
+    const app = buildApp(store);
+    const res = await request(app)
+      .post('/auth/totp/verify')
+      .send({ userId: 'user-1', code: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  it('200s on a correct code and activates the enrolment', async () => {
+    const store = new TotpSecretStore();
+    const { record } = store.startEnrollment('user-1');
+    const secret = decryptSecret(record.encrypted);
+    const code = generateTotp(secret);
+    const app = buildApp(store);
+
+    const res = await request(app)
+      .post('/auth/totp/verify')
+      .send({ userId: 'user-1', code });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, active: true });
+  });
+
+  it('rejects a replayed code with 401 and reason=replay', async () => {
+    const store = new TotpSecretStore();
+    const { record } = store.startEnrollment('user-1');
+    const secret = decryptSecret(record.encrypted);
+    const code = generateTotp(secret);
+    const app = buildApp(store);
+
+    const first = await request(app)
+      .post('/auth/totp/verify')
+      .send({ userId: 'user-1', code });
+    expect(first.status).toBe(200);
+
+    const replay = await request(app)
+      .post('/auth/totp/verify')
+      .send({ userId: 'user-1', code });
+    expect(replay.status).toBe(401);
+    expect(replay.body).toEqual({
+      error: 'invalid totp code',
+      reason: 'replay',
+    });
+  });
+});
+
+describe('POST /auth/totp/disable', () => {
+  it('404s when TOTP is not active', async () => {
+    const store = new TotpSecretStore();
+    const app = buildApp(store);
+    const res = await request(app)
+      .post('/auth/totp/disable')
+      .send({ userId: 'user-1', code: '123456' });
+    expect(res.status).toBe(404);
+  });
+
+  it('400s on a malformed code', async () => {
+    const store = new TotpSecretStore();
+    const { record } = store.startEnrollment('user-1');
+    const secret = decryptSecret(record.encrypted);
+    // Activate first.
+    store.verifyAndConsume('user-1', generateTotp(secret));
+    const app = buildApp(store);
+
+    const res = await request(app)
+      .post('/auth/totp/disable')
+      .send({ userId: 'user-1', code: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  it('disables TOTP when the code is valid and not a replay', async () => {
+    const store = new TotpSecretStore();
+    const { record } = store.startEnrollment('user-1');
+    const secret = decryptSecret(record.encrypted);
+
+    // Activate the enrolment with a code from far in the past so the
+    // current-time code is on a much later counter and cannot collide
+    // with the activation counter (which would otherwise be rejected as
+    // a replay).
+    const farPast = 0;
+    store.verifyAndConsume('user-1', generateTotp(secret, farPast), {
+      timestampMs: farPast,
+    });
+    expect(store.isActive('user-1')).toBe(true);
+
+    const app = buildApp(store);
+    const currentCode = generateTotp(secret);
+    const res = await request(app)
+      .post('/auth/totp/disable')
+      .send({ userId: 'user-1', code: currentCode });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(store.isActive('user-1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two routes-d contributions, both fully scoped to the `routes-d/` workspace and not touching any code outside it:

- **Login route with IP+email rate limiting** — `POST /auth/login` with a sliding-window limiter keyed independently on IP and IP+email so neither IP rotation nor email rotation alone defeats it. Thresholds come from `NEXTELLAR_LOGIN_RATE_WINDOW_MS`, `NEXTELLAR_LOGIN_RATE_IP_LIMIT`, `NEXTELLAR_LOGIN_RATE_IP_EMAIL_LIMIT` (sensible defaults if unset). Rejected requests get a 429 with `Retry-After` in seconds (RFC 7231). The credential check and session issuance are dependency-injected so the route stays storage-agnostic; production wiring replaces the throwing stubs. Honors the existing TOTP step-up by responding `{ totpRequired: true }` and *not* issuing a session when the verifier signals it.
- **TOTP two-factor endpoints** — `POST /auth/totp/{enroll,verify,disable}`. Pure-Node TOTP (RFC 6238, HMAC-SHA1, 6 digits, 30s period, ±1 step drift, constant-time comparison) so no new deps are pulled in. Shared secrets are encrypted at rest with AES-256-GCM keyed off `NEXTELLAR_TOTP_ENC_KEY` (scrypt-derived). The store tracks `lastUsedCounter` so the same OTP can't be replayed inside the drift window. Enrolment is two-step (`enroll` returns an `otpauth://` URI + base32 secret; `verify` activates it on the first successful code). `disable` requires a fresh valid code so a stolen session alone can't turn 2FA off.

Closes #256 and closes #258 — both wired into the same branch to keep history tidy. ~1.4k LOC of code + tests; no files outside `routes-d/` are modified.

closes #256
closes #258

## Files added

- routes-d/middleware/rateLimit.ts
- routes-d/routes/auth.login.ts
- routes-d/tests/auth.login.test.ts
- routes-d/lib/totp.ts
- routes-d/routes/auth.totp.ts
- routes-d/tests/auth.totp.test.ts

## Tests

Ran locally with the project's existing jest configuration:

\`\`\`
NODE_OPTIONS="--experimental-vm-modules --no-warnings" jest routes-d/tests/auth.login.test.ts routes-d/tests/auth.totp.test.ts
Test Suites: 2 passed, 2 total
Tests:       34 passed, 34 total
\`\`\`

Coverage highlights:
- Sliding-window limiter: limit enforcement, window-roll-off, retry-after math, constructor validation.
- /auth/login: input validation (400), wrong creds (401, generic), TOTP step-up signal (200, no session), happy path (200, token), per-email 429 with Retry-After (verifier not invoked on rejected attempt), per-IP 429 across rotating emails.
- TOTP lib: base32 round-trip, encrypt/decrypt round-trip + tamper rejection + random IV, code generation/verify at boundary, drift acceptance ±1 step, drift rejection outside window, malformed input.
- /auth/totp: enroll without user → 401; enroll returns base32 + otpauth URI; verify malformed → 400; correct code activates; replay → 401 reason=replay; disable not enrolled → 404; disable malformed code → 400; disable success → 200.

## Notes / disclosure

- I could not run the upstream-wide tooling (`build:content`, `check:links`, root-wide test suite) because the repo's root tooling has pre-existing failures on a clean main checkout, independent of this change. CI is the source of truth — please flag anything new that turns red and I'll address it.
- Both implementations follow the established routes-d patterns (DI-able deps via a module-level singleton, narrow in-memory store designed to be swapped for a persistent backend, status codes/shape matching the existing `auth.password.ts` / `auth.refresh.ts` files).