### PR TITLE
Add routes-d Stellar fee-bump endpoint

### DIFF
--- a/routes-d/routes/stellar.tx.feebump.ts
+++ b/routes-d/routes/stellar.tx.feebump.ts
@@ -1,0 +1,197 @@
+// POST /stellar/tx/feebump - wraps a user-signed inner transaction in a
+// server-paid Stellar fee-bump transaction.
+
+import { Router, type Request, type Response } from "express";
+import {
+  FeeBumpTransaction,
+  Keypair,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+
+export interface FeeBumpRequest {
+  /** Base64/XDR encoded user-signed inner transaction envelope. */
+  innerEnvelope: string;
+  /** Fee-bump fee in stroops. Must not exceed the configured cap. */
+  bumpFee: string;
+}
+
+export interface FeeBumpBuilder {
+  build(input: {
+    feeSource: string;
+    fee: string;
+    innerTransaction: Transaction;
+    networkPassphrase: string;
+  }): FeeBumpTransaction;
+}
+
+export interface FeeBumpSigner {
+  publicKey: string;
+  sign(transaction: FeeBumpTransaction): void | Promise<void>;
+}
+
+export interface FeeBumpRouterOptions {
+  signer: FeeBumpSigner;
+  networkPassphrase: string;
+  maxBumpFee: string | number | bigint;
+  builder?: FeeBumpBuilder;
+}
+
+export class FeeBumpValidationError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "FeeBumpValidationError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function readBody(body: unknown): FeeBumpRequest | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  const innerEnvelope = typeof b.innerEnvelope === "string" ? b.innerEnvelope.trim() : "";
+  const bumpFee = typeof b.bumpFee === "string" || typeof b.bumpFee === "number" || typeof b.bumpFee === "bigint"
+    ? String(b.bumpFee).trim()
+    : "";
+
+  if (!innerEnvelope || !bumpFee) return null;
+  return { innerEnvelope, bumpFee };
+}
+
+function parsePositiveInteger(value: string | number | bigint, label: string): bigint {
+  const raw = String(value).trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new FeeBumpValidationError(400, "invalid_fee", `${label} must be a positive integer stroop amount`);
+  }
+  return BigInt(raw);
+}
+
+export function validateBumpFee(
+  bumpFee: string | number | bigint,
+  maxBumpFee: string | number | bigint,
+): string {
+  const requested = parsePositiveInteger(bumpFee, "bumpFee");
+  const maximum = parsePositiveInteger(maxBumpFee, "maxBumpFee");
+
+  if (requested > maximum) {
+    throw new FeeBumpValidationError(
+      422,
+      "fee_cap_exceeded",
+      `bumpFee exceeds configured maximum of ${maximum.toString()} stroops`,
+    );
+  }
+
+  return requested.toString();
+}
+
+export function parseInnerTransaction(
+  innerEnvelope: string,
+  networkPassphrase: string,
+): Transaction {
+  let parsed: Transaction | FeeBumpTransaction;
+  try {
+    parsed = TransactionBuilder.fromXDR(innerEnvelope, networkPassphrase);
+  } catch {
+    throw new FeeBumpValidationError(400, "malformed_inner", "innerEnvelope is not a valid transaction envelope");
+  }
+
+  if (parsed instanceof FeeBumpTransaction) {
+    throw new FeeBumpValidationError(400, "malformed_inner", "innerEnvelope must not already be a fee-bump transaction");
+  }
+
+  if (!Array.isArray(parsed.signatures) || parsed.signatures.length === 0) {
+    throw new FeeBumpValidationError(400, "unsigned_inner", "innerEnvelope must include at least one user signature");
+  }
+
+  return parsed;
+}
+
+export function loadFeeBumpSignerFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): FeeBumpSigner {
+  const secret = env.STELLAR_FEE_BUMP_SECRET;
+  if (!secret) {
+    throw new Error("STELLAR_FEE_BUMP_SECRET must be set to enable fee bumping");
+  }
+
+  const keypair = Keypair.fromSecret(secret);
+  return {
+    publicKey: keypair.publicKey(),
+    sign: (transaction) => {
+      transaction.sign(keypair);
+    },
+  };
+}
+
+export function readMaxBumpFeeFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.STELLAR_FEE_BUMP_MAX_FEE ?? "1000000";
+  validateBumpFee(configured, configured);
+  return configured;
+}
+
+export function createFeeBumpRouter(options: FeeBumpRouterOptions): Router {
+  const maxBumpFee = validateBumpFee(options.maxBumpFee, options.maxBumpFee);
+  const builder: FeeBumpBuilder = options.builder ?? {
+    build: ({ feeSource, fee, innerTransaction, networkPassphrase }) =>
+      TransactionBuilder.buildFeeBumpTransaction(
+        feeSource,
+        fee,
+        innerTransaction,
+        networkPassphrase,
+      ),
+  };
+
+  const router = Router();
+
+  router.post("/feebump", async (req: Request, res: Response) => {
+    const body = readBody(req.body);
+    if (!body) {
+      res.status(400).json({
+        ok: false,
+        code: "invalid_request",
+        error: "innerEnvelope and bumpFee are required",
+      });
+      return;
+    }
+
+    let bumpFee: string;
+    let innerTransaction: Transaction;
+    try {
+      bumpFee = validateBumpFee(body.bumpFee, maxBumpFee);
+      innerTransaction = parseInnerTransaction(body.innerEnvelope, options.networkPassphrase);
+    } catch (error) {
+      if (error instanceof FeeBumpValidationError) {
+        res.status(error.status).json({ ok: false, code: error.code, error: error.message });
+        return;
+      }
+      throw error;
+    }
+
+    let feeBump: FeeBumpTransaction;
+    try {
+      feeBump = builder.build({
+        feeSource: options.signer.publicKey,
+        fee: bumpFee,
+        innerTransaction,
+        networkPassphrase: options.networkPassphrase,
+      });
+      await options.signer.sign(feeBump);
+    } catch {
+      res.status(500).json({ ok: false, code: "fee_bump_failed", error: "failed to build fee-bump transaction" });
+      return;
+    }
+
+    res.status(200).json({
+      ok: true,
+      feeSource: options.signer.publicKey,
+      bumpFee,
+      envelope: feeBump.toXDR(),
+    });
+  });
+
+  return router;
+}
+

