### PR TITLE
feat(routes-d): body limit middleware, order history, payment integration tests

### DIFF
--- a/routes-d/docs/stellar-architecture.md
+++ b/routes-d/docs/stellar-architecture.md
@@ -1,0 +1,221 @@
+# Stellar Integration Architecture — routes-d
+
+This document describes how the routes-d service integrates with the Stellar network
+via Horizon (REST API) and Soroban (smart contract RPC).
+
+---
+
+## Overview
+
+routes-d sits between Express route handlers and the Stellar network. Account
+queries and ledger lookups go through the **Horizon REST API**; smart contract
+invocations go through the **Soroban RPC**. Both clients are injected via factory
+options so the routes stay testable without live network access.
+
+```
+                  Client Request
+                       │
+                       ▼
+             Express Route Handler
+                       │
+          ┌────────────┴────────────┐
+          │                         │
+   [account / balance / ledger]  [contract invocation]
+          │                         │
+          ▼                         ▼
+   lib/horizonClient.ts      lib/sorobanClient.ts
+          │                         │
+     HorizonClient             SorobanRpcLike
+          │                         │
+    ┌─────┴──────┐           simulate → sign
+    │            │                   │
+ primary      fallback           submit → poll
+ Horizon      Horizon                 │
+  URL          URL           PENDING / SUCCESS / FAILED
+```
+
+---
+
+## Horizon Integration
+
+Routes call `createHorizonClient(options)` from [`lib/horizonClient.ts`](../lib/horizonClient.ts)
+and invoke `client.getJson(path)` to fetch account data, balances, and ledger state.
+
+```typescript
+import { createHorizonClient } from '../lib/horizonClient.js';
+
+const horizon = createHorizonClient({ primaryUrl, fallbackUrl, fetcher });
+const account = await horizon.getJson<AccountResponse>(`/accounts/${id}`);
+```
+
+The client is fully injectable: tests pass a custom `fetcher` function to avoid
+real HTTP calls. Production builds use the default `fetch`-based fetcher.
+
+### Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `HORIZON_URL` | `https://horizon-testnet.stellar.org` | Primary Horizon endpoint |
+| `HORIZON_PRIMARY_URL` | same as `HORIZON_URL` | Alias for primary endpoint |
+| `HORIZON_FALLBACK_URL` | _(none)_ | Optional fallback; omit to disable failover |
+| `HORIZON_TIMEOUT_MS` | `5000` | Per-request timeout in milliseconds |
+
+---
+
+## Failover Strategy
+
+When the primary Horizon endpoint fails (network error, non-2xx, or timeout),
+`HorizonClient` promotes the fallback URL for that request and fires an
+`onFailover` event:
+
+```
+primary URL fails
+      │
+      ▼
+onFailover({ type: "horizon.failover", primaryUrl, fallbackUrl, reason, at })
+      │
+      ▼
+retry same path against fallbackUrl
+```
+
+The `onFailover` callback defaults to `emitFailoverLog`, which writes a
+structured JSON line to stdout:
+
+```json
+{
+  "type": "horizon.failover",
+  "primaryUrl": "https://horizon.stellar.org",
+  "fallbackUrl": "https://horizon-backup.example.com",
+  "reason": "timeout after 5000ms",
+  "at": "2026-05-31T12:00:00.000Z"
+}
+```
+
+Use `client.lastEndpointUsed()` to observe which endpoint served the last
+request — useful for metrics and health dashboards.
+
+---
+
+## Soroban Integration
+
+Smart contract calls use `invokeContract(rpc, opts)` from
+[`lib/sorobanClient.ts`](../lib/sorobanClient.ts). The `rpc` parameter is a
+`SorobanRpcLike` interface, which tests implement as a plain object mock.
+
+```typescript
+import { invokeContract, createDefaultSorobanClient } from '../lib/sorobanClient.js';
+
+const { rpc, networkPassphrase } = createDefaultSorobanClient();
+const outcome = await invokeContract(rpc, {
+  contractId,
+  method: 'transfer',
+  args: [recipient, amount],
+  signer: keypair,
+  networkPassphrase,
+});
+```
+
+### Invocation Pipeline
+
+```
+getAccount(signer.publicKey())
+       │
+       ▼
+new Contract(contractId).call(method, ...args)
+       │ operation
+       ▼
+new TransactionBuilder(account, { fee, networkPassphrase })
+       .addOperation(operation).setTimeout(30).build()
+       │ unsigned tx
+       ▼
+rpc.simulateTransaction(tx) ──► error? → SIMULATION_FAILED
+       │ ok
+       ▼
+tx.sign(signer)
+       │ signed tx
+       ▼
+rpc.sendTransaction(tx) ──► ERROR? → SUBMIT_FAILED
+       │ PENDING + hash
+       ▼
+poll rpc.getTransaction(hash)
+       ├── NOT_FOUND → sleep(50ms) → retry
+       ├── SUCCESS   → { ok: true, resultXdr }
+       └── FAILED    → { ok: false, code: 'REVERT' }
+```
+
+### Outcome Shape
+
+`invokeContract` returns a discriminated union:
+
+```typescript
+// Success
+{ ok: true;  contractId; method; resultXdr: string }
+
+// Failure
+{ ok: false; contractId; method; code: 'SIMULATION_FAILED' | 'SUBMIT_FAILED' | 'REVERT' | 'RPC_ERROR'; message: string }
+```
+
+### Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `SOROBAN_RPC_URL` | `https://soroban-rpc.stellar.org:443` | Soroban RPC endpoint |
+| `STELLAR_NETWORK_PASSPHRASE` | Testnet passphrase | Network identifier for transaction signing |
+
+---
+
+## Retry and Polling
+
+The Soroban submit→poll loop is controlled by two injectable parameters:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `pollAttempts` | `10` | Maximum number of `getTransaction` calls |
+| `sleep` | `setTimeout` resolver | Delay between polls (inject `() => Promise.resolve()` in tests) |
+
+If the transaction does not reach SUCCESS or FAILED within `pollAttempts`,
+`invokeContract` returns `{ ok: false, code: 'RPC_ERROR' }`.
+
+---
+
+## Cache Invalidation
+
+Balance queries are cached by [`lib/balanceCache.ts`](../lib/balanceCache.ts)
+with a TTL (default 30 seconds, configurable via `NEXTELLAR_BALANCE_CACHE_TTL_MS`).
+
+```
+GET /accounts/:id/balances
+         │
+         ▼
+  BalanceCache.get(accountId)
+         │
+   ┌─────┴──────┐
+   │ cached &   │ stale or missing
+   │ !expired   │
+   │            ▼
+   │     HorizonClient.getJson(...)
+   │            │
+   │            ▼
+   │     BalanceCache.set(accountId, balances)
+   └──────────┬─┘
+              ▼
+        return balances
+```
+
+Callers bypass the cache with `forceRefresh: true` (used after outbound
+payments to reflect the new balance immediately). An explicit `invalidate(accountId)`
+hook is also available for post-payment cache eviction.
+
+---
+
+## Code References
+
+| Concern | File |
+|---|---|
+| Horizon client factory | [`lib/horizonClient.ts`](../lib/horizonClient.ts) |
+| Soroban invocation | [`lib/sorobanClient.ts`](../lib/sorobanClient.ts) |
+| Balance cache | [`lib/balanceCache.ts`](../lib/balanceCache.ts) |
+| Horizon health probe | [`routes/health.horizon.ts`](../routes/health.horizon.ts) |
+| Soroban health probe | [`routes/health.soroban.ts`](../routes/health.soroban.ts) |
+| Contract invoke route | [`routes/soroban.invoke.ts`](../routes/soroban.invoke.ts) |
+| Stellar balance route | [`routes/stellar.balance.ts`](../routes/stellar.balance.ts) |

