### PR TITLE
docs: add routes-d/docs/rate-limits.md and auth.md

### DIFF
--- a/routes-d/docs/auth.md
+++ b/routes-d/docs/auth.md
@@ -1,0 +1,118 @@
+# API Authentication Guide — routes-d
+
+All routes-d endpoints (except `/health` and `/auth/login`) require a valid
+Bearer token in the `Authorization` header.
+
+---
+
+## Authentication Flows
+
+### 1. Email + Password
+
+```bash
+# Obtain access token
+curl -s -X POST https://api.nextellar.app/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"s3cr3t"}' | jq .
+
+# Response
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+  "refreshToken": "rt_abc123...",
+  "expiresIn": 900
+}
+```
+
+Use the `accessToken` as a Bearer token on every subsequent request:
+
+```bash
+curl https://api.nextellar.app/orders \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..."
+```
+
+---
+
+### 2. Token Refresh
+
+Access tokens expire after **15 minutes**. Use the refresh token to obtain a
+new pair without re-entering credentials.
+
+```bash
+curl -s -X POST https://api.nextellar.app/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refreshToken":"rt_abc123..."}' | jq .
+
+# Response
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...<new>",
+  "refreshToken": "rt_xyz789...<rotated>",
+  "expiresIn": 900
+}
+```
+
+> Refresh tokens are **rotated** on every use. The old token is invalidated immediately.
+
+---
+
+### 3. OAuth (GitHub / Google)
+
+```bash
+# Step 1 — redirect the user to the provider
+GET https://api.nextellar.app/auth/oauth/github
+
+# Step 2 — callback (handled server-side)
+GET https://api.nextellar.app/auth/oauth/github/callback?code=...&state=...
+
+# Step 3 — response redirects to frontend with tokens in query params
+# Frontend picks them up from the URL and stores them securely
+```
+
+---
+
+### 4. Stellar Wallet (Freighter)
+
+```bash
+# Step 1 — get a sign challenge for the wallet address
+curl -s https://api.nextellar.app/auth/stellar/challenge?address=GXXXXXX | jq .
+# { "challenge": "nextellar-auth:1717171200:abc123" }
+
+# Step 2 — sign the challenge with Freighter (client-side)
+# const signed = await freighter.signMessage(challenge);
+
+# Step 3 — exchange signed challenge for tokens
+curl -s -X POST https://api.nextellar.app/auth/stellar/verify \
+  -H "Content-Type: application/json" \
+  -d '{"address":"GXXXXXX","signature":"<base64>","challenge":"nextellar-auth:..."}' | jq .
+
+# Response — same shape as email/password
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+  "refreshToken": "rt_abc123...",
+  "expiresIn": 900
+}
+```
+
+---
+
+## Error Responses
+
+| HTTP | `error` code | Meaning |
+|------|-------------|---------|
+| 400 | `invalid_credentials` | Wrong email/password |
+| 400 | `invalid_challenge` | Challenge expired or tampered |
+| 401 | `token_expired` | Access token has expired — refresh it |
+| 401 | `token_invalid` | Malformed or revoked token |
+| 403 | `refresh_token_reused` | Refresh token already rotated (possible replay attack) |
+| 429 | `rate_limit_exceeded` | Too many requests — see [rate-limits.md](rate-limits.md) |
+
+---
+
+## Rate Limits for Auth Endpoints
+
+See [rate-limits.md](rate-limits.md) for full details.
+
+| Endpoint | Limit |
+|----------|-------|
+| `POST /auth/login` | 10 per 15 min |
+| `POST /auth/register` | 5 per hour |
+| `POST /auth/refresh` | 30 per 15 min |