--- a/routes-d/tests/stellar.tx.feebump.integration.test.ts
+++ b/routes-d/tests/stellar.tx.feebump.integration.test.ts
@@ -1,0 +1,91 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import {
+  Account,
+  BASE_FEE,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { createFeeBumpRouter } from "../routes/stellar.tx.feebump.js";
+
+function buildSignedInner(): string {
+  const user = Keypair.random();
+  const tx = new TransactionBuilder(new Account(user.publicKey(), "1"), {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(Operation.manageData({ name: "fee-bump-route", value: "ok" }))
+    .setTimeout(30)
+    .build();
+
+  tx.sign(user);
+  return tx.toXDR();
+}
+
+function buildApp(server: Keypair, maxBumpFee = "1000"): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/stellar/tx",
+    createFeeBumpRouter({
+      signer: {
+        publicKey: server.publicKey(),
+        sign: (transaction) => {
+          transaction.sign(server);
+        },
+      },
+      networkPassphrase: Networks.TESTNET,
+      maxBumpFee,
+    }),
+  );
+  return app;
+}
+
+describe("POST /stellar/tx/feebump", () => {
+  it("wraps a valid signed inner transaction in a server-signed fee bump envelope", async () => {
+    const server = Keypair.random();
+    const res = await request(buildApp(server))
+      .post("/stellar/tx/feebump")
+      .send({ innerEnvelope: buildSignedInner(), bumpFee: "500" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      feeSource: server.publicKey(),
+      bumpFee: "500",
+    });
+    expect(typeof res.body.envelope).toBe("string");
+
+    const parsed = TransactionBuilder.fromXDR(res.body.envelope, Networks.TESTNET);
+    expect(parsed).toBeInstanceOf(FeeBumpTransaction);
+    expect(parsed.signatures.length).toBe(1);
+  });
+
+  it("rejects malformed inner envelopes before building the fee bump transaction", async () => {
+    const res = await request(buildApp(Keypair.random()))
+      .post("/stellar/tx/feebump")
+      .send({ innerEnvelope: "not-xdr", bumpFee: "500" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      ok: false,
+      code: "malformed_inner",
+    });
+  });
+
+  it("rejects bump fees above the configured cap", async () => {
+    const res = await request(buildApp(Keypair.random(), "100"))
+      .post("/stellar/tx/feebump")
+      .send({ innerEnvelope: buildSignedInner(), bumpFee: "101" });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      ok: false,
+      code: "fee_cap_exceeded",
+    });
+  });
+});
+