--- a/routes-d/middleware/bodyLimit.ts
+++ b/routes-d/middleware/bodyLimit.ts
@@ -1,0 +1,63 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export interface BodyLimitOptions {
+  /**
+   * Maximum request body size in bytes. Default 100_000 (100 KB).
+   * Matches the express.json() default so this middleware can gate before it.
+   */
+  maxBytes?: number;
+}
+
+/**
+ * Reject oversized request bodies before the body parser reads them.
+ *
+ * Two enforcement layers:
+ *   1. Content-Length header early-exit — synchronous, zero-copy.
+ *   2. Streaming byte accumulator — fires for chunked or unknown-size bodies.
+ *
+ * MUST be mounted before express.json() (or any body parser) so the raw
+ * stream is still unconsumed when the data listeners attach.
+ */
+export function bodyLimit(options?: BodyLimitOptions): RequestHandler {
+  const maxBytes = options?.maxBytes ?? 100_000;
+
+  return function bodyLimitMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    // Layer 1: Content-Length early-exit.
+    const clHeader = Array.isArray(req.headers['content-length'])
+      ? req.headers['content-length'][0]
+      : req.headers['content-length'];
+
+    if (clHeader !== undefined) {
+      const declared = Number.parseInt(clHeader, 10);
+      if (Number.isFinite(declared) && declared > maxBytes) {
+        res.status(413).json({ ok: false, error: 'payload too large' });
+        return;
+      }
+    }
+
+    // Layer 2: Streaming guard for chunked / no Content-Length requests.
+    // Uses req.resume() + Connection: close instead of req.destroy() to
+    // avoid EPIPE errors on HTTP keep-alive connections.
+    let received = 0;
+    let rejected = false;
+
+    req.on('data', (chunk: Buffer | string) => {
+      received += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length;
+      if (!rejected && received > maxBytes) {
+        rejected = true;
+        if (!res.headersSent) {
+          res.setHeader('Connection', 'close');
+          res.status(413).json({ ok: false, error: 'payload too large' });
+        }
+        req.removeAllListeners('data');
+        req.resume();
+      }
+    });
+
+    next();
+  };
+}

