### PR TITLE
feat(routes-d): CORS validator and security headers middleware

### DIFF
--- a/routes-d/docs/security.md
+++ b/routes-d/docs/security.md
@@ -1,0 +1,109 @@
+# Security Headers — routes-d
+
+This document describes the baseline security headers applied by
+`routes-d/middleware/secureHeaders.ts` and the rationale behind each chosen
+value. It also covers when and how to opt out of a header on a per-route basis.
+
+---
+
+## Applied Headers and Values
+
+### `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+
+Instructs browsers to use HTTPS exclusively for this origin (and all
+subdomains) for 365 days after the most recent response. Prevents SSL-stripping
+attacks and downgrade attempts.
+
+**`includeSubDomains`** is included because Nextellar's API, admin panel, and
+staging environments all share the same top-level domain. Remove this directive
+only when a subdomain is intentionally served over plain HTTP (e.g., a static
+asset CDN that pre-dates the HTTPS migration).
+
+### `X-Content-Type-Options: nosniff`
+
+Prevents browsers from MIME-sniffing a response away from the declared
+`Content-Type`. Without this header a browser could interpret a JSON payload as
+executable HTML, enabling reflected-XSS vectors on older Chromium and IE
+versions.
+
+This header should almost never be omitted.
+
+### `Referrer-Policy: strict-origin-when-cross-origin`
+
+Controls how much of the URL is included in the `Referer` header on outgoing
+navigation:
+
+| Request type | Value sent |
+|---|---|
+| Same origin | Full URL |
+| Cross-origin, HTTPS → HTTPS | Origin only (`https://app.nextellar.dev`) |
+| Cross-origin, HTTPS → HTTP | Nothing |
+
+This balances analytics usefulness (same-origin full URL) against privacy
+(no path leakage to third parties over HTTPS, nothing at all on downgrade).
+
+### `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`
+
+Disables browser features that Nextellar does not use. An empty list `()` means
+_no origin_ — including the page itself — is allowed to use that feature.
+This limits the blast radius if a dependency or injected script tries to access
+sensitive device APIs.
+
+Extend the list if future features require additional permissions:
+```
+Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(self)
+```
+
+---
+
+## Opt-Out — Per-Route Exceptions
+
+Use the `secureHeaders({ omit: [...] })` factory instead of the global
+`app.use(secureHeaders())` for routes that legitimately cannot carry a
+particular header.
+
+```ts
+import { secureHeaders } from "../middleware/secureHeaders.js";
+
+// Health-check served over plain HTTP in local dev — HSTS would break it.
+app.get(
+  "/health",
+  secureHeaders({ omit: ["Strict-Transport-Security"] }),
+  healthHandler,
+);
+
+// Legacy iframe integration requires relaxed Referrer-Policy.
+app.get(
+  "/embed/widget",
+  secureHeaders({ omit: ["Referrer-Policy"] }),
+  widgetHandler,
+);
+```
+
+**Rules for opt-outs:**
+
+1. Document the reason in a code comment next to the route definition.
+2. Omit only the specific header that causes the conflict; keep all others.
+3. Prefer fixing the underlying conflict (e.g., move the route behind HTTPS)
+   over a permanent opt-out.
+4. Opt-outs must be reviewed in code review; do not merge without justification.
+
+---
+
+## Adding or Changing a Header Value
+
+Edit `SECURE_HEADER_DEFAULTS` in `routes-d/middleware/secureHeaders.ts`.
+The tests in `routes-d/tests/middleware/secureHeaders.test.ts` validate the
+presence and value of each header — update them to reflect any intentional
+change.
+
+Before removing a header entirely, verify the reason and update this document.
+
+---
+
+## References
+
+- [MDN — HTTP Security Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#security)
+- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)
+- [RFC 6797 — HSTS](https://datatracker.ietf.org/doc/html/rfc6797)
+- [Permissions Policy specification](https://www.w3.org/TR/permissions-policy/)

--- a/routes-d/middleware/cors.ts
+++ b/routes-d/middleware/cors.ts
@@ -1,0 +1,78 @@
+import type { Request, Response, NextFunction } from "express";
+
+const DEFAULT_ALLOWED_METHODS = "GET,POST,PUT,PATCH,DELETE,OPTIONS";
+const DEFAULT_ALLOWED_HEADERS = "Content-Type, Authorization";
+
+/**
+ * Parse the ALLOWED_ORIGINS environment variable into a Set.
+ * Accepts a comma-separated list of exact origin strings.
+ * An empty or absent value means no origin is permitted.
+ */
+function parseAllowedOrigins(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * CORS allowed-origin validator middleware for routes-d.
+ *
+ * Behaviour:
+ * - Requests with no Origin header pass through untouched.
+ * - Requests whose Origin is in the ALLOWED_ORIGINS allowlist receive the
+ *   standard CORS headers including `Access-Control-Allow-Credentials: true`.
+ * - Requests from an unlisted origin are rejected with 403 and **no**
+ *   Access-Control-Allow-Origin header is written, so the disallowed origin
+ *   is never echoed back to the client.
+ *
+ * Configuration (environment variables):
+ * - ALLOWED_ORIGINS  Comma-separated list of exact origins to permit.
+ *                    Example: https://app.nextellar.dev,https://admin.nextellar.dev
+ */
+export function corsMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const requestOrigin = req.header("Origin");
+
+  // No Origin header — same-origin or non-browser request; proceed normally.
+  if (!requestOrigin) {
+    next();
+    return;
+  }
+
+  const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+
+  if (!allowedOrigins.has(requestOrigin)) {
+    // Reject without reflecting the origin in any header.
+    res.status(403).json({ success: false, message: "Origin not allowed" });
+    return;
+  }
+
+  // Allowlisted: set precise CORS headers and enable credentials.
+  res.setHeader("Access-Control-Allow-Origin", requestOrigin);
+  res.setHeader("Access-Control-Allow-Credentials", "true");
+  res.setHeader("Access-Control-Allow-Methods", DEFAULT_ALLOWED_METHODS);
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    req.header("Access-Control-Request-Headers") ?? DEFAULT_ALLOWED_HEADERS,
+  );
+  // Vary: Origin prevents caches from serving a cached ACAO header to a
+  // different origin.
+  res.setHeader("Vary", "Origin");
+
+  // Handle CORS preflight.
+  if (req.method === "OPTIONS") {
+    res.sendStatus(204);
+    return;
+  }
+
+  next();
+}
+
+export default corsMiddleware;

--- a/routes-d/middleware/secureHeaders.ts
+++ b/routes-d/middleware/secureHeaders.ts
@@ -1,0 +1,59 @@
+import type { Request, Response, NextFunction } from "express";
+
+/**
+ * Default security header values applied to every response unless opted out.
+ *
+ * See routes-d/docs/security.md for rationale and opt-out guidance.
+ */
+export const SECURE_HEADER_DEFAULTS = {
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy":
+    "camera=(), microphone=(), geolocation=(), payment=()",
+} as const;
+
+export type SecureHeaderName = keyof typeof SECURE_HEADER_DEFAULTS;
+
+/**
+ * Options accepted by the per-route opt-out helper.
+ */
+export interface SecureHeadersOptions {
+  /**
+   * Headers to omit for this specific route.
+   * Pass an array of header names (keys of SECURE_HEADER_DEFAULTS).
+   *
+   * Example — disable HSTS on a health-check route that is also served over
+   * plain HTTP in local dev:
+   *   secureHeaders({ omit: ["Strict-Transport-Security"] })
+   */
+  omit?: SecureHeaderName[];
+}
+
+/**
+ * Middleware factory that sets baseline security headers.
+ *
+ * Usage — global (apply to every route):
+ *   app.use(secureHeaders());
+ *
+ * Usage — per-route opt-out:
+ *   app.get("/health", secureHeaders({ omit: ["Strict-Transport-Security"] }), handler);
+ */
+export function secureHeaders(options: SecureHeadersOptions = {}) {
+  const omitSet = new Set<string>(options.omit ?? []);
+
+  return function secureHeadersMiddleware(
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    for (const [name, value] of Object.entries(SECURE_HEADER_DEFAULTS)) {
+      if (!omitSet.has(name)) {
+        res.setHeader(name, value);
+      }
+    }
+    next();
+  };
+}
+
+export default secureHeaders;

--- a/routes-d/tests/middleware/cors.test.ts
+++ b/routes-d/tests/middleware/cors.test.ts
@@ -1,0 +1,151 @@
+import express from "express";
+import request from "supertest";
+import corsMiddleware from "../../middleware/cors.js";
+
+const ORIGINAL_ENV = process.env;
+
+function buildApp() {
+  const app = express();
+  app.use(corsMiddleware);
+  app.get("/ping", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+}
+
+describe("routes-d corsMiddleware", () => {
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      ALLOWED_ORIGINS:
+        "https://app.nextellar.dev,https://admin.nextellar.dev",
+    };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  // ── Allowed origins ────────────────────────────────────────────────────────
+
+  it("allows an explicitly allowlisted origin", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://app.nextellar.dev");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://app.nextellar.dev",
+    );
+  });
+
+  it("allows the second allowlisted origin", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://admin.nextellar.dev");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://admin.nextellar.dev",
+    );
+  });
+
+  // ── Credentialed requests ──────────────────────────────────────────────────
+
+  it("sets Access-Control-Allow-Credentials: true for allowlisted origins", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://app.nextellar.dev");
+
+    expect(res.headers["access-control-allow-credentials"]).toBe("true");
+  });
+
+  it("sets Vary: Origin to prevent cache poisoning", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://app.nextellar.dev");
+
+    expect(res.headers["vary"]).toMatch(/Origin/i);
+  });
+
+  // ── Disallowed origins ─────────────────────────────────────────────────────
+
+  it("rejects an unlisted origin with 403", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://evil.example.com");
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("Origin not allowed");
+  });
+
+  it("does NOT echo the disallowed origin in response headers", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://evil.example.com");
+
+    // The disallowed origin must never appear as ACAO — prevents leaking it.
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("does NOT set credentials header for a disallowed origin", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://evil.example.com");
+
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  // ── No Origin header ──────────────────────────────────────────────────────
+
+  it("passes through requests with no Origin header", async () => {
+    const app = buildApp();
+    const res = await request(app).get("/ping");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  // ── CORS preflight ────────────────────────────────────────────────────────
+
+  it("handles OPTIONS preflight for an allowed origin with 204", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .options("/ping")
+      .set("Origin", "https://app.nextellar.dev")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-methods"]).toContain("POST");
+  });
+
+  it("rejects OPTIONS preflight from a disallowed origin", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .options("/ping")
+      .set("Origin", "https://evil.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.status).toBe(403);
+  });
+
+  // ── Empty allowlist ───────────────────────────────────────────────────────
+
+  it("rejects all origins when ALLOWED_ORIGINS is empty", async () => {
+    process.env.ALLOWED_ORIGINS = "";
+    const app = buildApp();
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://app.nextellar.dev");
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/routes-d/tests/middleware/secureHeaders.test.ts
+++ b/routes-d/tests/middleware/secureHeaders.test.ts
@@ -1,0 +1,124 @@
+import express from "express";
+import request from "supertest";
+import {
+  secureHeaders,
+  SECURE_HEADER_DEFAULTS,
+} from "../../middleware/secureHeaders.js";
+
+function buildApp() {
+  const app = express();
+  app.use(secureHeaders());
+  app.get("/health", (_req, res) => res.status(200).json({ ok: true }));
+  return app;
+}
+
+describe("routes-d secureHeaders middleware", () => {
+  // ── Default header presence ────────────────────────────────────────────────
+
+  it("sets Strict-Transport-Security with correct max-age", async () => {
+    const res = await request(buildApp()).get("/health");
+
+    expect(res.headers["strict-transport-security"]).toBe(
+      SECURE_HEADER_DEFAULTS["Strict-Transport-Security"],
+    );
+  });
+
+  it("sets X-Content-Type-Options: nosniff", async () => {
+    const res = await request(buildApp()).get("/health");
+
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("sets Referrer-Policy", async () => {
+    const res = await request(buildApp()).get("/health");
+
+    expect(res.headers["referrer-policy"]).toBe(
+      SECURE_HEADER_DEFAULTS["Referrer-Policy"],
+    );
+  });
+
+  it("sets Permissions-Policy restricting sensitive APIs", async () => {
+    const res = await request(buildApp()).get("/health");
+
+    const pp = res.headers["permissions-policy"] as string;
+    expect(pp).toContain("camera=()");
+    expect(pp).toContain("microphone=()");
+    expect(pp).toContain("geolocation=()");
+  });
+
+  it("sets all four default security headers in one request", async () => {
+    const res = await request(buildApp()).get("/health");
+
+    expect(res.status).toBe(200);
+    for (const name of Object.keys(SECURE_HEADER_DEFAULTS)) {
+      expect(res.headers[name.toLowerCase()]).toBeDefined();
+    }
+  });
+
+  // ── Per-route opt-out ──────────────────────────────────────────────────────
+
+  it("omits HSTS when opted out on a specific route", async () => {
+    const app = express();
+    app.get(
+      "/internal",
+      secureHeaders({ omit: ["Strict-Transport-Security"] }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    );
+
+    const res = await request(app).get("/internal");
+
+    expect(res.headers["strict-transport-security"]).toBeUndefined();
+    // Other headers are still present
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("omits multiple headers when listed in omit array", async () => {
+    const app = express();
+    app.get(
+      "/legacy",
+      secureHeaders({
+        omit: ["Strict-Transport-Security", "Permissions-Policy"],
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    );
+
+    const res = await request(app).get("/legacy");
+
+    expect(res.headers["strict-transport-security"]).toBeUndefined();
+    expect(res.headers["permissions-policy"]).toBeUndefined();
+    // Non-omitted headers still applied
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["referrer-policy"]).toBeDefined();
+  });
+
+  it("applies all headers when omit is an empty array", async () => {
+    const app = express();
+    app.use(secureHeaders({ omit: [] }));
+    app.get("/full", (_req, res) => res.status(200).json({ ok: true }));
+
+    const res = await request(app).get("/full");
+
+    for (const name of Object.keys(SECURE_HEADER_DEFAULTS)) {
+      expect(res.headers[name.toLowerCase()]).toBeDefined();
+    }
+  });
+
+  // ── Does not break normal response flow ───────────────────────────────────
+
+  it("does not alter the response status code", async () => {
+    const res = await request(buildApp()).get("/health");
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block POST requests", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(secureHeaders());
+    app.post("/data", (_req, res) => res.status(201).json({ created: true }));
+
+    const res = await request(app).post("/data").send({ key: "value" });
+
+    expect(res.status).toBe(201);
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+});


### PR DESCRIPTION
## Summary

Implements two new middleware modules under `routes-d/` as required by the issue scope. All implementation lives in `routes-d/`; no files outside that folder were modified.

---

## Issue #319 — Create CORS allowed-origin validator in routes-d

**File:** `routes-d/middleware/cors.ts`

- Reads the allowlist from `ALLOWED_ORIGINS` env var (comma-separated exact origins)
- Requests with no `Origin` header pass through untouched
- Allowlisted origins receive `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials: true`, method/header grants, and `Vary: Origin`
- Disallowed origins are rejected with **403** and **no** `Access-Control-Allow-Origin` header — the unlisted origin is never echoed back
- OPTIONS preflight returns 204 for allowed origins, 403 for disallowed

**Tests:** `routes-d/tests/middleware/cors.test.ts` — 11 tests covering allowed origins, credentialed requests, disallowed rejection (no ACAO leakage), no-Origin pass-through, preflight, and empty allowlist.

---

## Issue #320 — Create default security headers middleware in routes-d

**File:** `routes-d/middleware/secureHeaders.ts`

Applies four baseline headers to every response by default:

| Header | Value |
|---|---|
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` |

Per-route opt-out via `secureHeaders({ omit: ["Strict-Transport-Security"] })` — omit only the specific header that conflicts; all others still apply.

**Documentation:** `routes-d/docs/security.md` — rationale for each value, opt-out rules and review requirements, and external references (RFC 6797, OWASP Secure Headers, MDN).

**Tests:** `routes-d/tests/middleware/secureHeaders.test.ts` — 10 tests covering header presence and values, single and multi-header opt-out, empty omit array, response code integrity, and POST requests.

---

## Test results

```
PASS routes-d/tests/middleware/cors.test.ts         (11 passed)
PASS routes-d/tests/middleware/secureHeaders.test.ts (10 passed)
```

Closes #312
Closes #313
Closes #319
Closes #320