--- a/routes-d/tests/stellar.tx.feebump.unit.test.ts
+++ b/routes-d/tests/stellar.tx.feebump.unit.test.ts
@@ -1,0 +1,101 @@
+import {
+  Account,
+  BASE_FEE,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import {
+  FeeBumpValidationError,
+  loadFeeBumpSignerFromEnv,
+  parseInnerTransaction,
+  readMaxBumpFeeFromEnv,
+  validateBumpFee,
+} from "../routes/stellar.tx.feebump.js";
+
+function buildSignedInner(): string {
+  const user = Keypair.random();
+  const tx = new TransactionBuilder(new Account(user.publicKey(), "1"), {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(Operation.manageData({ name: "fee-bump-test", value: "ok" }))
+    .setTimeout(30)
+    .build();
+
+  tx.sign(user);
+  return tx.toXDR();
+}
+
+describe("validateBumpFee", () => {
+  it("returns the normalized fee when it is within the cap", () => {
+    expect(validateBumpFee("500", "1000")).toBe("500");
+  });
+
+  it("rejects malformed fees", () => {
+    expect(() => validateBumpFee("not-a-fee", "1000")).toThrow(FeeBumpValidationError);
+    expect(() => validateBumpFee("0", "1000")).toThrow(/positive integer/);
+  });
+
+  it("rejects fees above the configured cap", () => {
+    expect(() => validateBumpFee("1001", "1000")).toThrow(/exceeds configured maximum/);
+  });
+});
+
+describe("parseInnerTransaction", () => {
+  it("parses a signed inner transaction", () => {
+    const tx = parseInnerTransaction(buildSignedInner(), Networks.TESTNET);
+    expect(tx.signatures.length).toBe(1);
+  });
+
+  it("rejects malformed inner envelopes", () => {
+    expect(() => parseInnerTransaction("definitely-not-xdr", Networks.TESTNET)).toThrow(/valid transaction envelope/);
+  });
+
+  it("rejects unsigned inner envelopes", () => {
+    const user = Keypair.random();
+    const tx = new TransactionBuilder(new Account(user.publicKey(), "1"), {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(Operation.manageData({ name: "fee-bump-test", value: "unsigned" }))
+      .setTimeout(30)
+      .build();
+
+    expect(() => parseInnerTransaction(tx.toXDR(), Networks.TESTNET)).toThrow(/at least one user signature/);
+  });
+
+  it("rejects envelopes that are already fee-bump transactions", () => {
+    const server = Keypair.random();
+    const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+      server.publicKey(),
+      "100",
+      parseInnerTransaction(buildSignedInner(), Networks.TESTNET),
+      Networks.TESTNET,
+    );
+
+    expect(feeBump).toBeInstanceOf(FeeBumpTransaction);
+    expect(() => parseInnerTransaction(feeBump.toXDR(), Networks.TESTNET)).toThrow(/must not already/);
+  });
+});
+
+describe("fee-bump env helpers", () => {
+  it("loads a signer from STELLAR_FEE_BUMP_SECRET", () => {
+    const keypair = Keypair.random();
+    const signer = loadFeeBumpSignerFromEnv({ STELLAR_FEE_BUMP_SECRET: keypair.secret() });
+
+    expect(signer.publicKey).toBe(keypair.publicKey());
+  });
+
+  it("throws when the fee-bump secret is missing", () => {
+    expect(() => loadFeeBumpSignerFromEnv({})).toThrow(/must be set/);
+  });
+
+  it("reads and validates the max fee cap from env", () => {
+    expect(readMaxBumpFeeFromEnv({ STELLAR_FEE_BUMP_MAX_FEE: "12345" })).toBe("12345");
+    expect(() => readMaxBumpFeeFromEnv({ STELLAR_FEE_BUMP_MAX_FEE: "bad" })).toThrow(/positive integer/);
+  });
+});
+


### PR DESCRIPTION
## Summary #283 

Implements issue #283 by adding a `routes-d` Stellar fee-bump transaction endpoint that wraps a user-signed inner transaction with a server-paid fee-bump envelope.

All implementation and tests are scoped to `routes-d/`.

## Changes

- Added `routes-d/routes/stellar.tx.feebump.ts`
  - Exposes `createFeeBumpRouter`
  - Adds `POST /feebump`
  - Parses and validates the provided inner transaction envelope before fee bumping
  - Rejects malformed, unsigned, or already fee-bumped inner envelopes
  - Enforces a configurable maximum bump fee
  - Signs the resulting fee-bump transaction with the configured server signer
  - Includes env helpers for `STELLAR_FEE_BUMP_SECRET` and `STELLAR_FEE_BUMP_MAX_FEE`

- Added unit tests under `routes-d/tests/stellar.tx.feebump.unit.test.ts`
  - Validates fee cap behavior
  - Covers malformed fee inputs
  - Covers inner transaction validation
  - Covers env helper behavior

- Added integration tests under `routes-d/tests/stellar.tx.feebump.integration.test.ts`
  - Covers valid fee-bump wrapping
  - Covers malformed inner envelope rejection
  - Covers fee cap rejection

## Validation

Passed issue-specific checks:

```powershell
$env:NODE_OPTIONS='--experimental-vm-modules'
npx jest --config jest.config.js --runInBand --runTestsByPath tests/stellar.tx.feebump.unit.test.ts tests/stellar.tx.feebump.integration.test.ts

Closes #283 