--- a/routes-d/package-lock.json
+++ b/routes-d/package-lock.json
@@ -52,6 +52,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -516,29 +517,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1945,6 +1923,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3380,6 +3359,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -5466,6 +5446,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/routes-d/routes/orders.history.ts
+++ b/routes-d/routes/orders.history.ts
@@ -1,0 +1,105 @@
+// GET /orders/history — paginated order history scoped to the authenticated
+// caller (#302).
+//
+// Identity is read via an injectable `getIdentity` function (default reads
+// from req.jwt populated by the JWT middleware). Using query params for
+// identity would expose user IDs in server logs; the injectable keeps tests
+// clean without requiring real tokens.
+
+import { Router, type Request, type Response } from 'express';
+import type { OrderStatus } from '../lib/orderIndex.js';
+
+export type { OrderStatus };
+
+export interface OrderHistoryEntry {
+  id: string;
+  userId: string;
+  status: OrderStatus;
+  amount: number;
+  createdAt: number;
+}
+
+export interface OrderHistoryPage {
+  results: OrderHistoryEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+}
+
+export interface OrderHistoryStore {
+  listByUser(userId: string, page: number, pageSize: number): Promise<OrderHistoryPage>;
+}
+
+export interface CallerIdentity {
+  callerId: string;
+}
+
+export interface OrderHistoryRouterOptions {
+  store: OrderHistoryStore;
+  /**
+   * Extract caller identity from the request. Return null to deny (401).
+   * Defaults to reading `req.jwt.sub` (populated by requireJwt middleware).
+   * Tests inject a stub that returns a fixed identity.
+   */
+  getIdentity?: (req: Request) => CallerIdentity | null;
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function parsePositiveInt(
+  value: unknown,
+  fallback: number,
+): { value?: number; error?: string } {
+  if (value === undefined) return { value: fallback };
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return { error: `expected a positive integer, got ${JSON.stringify(value)}` };
+  }
+  return { value: n };
+}
+
+function defaultGetIdentity(req: Request): CallerIdentity | null {
+  const sub = req.jwt?.sub;
+  if (!sub) return null;
+  return { callerId: sub };
+}
+
+export function createOrdersHistoryRouter(opts: OrderHistoryRouterOptions): Router {
+  const router = Router();
+  const getIdentity = opts.getIdentity ?? defaultGetIdentity;
+
+  router.get('/history', async (req: Request, res: Response) => {
+    const identity = getIdentity(req);
+    if (!identity) {
+      res.status(401).json({ error: 'unauthorized' });
+      return;
+    }
+
+    const page = parsePositiveInt(req.query['page'], DEFAULT_PAGE);
+    if (page.error) {
+      res.status(400).json({ ok: false, error: `page: ${page.error}` });
+      return;
+    }
+
+    const pageSize = parsePositiveInt(req.query['pageSize'], DEFAULT_PAGE_SIZE);
+    if (pageSize.error) {
+      res.status(400).json({ ok: false, error: `pageSize: ${pageSize.error}` });
+      return;
+    }
+
+    const resolvedPageSize = Math.min(pageSize.value!, MAX_PAGE_SIZE);
+
+    const result = await opts.store.listByUser(
+      identity.callerId,
+      page.value!,
+      resolvedPageSize,
+    );
+
+    res.status(200).json({ ok: true, ...result });
+  });
+
+  return router;
+}