--- a/routes-d/docs/rate-limits.md
+++ b/routes-d/docs/rate-limits.md
@@ -1,0 +1,114 @@
+# Rate Limits — routes-d
+
+All routes-d endpoints enforce per-IP and per-account rate limits to protect
+Horizon, the Soroban RPC, and the Nextellar database.
+
+---
+
+## Per-Route Limits
+
+| Route | Window | Limit | Burst |
+|-------|--------|-------|-------|
+| `POST /auth/login` | 15 min | 10 requests | 3 |
+| `POST /auth/register` | 1 hour | 5 requests | 1 |
+| `POST /auth/refresh` | 15 min | 30 requests | 5 |
+| `POST /auth/logout` | 1 min | 10 requests | 10 |
+| `GET /orders` | 1 min | 120 requests | 20 |
+| `POST /orders` | 1 min | 30 requests | 5 |
+| `GET /orders/:id` | 1 min | 200 requests | 30 |
+| `DELETE /orders/:id` | 1 min | 20 requests | 5 |
+| `GET /horizon/*` (proxy) | 1 min | 60 requests | 10 |
+| `POST /soroban/simulate` | 1 min | 30 requests | 5 |
+| `POST /soroban/send` | 1 min | 10 requests | 2 |
+| `GET /health` | 1 min | 600 requests | 100 |
+
+> **Burst** = extra requests allowed in the first second of a new window.
+
+---
+
+## Response Headers
+
+Every response from a rate-limited endpoint includes these headers:
+
+```
+X-RateLimit-Limit:     120
+X-RateLimit-Remaining: 87
+X-RateLimit-Reset:     1717171200
+Retry-After:           34          ← present only on 429 responses
+```
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests allowed in the window |
+| `X-RateLimit-Remaining` | Requests left in the current window |
+| `X-RateLimit-Reset` | Unix timestamp (seconds) when the window resets |
+| `Retry-After` | Seconds to wait before retrying (429 only) |
+
+---
+
+## 429 Response Body
+
+```json
+{
+  "error": "rate_limit_exceeded",
+  "message": "Too many requests. Please wait 34 seconds before retrying.",
+  "retryAfter": 34
+}
+```
+
+---
+
+## Retry-After Contract
+
+- `Retry-After` is **always** present on `429 Too Many Requests` responses.
+- The value is a positive integer (seconds).
+- Clients **must** honour this value — immediate retries will be rejected and
+  may result in an extended block on the IP.
+- The window resets hard at `X-RateLimit-Reset`; `Retry-After` is the
+  remaining time in the *current* window, so `Retry-After ≤ window_size`.
+
+---
+
+## Client Retry Example (TypeScript / fetch)
+
+```ts
+async function requestWithRetry(
+  url: string,
+  init?: RequestInit,
+  maxAttempts = 4,
+): Promise<Response> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const res = await fetch(url, init);
+
+    if (res.status !== 429) return res;
+
+    const retryAfter = Number(res.headers.get("Retry-After") ?? "5");
+    if (attempt === maxAttempts) {
+      throw new Error(`Rate limited after ${maxAttempts} attempts. Retry in ${retryAfter}s.`);
+    }
+
+    // Honour the Retry-After header with a small jitter to spread load
+    const jitter = Math.random() * 1_000;
+    const delay = retryAfter * 1_000 + jitter;
+    console.warn(`Rate limited (attempt ${attempt}/${maxAttempts}). Waiting ${Math.ceil(delay)}ms…`);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  throw new Error("Unreachable");
+}
+
+// Usage
+const response = await requestWithRetry("/api/orders", {
+  method: "GET",
+  headers: { Authorization: `Bearer ${token}` },
+});
+const data = await response.json();
+```
+
+---
+
+## Global IP Block
+
+Repeated 429s without honouring `Retry-After` may trigger a temporary IP-level
+block enforced at the load balancer (separate from per-route limits). The block
+duration starts at **5 minutes** and doubles on each subsequent violation, up to
+**24 hours**.


### PR DESCRIPTION
Issue #343 — rate-limits.md:
- Documents per-route limits and burst sizes for every routes-d endpoint
- Explains Retry-After contract and all X-RateLimit-* response headers
- Includes 429 response body shape
- Includes TypeScript fetch retry example with jitter and Retry-After honour

Issue #341 — auth.md:
- Documents email/password, token refresh, OAuth (GitHub/Google), and Stellar Wallet (Freighter challenge/verify) authentication flows
- curl examples for every flow
- Error response table with HTTP codes and error codes
- Rate limit cross-reference to rate-limits.md

Closes #341
Closes #342
Closes #343
Closes #347