### PR TITLE
feat: auth schemas, CAPTCHA registration, OAuth sign-in, and Stellar …

### DIFF
--- a/routes-d/lib/captcha.ts
+++ b/routes-d/lib/captcha.ts
@@ -1,0 +1,93 @@
+// routes-d/lib/captcha.ts
+//
+// Server-side CAPTCHA token verification (Issue #267).
+//
+// The verifier is abstracted behind a `CaptchaVerifier` interface so the
+// concrete provider (hCaptcha, reCAPTCHA v3, Turnstile, …) can be swapped
+// without touching route code. Tests inject a fake verifier.
+//
+// The default export wires the real provider from environment variables.
+// If CAPTCHA_SECRET_KEY is absent the module still loads — the verifier
+// will reject every token with a clear error so a misconfigured deploy
+// fails loudly rather than silently bypassing the check.
+
+export interface CaptchaVerifyResult {
+  success: boolean;
+  /** Human-readable reason when success is false. */
+  reason?: string;
+}
+
+export interface CaptchaVerifier {
+  verify(token: string, remoteIp?: string): Promise<CaptchaVerifyResult>;
+}
+
+// ---------------------------------------------------------------------------
+// hCaptcha / reCAPTCHA-compatible HTTP verifier
+// ---------------------------------------------------------------------------
+
+export interface HttpCaptchaVerifierOptions {
+  /** Secret key for the CAPTCHA provider. */
+  secretKey: string;
+  /** Verification endpoint URL. Defaults to hCaptcha's endpoint. */
+  verifyUrl?: string;
+  /** Injectable fetch for testing without real HTTP. */
+  fetch?: typeof globalThis.fetch;
+}
+
+const DEFAULT_VERIFY_URL = 'https://hcaptcha.com/siteverify';
+
+export function createHttpCaptchaVerifier(
+  opts: HttpCaptchaVerifierOptions,
+): CaptchaVerifier {
+  const verifyUrl = opts.verifyUrl ?? DEFAULT_VERIFY_URL;
+  const fetchFn = opts.fetch ?? globalThis.fetch;
+
+  return {
+    async verify(token: string, remoteIp?: string): Promise<CaptchaVerifyResult> {
+      if (!token || !token.trim()) {
+        return { success: false, reason: 'missing_token' };
+      }
+
+      const body = new URLSearchParams({ secret: opts.secretKey, response: token });
+      if (remoteIp) body.set('remoteip', remoteIp);
+
+      let data: { success: boolean; 'error-codes'?: string[] };
+      try {
+        const resp = await fetchFn(verifyUrl, { method: 'POST', body });
+        data = (await resp.json()) as typeof data;
+      } catch {
+        return { success: false, reason: 'provider_unreachable' };
+      }
+
+      if (!data.success) {
+        const codes = data['error-codes'] ?? [];
+        return { success: false, reason: codes[0] ?? 'invalid_token' };
+      }
+
+      return { success: true };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default singleton — wired from env at module load time
+// ---------------------------------------------------------------------------
+
+function buildDefaultVerifier(): CaptchaVerifier {
+  const secretKey = process.env.CAPTCHA_SECRET_KEY;
+  if (!secretKey) {
+    // Return a verifier that always fails so the route rejects requests
+    // rather than silently skipping the check.
+    return {
+      async verify(): Promise<CaptchaVerifyResult> {
+        return { success: false, reason: 'captcha_not_configured' };
+      },
+    };
+  }
+  return createHttpCaptchaVerifier({
+    secretKey,
+    verifyUrl: process.env.CAPTCHA_VERIFY_URL ?? DEFAULT_VERIFY_URL,
+  });
+}
+
+export const defaultCaptchaVerifier: CaptchaVerifier = buildDefaultVerifier();

--- a/routes-d/lib/identity.ts
+++ b/routes-d/lib/identity.ts
@@ -1,0 +1,123 @@
+// routes-d/lib/identity.ts
+//
+// Maps external OAuth provider identities to Nextellar user records
+// (Issue #260).
+//
+// An "identity" is the combination of (provider, providerUserId) that
+// uniquely identifies a user within a given OAuth provider. On first
+// sign-in a new Nextellar account is created and linked; on subsequent
+// sign-ins the existing account is returned.
+//
+// The store is intentionally in-memory so the module stays portable.
+// Production deployments replace `identityStore` / `userStore` with
+// database-backed implementations that expose the same interface.
+
+import { randomId } from './tokens.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OAuthProfile {
+  /** Provider name, e.g. "github", "google". */
+  provider: string;
+  /** Stable user ID within the provider. */
+  providerUserId: string;
+  /** Display name from the provider (optional). */
+  displayName?: string;
+  /** Primary email from the provider (optional). */
+  email?: string;
+}
+
+export interface NexitellarUser {
+  id: string;
+  email?: string;
+  displayName?: string;
+  createdAt: number;
+}
+
+export interface IdentityRecord {
+  /** Nextellar user id. */
+  userId: string;
+  provider: string;
+  providerUserId: string;
+  linkedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory stores (swap for DB in production)
+// ---------------------------------------------------------------------------
+
+/** keyed by `${provider}:${providerUserId}` */
+export const identityStore = new Map<string, IdentityRecord>();
+
+/** keyed by userId */
+export const userStore = new Map<string, NexitellarUser>();
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+function identityKey(provider: string, providerUserId: string): string {
+  return `${provider}:${providerUserId}`;
+}
+
+export interface FindOrCreateResult {
+  user: NexitellarUser;
+  /** True when a new Nextellar account was created during this call. */
+  isNew: boolean;
+}
+
+/**
+ * Find an existing Nextellar user linked to the given OAuth profile, or
+ * create a new one and link it. Returns the user and whether it was newly
+ * created.
+ */
+export function findOrCreateUser(
+  profile: OAuthProfile,
+  deps: {
+    identityStore?: Map<string, IdentityRecord>;
+    userStore?: Map<string, NexitellarUser>;
+    now?: () => number;
+    nextId?: () => string;
+  } = {},
+): FindOrCreateResult {
+  const iStore = deps.identityStore ?? identityStore;
+  const uStore = deps.userStore ?? userStore;
+  const now = deps.now ?? (() => Date.now());
+  const nextId = deps.nextId ?? (() => randomId('usr'));
+
+  const key = identityKey(profile.provider, profile.providerUserId);
+  const existing = iStore.get(key);
+
+  if (existing) {
+    const user = uStore.get(existing.userId);
+    if (!user) {
+      // Identity record exists but user was deleted — treat as new.
+      uStore.delete(existing.userId);
+      iStore.delete(key);
+    } else {
+      return { user, isNew: false };
+    }
+  }
+
+  // Create a new user and link the identity.
+  const userId = nextId();
+  const user: NexitellarUser = {
+    id: userId,
+    email: profile.email,
+    displayName: profile.displayName,
+    createdAt: now(),
+  };
+  const identity: IdentityRecord = {
+    userId,
+    provider: profile.provider,
+    providerUserId: profile.providerUserId,
+    linkedAt: now(),
+  };
+
+  uStore.set(userId, user);
+  iStore.set(key, identity);
+
+  return { user, isNew: true };
+}

--- a/routes-d/lib/operationAllowlist.ts
+++ b/routes-d/lib/operationAllowlist.ts
@@ -1,0 +1,58 @@
+// routes-d/lib/operationAllowlist.ts
+//
+// Single source of truth for which Stellar operation types the relay
+// endpoints are permitted to prepare and submit. Any operation type not
+// present in DEFAULT_ALLOWED_OPERATIONS will be rejected with a 403.
+//
+// The allowlist is intentionally conservative — only the most common,
+// non-destructive operation types are enabled by default. Operators can
+// extend it at router construction time via `createAllowlist`.
+
+/** Operation types allowed by default. */
+export const DEFAULT_ALLOWED_OPERATIONS: ReadonlySet<string> = new Set([
+  'payment',
+  'pathPaymentStrictSend',
+  'pathPaymentStrictReceive',
+  'manageBuyOffer',
+  'manageSellOffer',
+  'createPassiveSellOffer',
+  'changeTrust',
+  'manageData',
+  'bumpSequence',
+  'claimClaimableBalance',
+  'invokeHostFunction',
+]);
+
+export interface AllowlistCheckResult {
+  allowed: boolean;
+  /** Operation types that are not in the allowlist (empty when all pass). */
+  disallowed: string[];
+}
+
+/**
+ * Check a list of operation type strings against an allowlist.
+ * Pure function — no side effects.
+ */
+export function checkOperations(
+  operationTypes: readonly string[],
+  allowlist: ReadonlySet<string> = DEFAULT_ALLOWED_OPERATIONS,
+): AllowlistCheckResult {
+  const disallowed: string[] = [];
+  for (const type of operationTypes) {
+    if (!allowlist.has(type)) disallowed.push(type);
+  }
+  return { allowed: disallowed.length === 0, disallowed };
+}
+
+/**
+ * Build a custom allowlist by merging the defaults with additional types.
+ * Pass `replaceDefaults: true` to start from an empty set instead.
+ */
+export function createAllowlist(
+  extra: Iterable<string> = [],
+  replaceDefaults = false,
+): Set<string> {
+  const base = replaceDefaults ? new Set<string>() : new Set(DEFAULT_ALLOWED_OPERATIONS);
+  for (const t of extra) base.add(t);
+  return base;
+}

--- a/routes-d/routes/auth.oauth.ts
+++ b/routes-d/routes/auth.oauth.ts
@@ -1,0 +1,176 @@
+// routes-d/routes/auth.oauth.ts
+//
+// OAuth provider sign-in flow (Issue #260).
+//
+// Two endpoints:
+//
+//   GET  /auth/oauth/start?provider=<name>
+//        Redirect the browser to the provider's authorization URL.
+//
+//   GET  /auth/oauth/callback?provider=<name>&code=<code>&state=<state>
+//        Exchange the authorization code for a provider access token,
+//        fetch the user profile, map it to a Nextellar account via
+//        identity.ts, and issue a session.
+//
+// All provider-specific logic (token exchange, profile fetch) is injected
+// via `OAuthProviderAdapter` so tests can mock the exchange without real
+// HTTP calls.
+
+import { Router, type Request, type Response } from 'express';
+import { findOrCreateUser, type OAuthProfile } from '../lib/identity.js';
+import { issueNextellarSession, sessionCookieOptions } from '../lib/session.js';
+import { randomId } from '../lib/tokens.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OAuthTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+}
+
+export interface OAuthProviderAdapter {
+  /** Human-readable provider name, e.g. "github". */
+  name: string;
+  /**
+   * Build the authorization URL the browser should be redirected to.
+   * `state` is a CSRF-prevention nonce generated per request.
+   */
+  buildAuthUrl(state: string): string;
+  /**
+   * Exchange an authorization code for provider tokens.
+   * Returns null when the exchange fails (bad code, expired, etc.).
+   */
+  exchangeCode(code: string): Promise<OAuthTokens | null>;
+  /**
+   * Fetch the authenticated user's profile from the provider.
+   * Returns null when the access token is invalid.
+   */
+  fetchProfile(accessToken: string): Promise<OAuthProfile | null>;
+}
+
+export interface OAuthRouterDeps {
+  /** Map of provider name → adapter. */
+  providers: Map<string, OAuthProviderAdapter>;
+  /** Injectable session issuer for testing. */
+  issueSession?: typeof issueNextellarSession;
+  /** Injectable identity resolver for testing. */
+  resolveIdentity?: typeof findOrCreateUser;
+  /** Injectable state generator for testing. */
+  generateState?: () => string;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory state store (CSRF nonce per request)
+// ---------------------------------------------------------------------------
+
+/** Keyed by state nonce; value is the provider name. */
+export const oauthStateStore = new Map<string, { provider: string; expiresAt: number }>();
+
+const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function pruneExpiredStates(): void {
+  const now = Date.now();
+  for (const [key, val] of oauthStateStore) {
+    if (val.expiresAt < now) oauthStateStore.delete(key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export function createOAuthRouter(deps: OAuthRouterDeps): Router {
+  const router = Router();
+  const issueSession = deps.issueSession ?? issueNextellarSession;
+  const resolveIdentity = deps.resolveIdentity ?? findOrCreateUser;
+  const generateState = deps.generateState ?? (() => randomId('oauth'));
+
+  // GET /auth/oauth/start?provider=<name>
+  router.get('/auth/oauth/start', (req: Request, res: Response) => {
+    const providerName =
+      typeof req.query.provider === 'string' ? req.query.provider.trim() : '';
+
+    const adapter = deps.providers.get(providerName);
+    if (!adapter) {
+      res.status(400).json({ error: 'unknown_provider', provider: providerName || undefined });
+      return;
+    }
+
+    pruneExpiredStates();
+    const state = generateState();
+    oauthStateStore.set(state, { provider: providerName, expiresAt: Date.now() + STATE_TTL_MS });
+
+    const authUrl = adapter.buildAuthUrl(state);
+    res.redirect(302, authUrl);
+  });
+
+  // GET /auth/oauth/callback?provider=<name>&code=<code>&state=<state>
+  router.get('/auth/oauth/callback', async (req: Request, res: Response) => {
+    const code = typeof req.query.code === 'string' ? req.query.code.trim() : '';
+    const state = typeof req.query.state === 'string' ? req.query.state.trim() : '';
+    const providerName =
+      typeof req.query.provider === 'string' ? req.query.provider.trim() : '';
+
+    if (!code || !state) {
+      res.status(400).json({ error: 'code and state are required' });
+      return;
+    }
+
+    // Validate state (CSRF check).
+    const stateRecord = oauthStateStore.get(state);
+    if (!stateRecord || stateRecord.expiresAt < Date.now()) {
+      oauthStateStore.delete(state);
+      res.status(400).json({ error: 'invalid_or_expired_state' });
+      return;
+    }
+
+    // Use provider from state record (more trustworthy than query param).
+    const resolvedProvider = stateRecord.provider;
+    if (providerName && providerName !== resolvedProvider) {
+      res.status(400).json({ error: 'provider_mismatch' });
+      return;
+    }
+
+    oauthStateStore.delete(state);
+
+    const adapter = deps.providers.get(resolvedProvider);
+    if (!adapter) {
+      res.status(400).json({ error: 'unknown_provider' });
+      return;
+    }
+
+    // Exchange code for tokens.
+    const tokens = await adapter.exchangeCode(code);
+    if (!tokens) {
+      res.status(401).json({ error: 'code_exchange_failed' });
+      return;
+    }
+
+    // Fetch provider profile.
+    const profile = await adapter.fetchProfile(tokens.accessToken);
+    if (!profile) {
+      res.status(401).json({ error: 'profile_fetch_failed' });
+      return;
+    }
+
+    // Map to Nextellar user.
+    const { user, isNew } = resolveIdentity(profile);
+
+    // Issue session.
+    const session = issueSession(user.id);
+    res.cookie('session', session.token, sessionCookieOptions());
+
+    res.status(200).json({
+      ok: true,
+      isNew,
+      user: { id: user.id, email: user.email, displayName: user.displayName },
+      token: session.token,
+      expiresAt: session.expiresAt,
+    });
+  });
+
+  return router;
+}

--- a/routes-d/routes/auth.register.ts
+++ b/routes-d/routes/auth.register.ts
@@ -1,0 +1,136 @@
+// routes-d/routes/auth.register.ts
+//
+// POST /auth/register — new account registration with server-side CAPTCHA
+// verification (Issue #267).
+//
+// Flow:
+//   1. Validate the request body with registerSchema (email, password, name).
+//   2. Verify the supplied captchaToken with the injected CaptchaVerifier.
+//   3. Create the user account via the injected createUser dep.
+//   4. Issue a session and return it.
+//
+// The CAPTCHA verifier and user-creation logic are injected so tests can
+// mock both without real HTTP calls or a database.
+
+import { Router, type Request, type Response } from 'express';
+import { parseOrReject, registerSchema } from '../lib/schemas/auth.js';
+import {
+  type CaptchaVerifier,
+  defaultCaptchaVerifier,
+} from '../lib/captcha.js';
+import { issueNextellarSession } from '../lib/session.js';
+import { randomId } from '../lib/tokens.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RegisteredUser {
+  id: string;
+  email: string;
+  displayName: string;
+}
+
+export interface RegisterDeps {
+  /** Server-side CAPTCHA verifier. */
+  captcha: CaptchaVerifier;
+  /**
+   * Persist a new user record. Should throw if the email is already taken
+   * (the route surfaces a 409 in that case).
+   */
+  createUser(params: {
+    email: string;
+    password: string;
+    name: string;
+    inviteCode?: string;
+  }): Promise<RegisteredUser>;
+}
+
+// ---------------------------------------------------------------------------
+// Default deps
+// ---------------------------------------------------------------------------
+
+export const defaultRegisterDeps: RegisterDeps = {
+  captcha: defaultCaptchaVerifier,
+  async createUser({ email, name }) {
+    // Placeholder — replace with real DB call in production.
+    return { id: randomId('usr'), email, displayName: name };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export interface CreateRegisterRouterOptions {
+  deps?: RegisterDeps;
+}
+
+export function createRegisterRouter(opts: CreateRegisterRouterOptions = {}): Router {
+  const router = Router();
+  const deps = opts.deps ?? defaultRegisterDeps;
+
+  router.post('/auth/register', async (req: Request, res: Response) => {
+    // 1. Validate body schema (email, password, name, optional inviteCode).
+    const body = parseOrReject(registerSchema, req.body, res);
+    if (!body) return; // 400 already sent
+
+    // 2. Require captchaToken in the raw body (not part of registerSchema).
+    const captchaToken =
+      typeof req.body?.captchaToken === 'string' ? req.body.captchaToken.trim() : '';
+    if (!captchaToken) {
+      res.status(400).json({
+        error: 'validation_failed',
+        fields: [{ field: 'captchaToken', message: 'required' }],
+      });
+      return;
+    }
+
+    // 3. Verify CAPTCHA server-side.
+    const remoteIp =
+      (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
+      req.socket.remoteAddress;
+
+    const captchaResult = await deps.captcha.verify(captchaToken, remoteIp);
+    if (!captchaResult.success) {
+      res.status(400).json({
+        error: 'captcha_failed',
+        reason: captchaResult.reason ?? 'invalid_token',
+      });
+      return;
+    }
+
+    // 4. Create the user.
+    let user: RegisteredUser;
+    try {
+      user = await deps.createUser({
+        email: body.email,
+        password: body.password,
+        name: body.name,
+        inviteCode: body.inviteCode,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '';
+      if (message.toLowerCase().includes('already')) {
+        res.status(409).json({ error: 'email_already_registered' });
+        return;
+      }
+      res.status(500).json({ error: 'registration_failed' });
+      return;
+    }
+
+    // 5. Issue session.
+    const session = issueNextellarSession(user.id);
+
+    res.status(201).json({
+      ok: true,
+      user: { id: user.id, email: user.email, displayName: user.displayName },
+      token: session.token,
+      expiresAt: session.expiresAt,
+    });
+  });
+
+  return router;
+}
+
+export default createRegisterRouter();

--- a/routes-d/routes/stellar.tx.prepare.ts
+++ b/routes-d/routes/stellar.tx.prepare.ts
@@ -1,0 +1,174 @@
+// routes-d/routes/stellar.tx.prepare.ts
+//
+// POST /stellar/tx/prepare — build an unsigned Stellar transaction envelope
+// that the client can sign and later submit via /stellar/tx/submit (Issue #273).
+//
+// The route validates every requested operation type against the allowlist
+// before building the envelope. If any operation is disallowed the request
+// is rejected with 403 so the client never receives an envelope it cannot
+// submit.
+//
+// The actual XDR construction is injected via `PrepareTransactionDeps` so
+// the route stays portable and tests can supply deterministic envelopes
+// without a real Stellar SDK.
+
+import { Router, type Request, type Response } from 'express';
+import {
+  checkOperations,
+  DEFAULT_ALLOWED_OPERATIONS,
+} from '../lib/operationAllowlist.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PrepareOperation {
+  /** Stellar operation type, e.g. "payment", "manageData". */
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface PrepareRequest {
+  /** Source account (G… address). */
+  sourceAccount: string;
+  /** Operations to include in the transaction. */
+  operations: PrepareOperation[];
+  /** Optional memo string. */
+  memo?: string;
+  /** Optional fee in stroops (defaults to 100 per operation). */
+  fee?: number;
+}
+
+export interface PrepareEnvelope {
+  /** Base64-encoded unsigned transaction XDR. */
+  envelope: string;
+  /** Network passphrase the envelope was built for. */
+  network: string;
+  /** Operations included (echoed back for client verification). */
+  operations: PrepareOperation[];
+  /** Source account. */
+  sourceAccount: string;
+}
+
+export interface PrepareTransactionDeps {
+  /**
+   * Build an unsigned transaction envelope from the given parameters.
+   * Returns a base64 XDR string. Injected so tests avoid real SDK calls.
+   */
+  buildEnvelope(params: {
+    sourceAccount: string;
+    operations: PrepareOperation[];
+    memo?: string;
+    fee: number;
+    network: string;
+  }): Promise<string> | string;
+  /** Network passphrase. Defaults to testnet. */
+  network?: string;
+  /** Allowlist of permitted operation types. */
+  allowedOperations?: ReadonlySet<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Default deps (placeholder — wire real Stellar SDK in production)
+// ---------------------------------------------------------------------------
+
+export const defaultPrepareDeps: PrepareTransactionDeps = {
+  buildEnvelope({ sourceAccount, operations, fee, network }) {
+    // Placeholder: real implementation uses @stellar/stellar-sdk
+    const payload = JSON.stringify({ sourceAccount, operations, fee, network });
+    return Buffer.from(payload).toString('base64');
+  },
+  network: process.env.STELLAR_NETWORK ?? 'Test SDF Network ; September 2015',
+};
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function readPrepareRequest(body: unknown): PrepareRequest | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.sourceAccount !== 'string' || !b.sourceAccount.trim()) return null;
+  if (!Array.isArray(b.operations) || b.operations.length === 0) return null;
+
+  for (const op of b.operations) {
+    if (!op || typeof op !== 'object' || typeof (op as { type?: unknown }).type !== 'string') {
+      return null;
+    }
+  }
+
+  return {
+    sourceAccount: (b.sourceAccount as string).trim(),
+    operations: b.operations as PrepareOperation[],
+    memo: typeof b.memo === 'string' ? b.memo : undefined,
+    fee: typeof b.fee === 'number' && b.fee > 0 ? b.fee : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export interface CreatePrepareRouterOptions {
+  deps?: PrepareTransactionDeps;
+}
+
+export function createPrepareRouter(opts: CreatePrepareRouterOptions = {}): Router {
+  const router = Router();
+  const deps = opts.deps ?? defaultPrepareDeps;
+  const allowlist = deps.allowedOperations ?? DEFAULT_ALLOWED_OPERATIONS;
+  const network = deps.network ?? 'Test SDF Network ; September 2015';
+  const DEFAULT_FEE_PER_OP = 100;
+
+  router.post('/prepare', async (req: Request, res: Response) => {
+    const payload = readPrepareRequest(req.body);
+    if (!payload) {
+      res.status(400).json({
+        ok: false,
+        error: 'sourceAccount (string) and operations (non-empty array of {type}) are required',
+      });
+      return;
+    }
+
+    const opTypes = payload.operations.map((op) => op.type);
+    const check = checkOperations(opTypes, allowlist);
+    if (!check.allowed) {
+      res.status(403).json({
+        ok: false,
+        error: `disallowed operation type(s): ${check.disallowed.join(', ')}`,
+        disallowed: check.disallowed,
+      });
+      return;
+    }
+
+    const fee = payload.fee ?? DEFAULT_FEE_PER_OP * payload.operations.length;
+
+    let envelope: string;
+    try {
+      envelope = await deps.buildEnvelope({
+        sourceAccount: payload.sourceAccount,
+        operations: payload.operations,
+        memo: payload.memo,
+        fee,
+        network,
+      });
+    } catch {
+      res.status(500).json({ ok: false, error: 'failed to build transaction envelope' });
+      return;
+    }
+
+    const result: PrepareEnvelope = {
+      envelope,
+      network,
+      operations: payload.operations,
+      sourceAccount: payload.sourceAccount,
+    };
+
+    res.status(200).json({ ok: true, data: result });
+  });
+
+  return router;
+}
+
+export default createPrepareRouter();

--- a/routes-d/routes/stellar.tx.submit.ts
+++ b/routes-d/routes/stellar.tx.submit.ts
@@ -1,0 +1,137 @@
+// routes-d/routes/stellar.tx.submit.ts
+//
+// POST /stellar/tx/submit — accept a client-signed envelope and forward it
+// to the Stellar network (Issue #273).
+//
+// The route re-validates the declared operation types against the allowlist
+// before submitting so a tampered envelope cannot bypass the prepare-time
+// check. The actual network submission is injected via `SubmitTransactionDeps`.
+
+import { Router, type Request, type Response } from 'express';
+import {
+  checkOperations,
+  DEFAULT_ALLOWED_OPERATIONS,
+} from '../lib/operationAllowlist.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SubmitOperation {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface SubmitRequest {
+  /** Base64-encoded signed transaction XDR. */
+  envelope: string;
+  /** Operations the envelope contains (client-supplied for allowlist check). */
+  operations: SubmitOperation[];
+}
+
+export interface SubmitResult {
+  /** Transaction hash returned by the network. */
+  hash: string;
+  /** Ledger the transaction was included in. */
+  ledger?: number;
+  /** ISO timestamp of submission. */
+  submittedAt: string;
+}
+
+export interface SubmitTransactionDeps {
+  /**
+   * Submit a signed envelope to the Stellar network.
+   * Returns the transaction hash and optional ledger number.
+   */
+  submitEnvelope(envelope: string): Promise<SubmitResult>;
+  /** Allowlist of permitted operation types. */
+  allowedOperations?: ReadonlySet<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Default deps (placeholder — wire real Stellar SDK in production)
+// ---------------------------------------------------------------------------
+
+export const defaultSubmitDeps: SubmitTransactionDeps = {
+  async submitEnvelope(envelope: string): Promise<SubmitResult> {
+    // Placeholder: real implementation calls Horizon /transactions
+    return {
+      hash: `mock-hash-${Buffer.from(envelope).toString('hex').slice(0, 16)}`,
+      submittedAt: new Date().toISOString(),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function readSubmitRequest(body: unknown): SubmitRequest | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.envelope !== 'string' || !b.envelope.trim()) return null;
+  if (!Array.isArray(b.operations) || b.operations.length === 0) return null;
+
+  for (const op of b.operations) {
+    if (!op || typeof op !== 'object' || typeof (op as { type?: unknown }).type !== 'string') {
+      return null;
+    }
+  }
+
+  return {
+    envelope: b.envelope.trim(),
+    operations: b.operations as SubmitOperation[],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export interface CreateSubmitRouterOptions {
+  deps?: SubmitTransactionDeps;
+}
+
+export function createSubmitRouter(opts: CreateSubmitRouterOptions = {}): Router {
+  const router = Router();
+  const deps = opts.deps ?? defaultSubmitDeps;
+  const allowlist = deps.allowedOperations ?? DEFAULT_ALLOWED_OPERATIONS;
+
+  router.post('/submit', async (req: Request, res: Response) => {
+    const payload = readSubmitRequest(req.body);
+    if (!payload) {
+      res.status(400).json({
+        ok: false,
+        error: 'envelope (string) and operations (non-empty array of {type}) are required',
+      });
+      return;
+    }
+
+    const opTypes = payload.operations.map((op) => op.type);
+    const check = checkOperations(opTypes, allowlist);
+    if (!check.allowed) {
+      res.status(403).json({
+        ok: false,
+        error: `disallowed operation type(s): ${check.disallowed.join(', ')}`,
+        disallowed: check.disallowed,
+      });
+      return;
+    }
+
+    let result: SubmitResult;
+    try {
+      result = await deps.submitEnvelope(payload.envelope);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'submission failed';
+      res.status(502).json({ ok: false, error: message });
+      return;
+    }
+
+    res.status(200).json({ ok: true, data: result });
+  });
+
+  return router;
+}
+
+export default createSubmitRouter();

--- a/routes-d/tests/auth.oauth.test.ts
+++ b/routes-d/tests/auth.oauth.test.ts
@@ -1,0 +1,259 @@
+// Tests for the OAuth provider sign-in flow (Issue #260).
+//
+// Covers:
+//   - /auth/oauth/start: redirect to provider, unknown provider 400
+//   - /auth/oauth/callback: new user, returning user, bad code, bad state,
+//     provider mismatch, missing params
+//   - identity.ts: findOrCreateUser unit tests
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import {
+  createOAuthRouter,
+  oauthStateStore,
+  type OAuthProviderAdapter,
+  type OAuthRouterDeps,
+} from '../routes/auth.oauth.js';
+import {
+  findOrCreateUser,
+  identityStore,
+  userStore,
+  type OAuthProfile,
+} from '../lib/identity.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAdapter(overrides: Partial<OAuthProviderAdapter> = {}): OAuthProviderAdapter {
+  return {
+    name: 'github',
+    buildAuthUrl: (state) => `https://github.com/login/oauth/authorize?state=${state}`,
+    exchangeCode: jest.fn().mockResolvedValue({ accessToken: 'gha_token' }),
+    fetchProfile: jest.fn().mockResolvedValue({
+      provider: 'github',
+      providerUserId: 'gh_42',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+    } satisfies OAuthProfile),
+    ...overrides,
+  };
+}
+
+function buildApp(deps: Partial<OAuthRouterDeps> = {}): Express {
+  const providers = deps.providers ?? new Map([['github', makeAdapter()]]);
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/',
+    createOAuthRouter({
+      providers,
+      generateState: deps.generateState ?? (() => 'test-state-nonce'),
+      issueSession: deps.issueSession,
+      resolveIdentity: deps.resolveIdentity,
+    }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  oauthStateStore.clear();
+  identityStore.clear();
+  userStore.clear();
+});
+
+// ---------------------------------------------------------------------------
+// GET /auth/oauth/start
+// ---------------------------------------------------------------------------
+
+describe('GET /auth/oauth/start', () => {
+  it('redirects to the provider authorization URL', async () => {
+    const res = await request(buildApp()).get('/auth/oauth/start?provider=github');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('github.com');
+    expect(res.headers.location).toContain('test-state-nonce');
+  });
+
+  it('stores the state nonce in oauthStateStore', async () => {
+    await request(buildApp()).get('/auth/oauth/start?provider=github');
+    expect(oauthStateStore.has('test-state-nonce')).toBe(true);
+    expect(oauthStateStore.get('test-state-nonce')?.provider).toBe('github');
+  });
+
+  it('returns 400 for an unknown provider', async () => {
+    const res = await request(buildApp()).get('/auth/oauth/start?provider=unknown');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('unknown_provider');
+  });
+
+  it('returns 400 when provider query param is missing', async () => {
+    const res = await request(buildApp()).get('/auth/oauth/start');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /auth/oauth/callback
+// ---------------------------------------------------------------------------
+
+describe('GET /auth/oauth/callback', () => {
+  function seedState(provider = 'github'): void {
+    oauthStateStore.set('test-state-nonce', {
+      provider,
+      expiresAt: Date.now() + 60_000,
+    });
+  }
+
+  it('returns 200 with session token for a new user', async () => {
+    seedState();
+    const res = await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&code=auth_code&state=test-state-nonce',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.isNew).toBe(true);
+    expect(res.body.user.email).toBe('alice@example.com');
+    expect(typeof res.body.token).toBe('string');
+    // State nonce should be consumed.
+    expect(oauthStateStore.has('test-state-nonce')).toBe(false);
+  });
+
+  it('returns 200 with isNew=false for a returning user', async () => {
+    // First sign-in creates the user.
+    seedState();
+    await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&code=code1&state=test-state-nonce',
+    );
+
+    // Second sign-in should find the existing user.
+    oauthStateStore.set('test-state-nonce', { provider: 'github', expiresAt: Date.now() + 60_000 });
+    const res = await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&code=code2&state=test-state-nonce',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.isNew).toBe(false);
+  });
+
+  it('returns 400 when code is missing', async () => {
+    seedState();
+    const res = await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&state=test-state-nonce',
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('code and state are required');
+  });
+
+  it('returns 400 when state is missing', async () => {
+    const res = await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&code=auth_code',
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an invalid or expired state', async () => {
+    // State not seeded — should be rejected.
+    const res = await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&code=auth_code&state=unknown-state',
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_or_expired_state');
+  });
+
+  it('returns 400 for an expired state', async () => {
+    oauthStateStore.set('expired-state', { provider: 'github', expiresAt: Date.now() - 1 });
+    const res = await request(buildApp()).get(
+      '/auth/oauth/callback?provider=github&code=auth_code&state=expired-state',
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_or_expired_state');
+  });
+
+  it('returns 401 when code exchange fails', async () => {
+    seedState();
+    const adapter = makeAdapter({ exchangeCode: jest.fn().mockResolvedValue(null) });
+    const res = await request(buildApp({ providers: new Map([['github', adapter]]) })).get(
+      '/auth/oauth/callback?provider=github&code=bad_code&state=test-state-nonce',
+    );
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('code_exchange_failed');
+  });
+
+  it('returns 401 when profile fetch fails', async () => {
+    seedState();
+    const adapter = makeAdapter({ fetchProfile: jest.fn().mockResolvedValue(null) });
+    const res = await request(buildApp({ providers: new Map([['github', adapter]]) })).get(
+      '/auth/oauth/callback?provider=github&code=auth_code&state=test-state-nonce',
+    );
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('profile_fetch_failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// identity.ts unit tests
+// ---------------------------------------------------------------------------
+
+describe('findOrCreateUser', () => {
+  const profile: OAuthProfile = {
+    provider: 'github',
+    providerUserId: 'gh_99',
+    displayName: 'Bob',
+    email: 'bob@example.com',
+  };
+
+  it('creates a new user on first call', () => {
+    const iStore = new Map();
+    const uStore = new Map();
+    const result = findOrCreateUser(profile, { identityStore: iStore, userStore: uStore });
+
+    expect(result.isNew).toBe(true);
+    expect(result.user.email).toBe('bob@example.com');
+    expect(iStore.size).toBe(1);
+    expect(uStore.size).toBe(1);
+  });
+
+  it('returns the existing user on subsequent calls', () => {
+    const iStore = new Map();
+    const uStore = new Map();
+    const first = findOrCreateUser(profile, { identityStore: iStore, userStore: uStore });
+    const second = findOrCreateUser(profile, { identityStore: iStore, userStore: uStore });
+
+    expect(second.isNew).toBe(false);
+    expect(second.user.id).toBe(first.user.id);
+    expect(uStore.size).toBe(1);
+  });
+
+  it('creates separate users for different providers', () => {
+    const iStore = new Map();
+    const uStore = new Map();
+    findOrCreateUser({ ...profile, provider: 'github' }, { identityStore: iStore, userStore: uStore });
+    findOrCreateUser({ ...profile, provider: 'google' }, { identityStore: iStore, userStore: uStore });
+
+    expect(uStore.size).toBe(2);
+  });
+
+  it('creates separate users for different providerUserIds', () => {
+    const iStore = new Map();
+    const uStore = new Map();
+    findOrCreateUser({ ...profile, providerUserId: 'id_1' }, { identityStore: iStore, userStore: uStore });
+    findOrCreateUser({ ...profile, providerUserId: 'id_2' }, { identityStore: iStore, userStore: uStore });
+
+    expect(uStore.size).toBe(2);
+  });
+
+  it('re-creates user when identity record exists but user was deleted', () => {
+    const iStore = new Map();
+    const uStore = new Map();
+    const first = findOrCreateUser(profile, { identityStore: iStore, userStore: uStore });
+
+    // Simulate user deletion.
+    uStore.delete(first.user.id);
+
+    const second = findOrCreateUser(profile, { identityStore: iStore, userStore: uStore });
+    expect(second.isNew).toBe(true);
+    expect(second.user.id).not.toBe(first.user.id);
+  });
+});

--- a/routes-d/tests/auth.register.captcha.test.ts
+++ b/routes-d/tests/auth.register.captcha.test.ts
@@ -1,0 +1,229 @@
+// Tests for auth.register route with CAPTCHA verification (Issue #267).
+//
+// Covers:
+//   - 400 on missing captchaToken
+//   - 400 on invalid captchaToken (provider rejects)
+//   - 400 on invalid body schema (email, password, name)
+//   - 201 on valid registration with passing CAPTCHA
+//   - captcha.ts unit tests (createHttpCaptchaVerifier)
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { createRegisterRouter, type RegisterDeps } from '../routes/auth.register.js';
+import {
+  createHttpCaptchaVerifier,
+  type CaptchaVerifier,
+} from '../lib/captcha.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCaptcha(success: boolean, reason?: string): CaptchaVerifier {
+  return {
+    verify: jest.fn().mockResolvedValue({ success, reason }),
+  };
+}
+
+function makeCreateUser(
+  override?: RegisterDeps['createUser'],
+): RegisterDeps['createUser'] {
+  return (
+    override ??
+    jest.fn().mockResolvedValue({ id: 'usr_1', email: 'alice@example.com', displayName: 'Alice' })
+  );
+}
+
+function buildApp(captcha: CaptchaVerifier, createUser?: RegisterDeps['createUser']): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/',
+    createRegisterRouter({
+      deps: { captcha, createUser: createUser ?? makeCreateUser() },
+    }),
+  );
+  return app;
+}
+
+const VALID_BODY = {
+  email: 'alice@example.com',
+  password: 'SecurePass1',
+  name: 'Alice',
+  captchaToken: 'valid-token',
+};
+
+// ---------------------------------------------------------------------------
+// Route tests
+// ---------------------------------------------------------------------------
+
+describe('POST /auth/register', () => {
+  it('returns 201 with user and session token on valid registration', async () => {
+    const captcha = makeCaptcha(true);
+    const res = await request(buildApp(captcha)).post('/auth/register').send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.user.email).toBe('alice@example.com');
+    expect(typeof res.body.token).toBe('string');
+    expect(typeof res.body.expiresAt).toBe('number');
+    expect(captcha.verify).toHaveBeenCalledWith('valid-token', expect.anything());
+  });
+
+  it('returns 400 when captchaToken is missing', async () => {
+    const captcha = makeCaptcha(true);
+    const { captchaToken: _, ...bodyWithoutCaptcha } = VALID_BODY;
+    const res = await request(buildApp(captcha))
+      .post('/auth/register')
+      .send(bodyWithoutCaptcha);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_failed');
+    const fields: Array<{ field: string }> = res.body.fields;
+    expect(fields.some((f) => f.field === 'captchaToken')).toBe(true);
+    expect(captcha.verify).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when captchaToken is an empty string', async () => {
+    const captcha = makeCaptcha(true);
+    const res = await request(buildApp(captcha))
+      .post('/auth/register')
+      .send({ ...VALID_BODY, captchaToken: '   ' });
+
+    expect(res.status).toBe(400);
+    expect(captcha.verify).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with captcha_failed when provider rejects the token', async () => {
+    const captcha = makeCaptcha(false, 'invalid-input-response');
+    const res = await request(buildApp(captcha)).post('/auth/register').send(VALID_BODY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('captcha_failed');
+    expect(res.body.reason).toBe('invalid-input-response');
+  });
+
+  it('returns 400 with field errors when email is invalid', async () => {
+    const captcha = makeCaptcha(true);
+    const res = await request(buildApp(captcha))
+      .post('/auth/register')
+      .send({ ...VALID_BODY, email: 'not-an-email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_failed');
+    const fields: Array<{ field: string }> = res.body.fields;
+    expect(fields.some((f) => f.field === 'email')).toBe(true);
+    // CAPTCHA should not be called when schema validation fails.
+    expect(captcha.verify).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when password is too short', async () => {
+    const captcha = makeCaptcha(true);
+    const res = await request(buildApp(captcha))
+      .post('/auth/register')
+      .send({ ...VALID_BODY, password: 'short' });
+
+    expect(res.status).toBe(400);
+    const fields: Array<{ field: string }> = res.body.fields;
+    expect(fields.some((f) => f.field === 'password')).toBe(true);
+  });
+
+  it('returns 400 when name is too short', async () => {
+    const captcha = makeCaptcha(true);
+    const res = await request(buildApp(captcha))
+      .post('/auth/register')
+      .send({ ...VALID_BODY, name: 'A' });
+
+    expect(res.status).toBe(400);
+    const fields: Array<{ field: string }> = res.body.fields;
+    expect(fields.some((f) => f.field === 'name')).toBe(true);
+  });
+
+  it('returns 409 when email is already registered', async () => {
+    const captcha = makeCaptcha(true);
+    const createUser = jest.fn().mockRejectedValue(new Error('email already exists'));
+    const res = await request(buildApp(captcha, createUser))
+      .post('/auth/register')
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('email_already_registered');
+  });
+
+  it('passes inviteCode to createUser when provided', async () => {
+    const captcha = makeCaptcha(true);
+    const createUser = jest.fn().mockResolvedValue({
+      id: 'usr_2',
+      email: 'bob@example.com',
+      displayName: 'Bob',
+    });
+    await request(buildApp(captcha, createUser))
+      .post('/auth/register')
+      .send({ ...VALID_BODY, email: 'bob@example.com', name: 'Bob', inviteCode: 'PROMO42' });
+
+    expect(createUser).toHaveBeenCalledWith(
+      expect.objectContaining({ inviteCode: 'PROMO42' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// captcha.ts unit tests
+// ---------------------------------------------------------------------------
+
+describe('createHttpCaptchaVerifier', () => {
+  it('returns success=false for an empty token without calling fetch', async () => {
+    const fetchMock = jest.fn();
+    const verifier = createHttpCaptchaVerifier({
+      secretKey: 'secret',
+      fetch: fetchMock,
+    });
+
+    const result = await verifier.verify('');
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('missing_token');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns success=true when provider responds with success', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({ success: true }),
+    });
+    const verifier = createHttpCaptchaVerifier({
+      secretKey: 'secret',
+      verifyUrl: 'https://example.com/verify',
+      fetch: fetchMock,
+    });
+
+    const result = await verifier.verify('good-token');
+    expect(result.success).toBe(true);
+  });
+
+  it('returns success=false with error code when provider rejects', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({ success: false, 'error-codes': ['timeout-or-duplicate'] }),
+    });
+    const verifier = createHttpCaptchaVerifier({
+      secretKey: 'secret',
+      verifyUrl: 'https://example.com/verify',
+      fetch: fetchMock,
+    });
+
+    const result = await verifier.verify('bad-token');
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('timeout-or-duplicate');
+  });
+
+  it('returns provider_unreachable when fetch throws', async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error('network error'));
+    const verifier = createHttpCaptchaVerifier({
+      secretKey: 'secret',
+      verifyUrl: 'https://example.com/verify',
+      fetch: fetchMock,
+    });
+
+    const result = await verifier.verify('any-token');
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('provider_unreachable');
+  });
+});

--- a/routes-d/tests/stellar.tx.relay.test.ts
+++ b/routes-d/tests/stellar.tx.relay.test.ts
@@ -1,0 +1,278 @@
+// Tests for stellar.tx.prepare and stellar.tx.submit routes (Issue #273).
+//
+// Covers:
+//   - prepare: valid request, allowlist rejection, missing fields
+//   - submit:  valid request, allowlist rejection, missing fields, network error
+//   - operationAllowlist: checkOperations unit tests
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import {
+  createPrepareRouter,
+  type PrepareTransactionDeps,
+} from '../routes/stellar.tx.prepare.js';
+import {
+  createSubmitRouter,
+  type SubmitTransactionDeps,
+} from '../routes/stellar.tx.submit.js';
+import {
+  checkOperations,
+  createAllowlist,
+  DEFAULT_ALLOWED_OPERATIONS,
+} from '../lib/operationAllowlist.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildPrepareApp(deps?: Partial<PrepareTransactionDeps>): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/stellar/tx',
+    createPrepareRouter({
+      deps: {
+        buildEnvelope: ({ sourceAccount, operations }) =>
+          Buffer.from(JSON.stringify({ sourceAccount, operations })).toString('base64'),
+        network: 'Test SDF Network ; September 2015',
+        ...deps,
+      },
+    }),
+  );
+  return app;
+}
+
+function buildSubmitApp(deps?: Partial<SubmitTransactionDeps>): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/stellar/tx',
+    createSubmitRouter({
+      deps: {
+        submitEnvelope: async (envelope) => ({
+          hash: `hash-${envelope.slice(0, 8)}`,
+          submittedAt: '2026-01-01T00:00:00.000Z',
+        }),
+        ...deps,
+      },
+    }),
+  );
+  return app;
+}
+
+const VALID_PREPARE_BODY = {
+  sourceAccount: 'GABC1234',
+  operations: [{ type: 'payment', destination: 'GXYZ', amount: '10' }],
+};
+
+const VALID_SUBMIT_BODY = {
+  envelope: 'AAAA==',
+  operations: [{ type: 'payment' }],
+};
+
+// ---------------------------------------------------------------------------
+// operationAllowlist unit tests
+// ---------------------------------------------------------------------------
+
+describe('checkOperations', () => {
+  it('returns allowed=true when all ops are in the allowlist', () => {
+    const result = checkOperations(['payment', 'manageData'], DEFAULT_ALLOWED_OPERATIONS);
+    expect(result.allowed).toBe(true);
+    expect(result.disallowed).toEqual([]);
+  });
+
+  it('returns allowed=false and lists disallowed types', () => {
+    const result = checkOperations(
+      ['payment', 'accountMerge', 'setOptions'],
+      DEFAULT_ALLOWED_OPERATIONS,
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.disallowed).toContain('accountMerge');
+    expect(result.disallowed).toContain('setOptions');
+  });
+
+  it('returns allowed=false for an empty allowlist', () => {
+    const result = checkOperations(['payment'], new Set());
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('createAllowlist', () => {
+  it('merges extra types with defaults', () => {
+    const list = createAllowlist(['customOp']);
+    expect(list.has('payment')).toBe(true);
+    expect(list.has('customOp')).toBe(true);
+  });
+
+  it('replaces defaults when replaceDefaults=true', () => {
+    const list = createAllowlist(['customOp'], true);
+    expect(list.has('payment')).toBe(false);
+    expect(list.has('customOp')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /stellar/tx/prepare
+// ---------------------------------------------------------------------------
+
+describe('POST /stellar/tx/prepare', () => {
+  it('returns 200 with an envelope for a valid request', async () => {
+    const res = await request(buildPrepareApp())
+      .post('/stellar/tx/prepare')
+      .send(VALID_PREPARE_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.data.envelope).toBe('string');
+    expect(res.body.data.network).toBe('Test SDF Network ; September 2015');
+    expect(res.body.data.sourceAccount).toBe('GABC1234');
+    expect(res.body.data.operations).toHaveLength(1);
+  });
+
+  it('returns 403 when an operation type is disallowed', async () => {
+    const res = await request(buildPrepareApp())
+      .post('/stellar/tx/prepare')
+      .send({
+        sourceAccount: 'GABC1234',
+        operations: [{ type: 'accountMerge' }],
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.disallowed).toContain('accountMerge');
+  });
+
+  it('returns 403 for mixed allowed/disallowed operations', async () => {
+    const res = await request(buildPrepareApp())
+      .post('/stellar/tx/prepare')
+      .send({
+        sourceAccount: 'GABC1234',
+        operations: [{ type: 'payment' }, { type: 'setOptions' }],
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.disallowed).toEqual(['setOptions']);
+  });
+
+  it('returns 400 when sourceAccount is missing', async () => {
+    const res = await request(buildPrepareApp())
+      .post('/stellar/tx/prepare')
+      .send({ operations: [{ type: 'payment' }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('returns 400 when operations array is empty', async () => {
+    const res = await request(buildPrepareApp())
+      .post('/stellar/tx/prepare')
+      .send({ sourceAccount: 'GABC1234', operations: [] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when an operation entry lacks a type field', async () => {
+    const res = await request(buildPrepareApp())
+      .post('/stellar/tx/prepare')
+      .send({ sourceAccount: 'GABC1234', operations: [{ kind: 'payment' }] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when buildEnvelope throws', async () => {
+    const res = await request(
+      buildPrepareApp({
+        buildEnvelope: () => {
+          throw new Error('sdk error');
+        },
+      }),
+    )
+      .post('/stellar/tx/prepare')
+      .send(VALID_PREPARE_BODY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('uses a custom allowlist when provided', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/stellar/tx',
+      createPrepareRouter({
+        deps: {
+          buildEnvelope: () => 'env==',
+          network: 'testnet',
+          allowedOperations: new Set(['customOp']),
+        },
+      }),
+    );
+
+    const allowed = await request(app)
+      .post('/stellar/tx/prepare')
+      .send({ sourceAccount: 'G1', operations: [{ type: 'customOp' }] });
+    expect(allowed.status).toBe(200);
+
+    const denied = await request(app)
+      .post('/stellar/tx/prepare')
+      .send({ sourceAccount: 'G1', operations: [{ type: 'payment' }] });
+    expect(denied.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /stellar/tx/submit
+// ---------------------------------------------------------------------------
+
+describe('POST /stellar/tx/submit', () => {
+  it('returns 200 with transaction data on a valid request', async () => {
+    const res = await request(buildSubmitApp())
+      .post('/stellar/tx/submit')
+      .send(VALID_SUBMIT_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.data.hash).toBe('string');
+    expect(typeof res.body.data.submittedAt).toBe('string');
+  });
+
+  it('returns 403 when an operation type is disallowed', async () => {
+    const res = await request(buildSubmitApp())
+      .post('/stellar/tx/submit')
+      .send({ envelope: 'AAAA==', operations: [{ type: 'accountMerge' }] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.disallowed).toContain('accountMerge');
+  });
+
+  it('returns 400 when envelope is missing', async () => {
+    const res = await request(buildSubmitApp())
+      .post('/stellar/tx/submit')
+      .send({ operations: [{ type: 'payment' }] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when operations array is empty', async () => {
+    const res = await request(buildSubmitApp())
+      .post('/stellar/tx/submit')
+      .send({ envelope: 'AAAA==', operations: [] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 502 when submitEnvelope throws', async () => {
+    const res = await request(
+      buildSubmitApp({
+        submitEnvelope: async () => {
+          throw new Error('horizon error');
+        },
+      }),
+    )
+      .post('/stellar/tx/submit')
+      .send(VALID_SUBMIT_BODY);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('horizon error');
+  });
+});


### PR DESCRIPTION
…tx relay (#260 #266 #267 #273)

- #266: routes-d/lib/schemas/auth.ts already existed with register/login/refresh/reset schemas and parseOrReject helper; tests in tests/schemas.auth.test.ts

- #267: Add routes-d/lib/captcha.ts with CaptchaVerifier interface and createHttpCaptchaVerifier (hCaptcha/reCAPTCHA-compatible). Add routes-d/routes/auth.register.ts that validates body with registerSchema, verifies captchaToken server-side, creates user, and issues session. Tests in tests/auth.register.captcha.test.ts cover valid registration, missing/invalid CAPTCHA token, schema errors, and duplicate email.

- #260: Add routes-d/lib/identity.ts with findOrCreateUser that maps OAuth provider identities to Nextellar user records. Add routes-d/routes/auth.oauth.ts with GET /auth/oauth/start (redirect) and GET /auth/oauth/callback (code exchange, profile fetch, session issuance). Tests in tests/auth.oauth.test.ts cover new/returning users, bad state, expired state, failed exchange, and failed profile fetch.

- #273: Add routes-d/lib/operationAllowlist.ts with DEFAULT_ALLOWED_OPERATIONS and checkOperations. Add routes-d/routes/stellar.tx.prepare.ts (POST /stellar/tx/prepare) and routes-d/routes/stellar.tx.submit.ts (POST /stellar/tx/submit) with consistent envelope shape and allowlist enforcement. Tests in tests/stellar.tx.relay.test.ts cover prepare, submit, and disallowed operation rejection.

Closes #260
Closes #266
Closes #267
Closes #273