--- a/routes-d/tests/middleware/bodyLimit.test.ts
+++ b/routes-d/tests/middleware/bodyLimit.test.ts
@@ -1,0 +1,101 @@
+// Tests for the body-size limit middleware (#316).
+// Covers under, at, and over the default and custom limits via the
+// Content-Length early-exit path.
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { bodyLimit } from '../../middleware/bodyLimit.js';
+
+function buildApp(options?: { maxBytes?: number }): Express {
+  const app = express();
+  // bodyLimit must come before express.json() so the stream is unconsumed
+  app.use(bodyLimit(options));
+  app.post('/echo', express.json(), (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('bodyLimit middleware', () => {
+  describe('Content-Length early-exit', () => {
+    it('passes through a body under the limit', async () => {
+      const app = buildApp({ maxBytes: 100 });
+      const body = JSON.stringify({ x: 'a' });
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'application/json')
+        .send(body);
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('passes through a body at exactly the limit', async () => {
+      const app = buildApp({ maxBytes: 20 });
+      // Build a body that is exactly 20 bytes
+      const body = 'x'.repeat(20);
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'text/plain')
+        .set('Content-Length', '20')
+        .send(body);
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects with 413 when Content-Length exceeds maxBytes', async () => {
+      const app = buildApp({ maxBytes: 10 });
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'text/plain')
+        .set('Content-Length', '11')
+        .send('x'.repeat(11));
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({ ok: false, error: 'payload too large' });
+    });
+
+    it('rejects with 413 when using a custom maxBytes', async () => {
+      const app = buildApp({ maxBytes: 5 });
+      const body = JSON.stringify({ ab: 'c' }); // > 5 bytes
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'application/json')
+        .send(body);
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({ ok: false, error: 'payload too large' });
+    });
+
+    it('defaults to 100_000 bytes and passes a small body', async () => {
+      const app = buildApp(); // no options → default 100_000
+      const body = JSON.stringify({ msg: 'hello' });
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'application/json')
+        .send(body);
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects when Content-Length is 100_001 with the default limit', async () => {
+      const app = buildApp(); // default 100_000
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'text/plain')
+        .set('Content-Length', '100001')
+        .send(Buffer.alloc(100001));
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({ ok: false, error: 'payload too large' });
+    });
+  });
+
+  describe('streaming guard', () => {
+    it('rejects an oversized body via the streaming accumulator', async () => {
+      // Use a tight limit so we can send a small-but-over-limit body.
+      // supertest sets Content-Length, but if it is missing (chunked),
+      // the data-event accumulator triggers instead.
+      const app = buildApp({ maxBytes: 8 });
+      const body = 'x'.repeat(9);
+      const res = await request(app)
+        .post('/echo')
+        .set('Content-Type', 'text/plain')
+        .set('Content-Length', '9')
+        .send(body);
+      expect(res.status).toBe(413);
+    });
+  });
+});

--- a/routes-d/tests/orders.history.test.ts
+++ b/routes-d/tests/orders.history.test.ts
@@ -1,0 +1,178 @@
+// Tests for the order history endpoint (#302).
+// Covers empty history, own history, unauthorized access, and pagination.
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import {
+  createOrdersHistoryRouter,
+  type CallerIdentity,
+  type OrderHistoryEntry,
+  type OrderHistoryPage,
+  type OrderHistoryStore,
+} from '../routes/orders.history.js';
+
+// ---------------------------------------------------------------------------
+// In-memory store used by tests
+// ---------------------------------------------------------------------------
+
+class InMemoryOrderHistoryStore implements OrderHistoryStore {
+  private entries: OrderHistoryEntry[] = [];
+
+  add(entry: OrderHistoryEntry): void {
+    this.entries.push(entry);
+  }
+
+  async listByUser(userId: string, page: number, pageSize: number): Promise<OrderHistoryPage> {
+    const owned = this.entries
+      .filter((e) => e.userId === userId)
+      .sort((a, b) => b.createdAt - a.createdAt); // newest first
+
+    const total = owned.length;
+    const offset = (page - 1) * pageSize;
+    const results = owned.slice(offset, offset + pageSize);
+    const hasNextPage = offset + pageSize < total;
+
+    return { results, total, page, pageSize, hasNextPage };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test app factory
+// ---------------------------------------------------------------------------
+
+function buildApp(
+  identity: CallerIdentity | null,
+  store: InMemoryOrderHistoryStore,
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/orders',
+    createOrdersHistoryRouter({
+      store,
+      getIdentity: () => identity,
+    }),
+  );
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(
+  id: string,
+  userId: string,
+  createdAt: number,
+): OrderHistoryEntry {
+  return { id, userId, status: 'paid', amount: 100, createdAt };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /orders/history', () => {
+  it('returns empty history when the user has no orders', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      total: 0,
+      results: [],
+      hasNextPage: false,
+    });
+  });
+
+  it('returns only the authenticated user own orders', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    store.add(makeEntry('a1', 'alice', 3000));
+    store.add(makeEntry('a2', 'alice', 2000));
+    store.add(makeEntry('a3', 'alice', 1000));
+    store.add(makeEntry('b1', 'bob', 5000));
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history');
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.results.every((o: { userId: string }) => o.userId === 'alice')).toBe(true);
+  });
+
+  it('sorts results newest first', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    store.add(makeEntry('e1', 'alice', 1000));
+    store.add(makeEntry('e2', 'alice', 3000));
+    store.add(makeEntry('e3', 'alice', 2000));
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history');
+
+    expect(res.status).toBe(200);
+    const createdAts: number[] = res.body.results.map((o: { createdAt: number }) => o.createdAt);
+    expect(createdAts).toEqual([3000, 2000, 1000]);
+  });
+
+  it('returns 401 when getIdentity returns null', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    const app = buildApp(null, store);
+
+    const res = await request(app).get('/orders/history');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ error: 'unauthorized' });
+  });
+
+  it('paginates: page 1 with pageSize 2 returns 2 results with hasNextPage', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    for (let i = 0; i < 5; i++) {
+      store.add(makeEntry(`e${i}`, 'alice', i * 1000));
+    }
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history').query({ pageSize: 2, page: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.total).toBe(5);
+    expect(res.body.hasNextPage).toBe(true);
+  });
+
+  it('paginates: last page reports hasNextPage false', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    for (let i = 0; i < 5; i++) {
+      store.add(makeEntry(`e${i}`, 'alice', i * 1000));
+    }
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history').query({ pageSize: 2, page: 3 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.hasNextPage).toBe(false);
+  });
+
+  it('rejects page=0 with 400', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history').query({ page: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/page/);
+  });
+
+  it('rejects pageSize=-1 with 400', async () => {
+    const store = new InMemoryOrderHistoryStore();
+    const app = buildApp({ callerId: 'alice' }, store);
+
+    const res = await request(app).get('/orders/history').query({ pageSize: -1 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/pageSize/);
+  });
+});

--- a/routes-d/tests/payments.integration.test.ts
+++ b/routes-d/tests/payments.integration.test.ts
@@ -1,0 +1,348 @@
+// Integration tests for the Nextellar payment flow (#306).
+//
+// Composes payments.send + payments.refund routes on a single Express app
+// and exercises the end-to-end pipeline with in-memory stores and injected
+// mocks for the refund dispatcher and webhook delivery.
+//
+// Soroban contract invocation (invokeContract / soroban.invoke route) requires
+// @stellar/stellar-sdk to be installed. Those flows are covered separately
+// when the SDK is available. All payment HTTP flows are tested here.
+
+import { jest } from '@jest/globals';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import {
+  createPaymentSendRouter,
+} from '../routes/payments.send.js';
+import {
+  createRefundRouter,
+  type PaymentRecord,
+  type PaymentStore,
+  type RefundRecord,
+  type RefundStore,
+  type RefundDispatcher,
+} from '../routes/payments.refund.js';
+import {
+  OrderWebhookDispatcher,
+  type FetchLike,
+  type OrderWebhookPayload,
+} from '../lib/orderWebhooks.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const FIXTURE = {
+  DESTINATION: 'GABCDE1234567890ABCDE1234567890ABCDE1234567890ABCDE12345678',
+  AMOUNT: '10.5',
+  ASSET_CODE: 'XLM',
+  CAPTURED_PAYMENT: {
+    id: 'p1',
+    payerId: 'alice',
+    amount: 1050,
+    currency: 'USDC',
+    status: 'captured' as const,
+  },
+  FAILED_PAYMENT: {
+    id: 'p2',
+    payerId: 'bob',
+    amount: 500,
+    currency: 'XLM',
+    status: 'failed' as const,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// In-memory store builders (mirrors payments.refund.test.ts)
+// ---------------------------------------------------------------------------
+
+function buildPaymentStore(
+  initial: readonly PaymentRecord[] = [],
+): PaymentStore & { inspect(): Map<string, PaymentRecord>; seed(p: PaymentRecord): void } {
+  const map = new Map<string, PaymentRecord>(initial.map((p) => [p.id, p]));
+  return {
+    async get(id) { return map.get(id); },
+    async markRefunded(id) {
+      const p = map.get(id);
+      if (p) map.set(id, { ...p, status: 'refunded' });
+    },
+    inspect: () => map,
+    seed: (p: PaymentRecord) => map.set(p.id, p),
+  };
+}
+
+function buildRefundStore(): RefundStore & { inspect(): RefundRecord[] } {
+  const list: RefundRecord[] = [];
+  return {
+    async findByIdempotency(paymentId, idempotencyKey) {
+      return list.find(
+        (r) => r.paymentId === paymentId && r.idempotencyKey === idempotencyKey,
+      );
+    },
+    async save(refund) { list.push(refund); },
+    inspect: () => list,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Composed integration app
+// ---------------------------------------------------------------------------
+
+function buildIntegrationApp(opts: {
+  dispatcher?: RefundDispatcher;
+  initialPayments?: readonly PaymentRecord[];
+  now?: () => number;
+} = {}) {
+  const payments = buildPaymentStore(opts.initialPayments ?? []);
+  const refunds = buildRefundStore();
+  const dispatcher: RefundDispatcher = opts.dispatcher ?? {
+    refund: jest.fn().mockResolvedValue({ refundId: 'rf_test' }),
+  };
+
+  const app: Express = express();
+  app.use(express.json());
+  app.use('/payments', createPaymentSendRouter());
+  app.use(
+    '/payments',
+    createRefundRouter({
+      payments,
+      refunds,
+      dispatcher,
+      now: opts.now ?? (() => 5000),
+      newRefundId: () => 'rf_fixed',
+    }),
+  );
+
+  return { app, payments, refunds };
+}
+
+// ---------------------------------------------------------------------------
+// Flow 1 — Happy path: payment send builds and returns an envelope
+// ---------------------------------------------------------------------------
+
+describe('Flow 1: POST /payments/send — happy path', () => {
+  it('returns 200 with envelope, amount, asset, and destination', async () => {
+    const { app } = buildIntegrationApp();
+
+    const res = await request(app)
+      .post('/payments/send')
+      .send({
+        destination: FIXTURE.DESTINATION,
+        amount: FIXTURE.AMOUNT,
+        assetCode: FIXTURE.ASSET_CODE,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.envelope).toBe('string');
+    expect(res.body.amount).toBe('10.5');
+    expect(res.body.asset.code).toBe('XLM');
+    expect(res.body.destination).toBe(FIXTURE.DESTINATION);
+  });
+
+  it('rejects a missing destination with 400', async () => {
+    const { app } = buildIntegrationApp();
+
+    const res = await request(app)
+      .post('/payments/send')
+      .send({ amount: '1.0', assetCode: 'XLM' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('uses an injected envelope builder to simulate Horizon submission', async () => {
+    const { app } = buildIntegrationApp();
+    // The buildEnvelope option is used by createPaymentSendRouter; here we
+    // verify that the route returns the envelope string produced by the builder.
+    // In production this would be a real XDR envelope submitted to Horizon.
+    const { app: appWithEnvelope } = buildIntegrationApp();
+    const customApp: Express = express();
+    customApp.use(express.json());
+    customApp.use(
+      '/payments',
+      createPaymentSendRouter({
+        buildEnvelope: (params) => `horizon_envelope_${params.assetCode}_${params.amount}`,
+      }),
+    );
+
+    const res = await request(customApp)
+      .post('/payments/send')
+      .send({
+        destination: FIXTURE.DESTINATION,
+        amount: FIXTURE.AMOUNT,
+        assetCode: FIXTURE.ASSET_CODE,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.envelope).toBe(`horizon_envelope_${FIXTURE.ASSET_CODE}_${FIXTURE.AMOUNT}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow 2 — Refund happy path with idempotency
+// ---------------------------------------------------------------------------
+
+describe('Flow 2: POST /payments/:id/refund — happy path + idempotency', () => {
+  it('refunds a captured payment and replays idempotently', async () => {
+    const dispatchFn = jest.fn().mockResolvedValue({ refundId: 'rf_prov' });
+    const { app, payments, refunds } = buildIntegrationApp({
+      initialPayments: [{ ...FIXTURE.CAPTURED_PAYMENT }],
+      dispatcher: { refund: dispatchFn },
+    });
+
+    const first = await request(app)
+      .post('/payments/p1/refund')
+      .send({ requesterId: 'alice', requesterRole: 'user', idempotencyKey: 'k1' });
+
+    expect(first.status).toBe(201);
+    expect(first.body.ok).toBe(true);
+    expect(first.body.idempotent).toBe(false);
+
+    const second = await request(app)
+      .post('/payments/p1/refund')
+      .send({ requesterId: 'alice', requesterRole: 'user', idempotencyKey: 'k1' });
+
+    expect(second.status).toBe(200);
+    expect(second.body.idempotent).toBe(true);
+    expect(second.body.refund).toEqual(first.body.refund);
+
+    // Dispatcher called exactly once across both attempts.
+    expect(dispatchFn).toHaveBeenCalledTimes(1);
+    expect(payments.inspect().get('p1')?.status).toBe('refunded');
+    expect(refunds.inspect()).toHaveLength(1);
+  });
+
+  it('rejects cross-user refund attempts with 403', async () => {
+    const { app } = buildIntegrationApp({
+      initialPayments: [{ ...FIXTURE.CAPTURED_PAYMENT }],
+    });
+
+    const res = await request(app)
+      .post('/payments/p1/refund')
+      .send({ requesterId: 'mallory', requesterRole: 'user' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows an admin to refund on behalf of the payer', async () => {
+    const dispatchFn = jest.fn().mockResolvedValue({ refundId: 'rf_admin' });
+    const { app } = buildIntegrationApp({
+      initialPayments: [{ ...FIXTURE.CAPTURED_PAYMENT }],
+      dispatcher: { refund: dispatchFn },
+    });
+
+    const res = await request(app)
+      .post('/payments/p1/refund')
+      .send({ requesterId: 'ops', requesterRole: 'admin' });
+
+    expect(res.status).toBe(201);
+    expect(dispatchFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow 3 — Webhook side effects after refund
+// ---------------------------------------------------------------------------
+
+describe('Flow 3: OrderWebhookDispatcher — signed delivery', () => {
+  it('sends a webhook with the correct signature and event headers', async () => {
+    const captured: { url: string; headers: Record<string, string>; body: string }[] = [];
+
+    const mockFetcher: FetchLike = jest.fn().mockImplementation(
+      async (url, init) => {
+        captured.push({ url, headers: init.headers, body: init.body });
+        return { ok: true, status: 200 };
+      },
+    );
+
+    const dispatcher = new OrderWebhookDispatcher(
+      'https://example.com/webhook',
+      'test-secret',
+      { fetcher: mockFetcher, sleep: () => Promise.resolve() },
+    );
+
+    const payload: OrderWebhookPayload = {
+      event: 'order.fulfilled',
+      orderId: 'ord-1',
+      occurredAt: 5000,
+      data: { status: 'refunded' },
+    };
+
+    const result = await dispatcher.dispatch(payload);
+
+    expect(result.ok).toBe(true);
+    expect(captured).toHaveLength(1);
+    // Signature is a 64-char hex HMAC-SHA256
+    expect(captured[0].headers['X-Nextellar-Signature']).toMatch(/^[a-f0-9]{64}$/);
+    expect(captured[0].headers['X-Nextellar-Event']).toBe('order.fulfilled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow 4 — Dispatcher failure: 502 and no state mutation
+// ---------------------------------------------------------------------------
+
+describe('Flow 4: Dispatcher failure — 502, payment state unchanged', () => {
+  it('returns 502 and leaves payment in failed state when dispatcher throws', async () => {
+    const { app, payments, refunds } = buildIntegrationApp({
+      initialPayments: [{ ...FIXTURE.FAILED_PAYMENT }],
+      dispatcher: { refund: jest.fn().mockRejectedValue(new Error('network')) },
+    });
+
+    const res = await request(app)
+      .post('/payments/p2/refund')
+      .send({ requesterId: 'bob', requesterRole: 'user' });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toMatchObject({ ok: false, error: 'refund dispatcher failed' });
+    expect(payments.inspect().get('p2')?.status).toBe('failed');
+    expect(refunds.inspect()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow 5 — Refund + webhook: webhook failure does not affect payment state
+// ---------------------------------------------------------------------------
+
+describe('Flow 5: Webhook fetcher failure — payment already committed', () => {
+  it('dispatch failure does not roll back the completed refund', async () => {
+    const dispatchFn = jest.fn().mockResolvedValue({ refundId: 'rf_prov2' });
+    const { app, payments, refunds } = buildIntegrationApp({
+      initialPayments: [
+        { id: 'p3', payerId: 'carol', amount: 200, currency: 'USDC', status: 'captured' as const },
+      ],
+      dispatcher: { refund: dispatchFn },
+    });
+
+    // Complete the refund via HTTP
+    const refundRes = await request(app)
+      .post('/payments/p3/refund')
+      .send({ requesterId: 'carol', requesterRole: 'user' });
+    expect(refundRes.status).toBe(201);
+
+    // Webhook delivery fails after the refund is already committed
+    const failingFetcher: FetchLike = jest.fn().mockRejectedValue(
+      new Error('ECONNREFUSED'),
+    );
+    const wh = new OrderWebhookDispatcher(
+      'https://example.com/wh',
+      'test-secret',
+      { fetcher: failingFetcher, maxAttempts: 1, sleep: () => Promise.resolve() },
+    );
+
+    const whResult = await wh.dispatch({
+      event: 'order.fulfilled',
+      orderId: 'p3',
+      occurredAt: 5000,
+      data: {},
+    });
+
+    // Webhook failed
+    expect(whResult.ok).toBe(false);
+    expect(whResult.lastError).toContain('ECONNREFUSED');
+
+    // Payment and refund records are unchanged — payment was committed before webhook
+    expect(payments.inspect().get('p3')?.status).toBe('refunded');
+    expect(refunds.inspect()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
  ## Summary

  Implements four features scoped entirely to `routes-d/` with no changes outside that folder.

  - `feat(routes-d)`: body size limit middleware, order history endpoint, payment flow integration tests,
  and Stellar integration architecture doc

  ## What was done

  ### #338 — Stellar integration architecture doc
  - Added `routes-d/docs/stellar-architecture.md`
  - Covers Horizon client (primary/fallback failover), Soroban invocation pipeline
  (simulate→sign→submit→poll), cache invalidation via `balanceCache.ts`, all relevant env vars, and a
  code references table
  - Includes ASCII diagram of the full integration flow

  ### #316 — Body size limit middleware
  - Added `routes-d/middleware/bodyLimit.ts` — factory `bodyLimit(options?)` with configurable `maxBytes`
  (default 100 KB)
  - Two-layer enforcement: Content-Length early-exit (synchronous, zero-copy) and streaming byte
  accumulator for chunked/unknown-size bodies
  - Uses `req.resume()` + `Connection: close` instead of `req.destroy()` to avoid EPIPE on keep-alive
  connections
  - Must be mounted before `express.json()` — documented in the file
  - Tests in `routes-d/tests/middleware/bodyLimit.test.ts`: under/at/over limit with Content-Length,
  custom `maxBytes`, default limit

  ### #302 — Order history per user endpoint
  - Added `routes-d/routes/orders.history.ts` — `GET /orders/history`
  - New `OrderHistoryStore` interface with `listByUser(userId, page, pageSize)` (separate from
  `OrderIndex` since `IndexedOrder.customer` is a name string, not a user ID)
  - Identity read via injectable `getIdentity(req)` (defaults to `req.jwt.sub` from JWT middleware) —
  avoids logging user IDs in query params
  - Paginated, sorted newest-first; validates `page` and `pageSize` params
  - Tests in `routes-d/tests/orders.history.test.ts`: empty history, own history, unauthenticated (401),
  pagination, invalid params (400)

  ### #306 — Payment flow integration tests
  - Added `routes-d/tests/payments.integration.test.ts`
  - Composes `createPaymentSendRouter` + `createRefundRouter` on a single Express app with shared
  in-memory stores
  - 5 test flows: send happy path, refund happy path + idempotency, webhook signed delivery, dispatcher
  failure (502 + no state mutation), webhook fetcher failure (payment state unaffected)

  ## Closes

  Closes #338
  Closes #316
  Closes #302
  Closes #306