### PR TITLE
Add routes-d order list, notes, resilience, and setup docs.

### DIFF
--- a/routes-d/docs/setup.md
+++ b/routes-d/docs/setup.md
@@ -1,0 +1,81 @@
+# routes-d contributor setup
+
+## Prerequisites
+
+- Node.js 20 or newer
+- npm 10 or newer
+
+## Install
+
+From the repository root:
+
+```bash
+cd routes-d
+npm install
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+TypeScript output is written to `routes-d/dist/`.
+
+## Run tests
+
+Run the full routes-d Jest suite:
+
+```bash
+npm test
+```
+
+Run only unit tests:
+
+```bash
+npm run test:unit
+```
+
+Run only integration tests:
+
+```bash
+npm run test:integration
+```
+
+Run a single file:
+
+```bash
+npx jest --config jest.config.js tests/orders.list.test.ts
+```
+
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `ROUTES_D_CURSOR_SECRET` | Signs cursor tokens for paginated list routes (16+ characters in production) |
+| `HORIZON_URL` / `HORIZON_PRIMARY_URL` | Primary Horizon endpoint |
+| `HORIZON_FALLBACK_URL` | Optional fallback Horizon endpoint |
+| `HORIZON_TIMEOUT_MS` | Per-request Horizon timeout |
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint for invoke and health routes |
+
+## Troubleshooting
+
+### `Invalid cursor signature` during list tests
+
+Set `ROUTES_D_CURSOR_SECRET` to the same value used when the cursor was created. Local tests inject a fixed secret in the router options.
+
+### Jest ESM import errors
+
+Ensure `NODE_OPTIONS=--experimental-vm-modules` is set. The `npm test` script in `routes-d/package.json` sets this automatically.
+
+### TypeScript cannot find `.js` imports
+
+routes-d uses NodeNext module resolution. Keep import specifiers aligned with emitted `.js` filenames (for example `../lib/pagination.js`).
+
+### Horizon or Soroban tests time out
+
+Chaos and client tests stub `fetch` or inject RPC mocks. If a test reaches the network, confirm the test uses the provided fake fetcher rather than the default global `fetch`.
+
+### `npm test` passes locally but fails in CI
+
+Run `npm run build` before tests in CI if a job compiles routes-d separately. Confirm the job executes from `routes-d/` with devDependencies installed.

--- a/routes-d/lib/circuitBreaker.ts
+++ b/routes-d/lib/circuitBreaker.ts
@@ -1,0 +1,90 @@
+export type CircuitState = "closed" | "open" | "half-open";
+
+export interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  resetTimeoutMs?: number;
+  halfOpenSuccessThreshold?: number;
+}
+
+export class CircuitOpenError extends Error {
+  readonly state: CircuitState = "open";
+
+  constructor(message = "circuit breaker is open") {
+    super(message);
+    this.name = "CircuitOpenError";
+  }
+}
+
+export class CircuitBreaker {
+  private state: CircuitState = "closed";
+  private consecutiveFailures = 0;
+  private halfOpenSuccesses = 0;
+  private openedAt = 0;
+  private readonly failureThreshold: number;
+  private readonly resetTimeoutMs: number;
+  private readonly halfOpenSuccessThreshold: number;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.failureThreshold = options.failureThreshold ?? 3;
+    this.resetTimeoutMs = options.resetTimeoutMs ?? 5_000;
+    this.halfOpenSuccessThreshold = options.halfOpenSuccessThreshold ?? 1;
+  }
+
+  getState(now = Date.now()): CircuitState {
+    if (this.state === "open" && now - this.openedAt >= this.resetTimeoutMs) {
+      this.state = "half-open";
+      this.halfOpenSuccesses = 0;
+    }
+    return this.state;
+  }
+
+  async execute<T>(fn: () => Promise<T>, now = Date.now()): Promise<T> {
+    const state = this.getState(now);
+    if (state === "open") {
+      throw new CircuitOpenError();
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      this.onFailure(now);
+      throw err;
+    }
+  }
+
+  private onSuccess(): void {
+    if (this.state === "half-open") {
+      this.halfOpenSuccesses += 1;
+      if (this.halfOpenSuccesses >= this.halfOpenSuccessThreshold) {
+        this.state = "closed";
+        this.consecutiveFailures = 0;
+        this.halfOpenSuccesses = 0;
+      }
+      return;
+    }
+
+    this.state = "closed";
+    this.consecutiveFailures = 0;
+  }
+
+  private onFailure(now: number): void {
+    if (this.state === "half-open") {
+      this.trip(now);
+      return;
+    }
+
+    this.consecutiveFailures += 1;
+    if (this.consecutiveFailures >= this.failureThreshold) {
+      this.trip(now);
+    }
+  }
+
+  private trip(now: number): void {
+    this.state = "open";
+    this.openedAt = now;
+    this.consecutiveFailures = 0;
+    this.halfOpenSuccesses = 0;
+  }
+}

--- a/routes-d/lib/orderList.ts
+++ b/routes-d/lib/orderList.ts
@@ -1,0 +1,117 @@
+import { decodeCursor, encodeCursor, type CursorSortKey } from "./pagination.js";
+import type { IndexedOrder, OrderSearchQuery, OrderStatus } from "./orderIndex.js";
+
+export interface OrderListQuery {
+  status?: OrderStatus;
+  customer?: string;
+  from?: number;
+  to?: number;
+  sortBy?: NonNullable<OrderSearchQuery["sortBy"]>;
+  sortDir?: NonNullable<OrderSearchQuery["sortDir"]>;
+  limit?: number;
+  cursor?: string;
+  cursorSecret?: string;
+}
+
+export interface OrderListPage {
+  results: IndexedOrder[];
+  pagination: {
+    limit: number;
+    nextCursor?: string;
+    hasMore: boolean;
+  };
+}
+
+export const DEFAULT_LIST_LIMIT = 20;
+export const MAX_LIST_LIMIT = 100;
+
+function compareOrders(
+  a: IndexedOrder,
+  b: IndexedOrder,
+  sortBy: NonNullable<OrderSearchQuery["sortBy"]>,
+  sortDir: NonNullable<OrderSearchQuery["sortDir"]>,
+): number {
+  let cmp = 0;
+  if (sortBy === "amount") cmp = a.amount - b.amount;
+  else if (sortBy === "customer") cmp = a.customer.localeCompare(b.customer);
+  else cmp = a.createdAt - b.createdAt;
+  if (cmp !== 0) return sortDir === "asc" ? cmp : -cmp;
+  return a.id.localeCompare(b.id);
+}
+
+function sortValue(order: IndexedOrder, sortBy: NonNullable<OrderSearchQuery["sortBy"]>): CursorSortKey["value"] {
+  if (sortBy === "amount") return order.amount;
+  if (sortBy === "customer") return order.customer;
+  return order.createdAt;
+}
+
+function cursorAnchor(keys: CursorSortKey[]): IndexedOrder {
+  const anchor: IndexedOrder = {
+    id: "",
+    customer: "",
+    amount: 0,
+    createdAt: 0,
+    status: "pending",
+  };
+  for (const key of keys) {
+    if (key.field === "id") anchor.id = String(key.value);
+    if (key.field === "customer") anchor.customer = String(key.value);
+    if (key.field === "amount") anchor.amount = Number(key.value);
+    if (key.field === "createdAt") anchor.createdAt = Number(key.value);
+  }
+  return anchor;
+}
+
+function isAfterCursor(
+  order: IndexedOrder,
+  keys: CursorSortKey[],
+  sortBy: NonNullable<OrderSearchQuery["sortBy"]>,
+  sortDir: NonNullable<OrderSearchQuery["sortDir"]>,
+): boolean {
+  return compareOrders(order, cursorAnchor(keys), sortBy, sortDir) > 0;
+}
+
+export function listOrdersWithCursor(orders: IndexedOrder[], query: OrderListQuery): OrderListPage {
+  const sortBy = query.sortBy ?? "createdAt";
+  const sortDir = query.sortDir ?? "desc";
+  const limit = Math.min(MAX_LIST_LIMIT, Math.max(1, query.limit ?? DEFAULT_LIST_LIMIT));
+  const customer = query.customer?.toLowerCase().trim();
+
+  let matches = orders.filter((order) => {
+    if (query.status && order.status !== query.status) return false;
+    if (customer && !order.customer.toLowerCase().includes(customer)) return false;
+    if (query.from !== undefined && order.createdAt < query.from) return false;
+    if (query.to !== undefined && order.createdAt > query.to) return false;
+    return true;
+  });
+
+  matches.sort((a, b) => compareOrders(a, b, sortBy, sortDir));
+
+  if (query.cursor) {
+    const payload = decodeCursor(query.cursor, { secret: query.cursorSecret });
+    matches = matches.filter((order) => isAfterCursor(order, payload.sort, sortBy, sortDir));
+  }
+
+  const slice = matches.slice(0, limit);
+  const hasMore = matches.length > limit;
+  const last = slice.at(-1);
+  const nextCursor =
+    hasMore && last
+      ? encodeCursor(
+          [
+            { field: sortBy, direction: sortDir, value: sortValue(last, sortBy) },
+            { field: "id", direction: "asc", value: last.id },
+          ],
+          { secret: query.cursorSecret },
+        )
+      : undefined;
+
+  return {
+    results: slice,
+    pagination: {
+      limit,
+      nextCursor,
+      hasMore,
+    },
+  };
+}

--- a/routes-d/lib/orderNotes.ts
+++ b/routes-d/lib/orderNotes.ts
@@ -1,0 +1,63 @@
+export type OrderNoteType = "internal" | "customer";
+
+export interface OrderNote {
+  id: string;
+  orderId: string;
+  type: OrderNoteType;
+  body: string;
+  authorId: string;
+  authorRole: string;
+  createdAt: number;
+}
+
+export interface CreateOrderNoteInput {
+  orderId: string;
+  type: OrderNoteType;
+  body: string;
+  authorId: string;
+  authorRole: string;
+  createdAt?: number;
+}
+
+export interface OrderNotesStore {
+  create(input: CreateOrderNoteInput): Promise<OrderNote>;
+  listByOrder(orderId: string, opts?: { visibleToCustomer?: boolean }): Promise<OrderNote[]>;
+}
+
+let noteSeq = 0;
+
+export function __resetOrderNoteIds(): void {
+  noteSeq = 0;
+}
+
+export class InMemoryOrderNotesStore implements OrderNotesStore {
+  private readonly notes: OrderNote[] = [];
+
+  async create(input: CreateOrderNoteInput): Promise<OrderNote> {
+    const note: OrderNote = {
+      id: `note_${++noteSeq}`,
+      orderId: input.orderId,
+      type: input.type,
+      body: input.body.trim(),
+      authorId: input.authorId,
+      authorRole: input.authorRole,
+      createdAt: input.createdAt ?? Date.now(),
+    };
+    this.notes.push(note);
+    return note;
+  }
+
+  async listByOrder(orderId: string, opts: { visibleToCustomer?: boolean } = {}): Promise<OrderNote[]> {
+    const filtered = this.notes.filter((n) => n.orderId === orderId);
+    if (opts.visibleToCustomer) {
+      return filtered
+        .filter((n) => n.type === "customer")
+        .sort((a, b) => a.createdAt - b.createdAt);
+    }
+    return filtered.slice().sort((a, b) => a.createdAt - b.createdAt);
+  }
+}
+
+export function isOrderNoteType(value: unknown): value is OrderNoteType {
+  return value === "internal" || value === "customer";
+}

--- a/routes-d/lib/resilientStellar.ts
+++ b/routes-d/lib/resilientStellar.ts
@@ -1,0 +1,57 @@
+import { CircuitBreaker, CircuitOpenError } from "./circuitBreaker.js";
+import {
+  createHorizonClient,
+  type HorizonClient,
+  type HorizonClientOptions,
+  type HorizonFailoverEvent,
+} from "./horizonClient.js";
+
+export interface ResilientHorizonOptions extends HorizonClientOptions {
+  circuitBreaker?: ConstructorParameters<typeof CircuitBreaker>[0];
+}
+
+export interface ResilientHorizonClient extends HorizonClient {
+  circuitState(): ReturnType<CircuitBreaker["getState"]>;
+}
+
+export function createResilientHorizonClient(options: ResilientHorizonOptions = {}): ResilientHorizonClient {
+  const breaker = new CircuitBreaker(options.circuitBreaker);
+  const inner = createHorizonClient(options);
+
+  return {
+    lastEndpointUsed() {
+      return inner.lastEndpointUsed();
+    },
+    circuitState() {
+      return breaker.getState();
+    },
+    getJson<T = unknown>(path: string): Promise<T> {
+      return breaker.execute(() => inner.getJson<T>(path));
+    },
+  };
+}
+
+export interface SorobanRpcProbe {
+  getLatestLedger(): Promise<{ sequence: number }>;
+}
+
+export interface ResilientSorobanRpc extends SorobanRpcProbe {
+  circuitState(): ReturnType<CircuitBreaker["getState"]>;
+}
+
+export function createResilientSorobanRpc(
+  rpc: SorobanRpcProbe,
+  options: ConstructorParameters<typeof CircuitBreaker>[0] = {},
+): ResilientSorobanRpc {
+  const breaker = new CircuitBreaker(options);
+  return {
+    circuitState() {
+      return breaker.getState();
+    },
+    getLatestLedger() {
+      return breaker.execute(() => rpc.getLatestLedger());
+    },
+  };
+}
+
+export { CircuitOpenError, type HorizonFailoverEvent };

--- a/routes-d/package-lock.json
+++ b/routes-d/package-lock.json
@@ -52,7 +52,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -517,6 +516,29 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1923,7 +1945,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3359,7 +3380,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -5446,7 +5466,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/routes-d/routes/orders.list.ts
+++ b/routes-d/routes/orders.list.ts
@@ -1,0 +1,155 @@
+import { Router, type Request, type Response } from "express";
+import { decodeCursor } from "../lib/pagination.js";
+import {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  listOrdersWithCursor,
+  type OrderListQuery,
+} from "../lib/orderList.js";
+import { type IndexedOrder, type OrderIndex, type OrderStatus } from "../lib/orderIndex.js";
+
+const ALLOWED_STATUSES: ReadonlyArray<OrderStatus> = [
+  "pending",
+  "paid",
+  "fulfilled",
+  "shipped",
+  "delivered",
+  "cancelled",
+  "refunded",
+];
+
+const ALLOWED_SORT_BY = ["createdAt", "amount", "customer"] as const;
+const ALLOWED_SORT_DIR = ["asc", "desc"] as const;
+
+export interface OrdersListRouterOptions {
+  index: OrderIndex;
+  cursorSecret?: string;
+}
+
+function parseLimit(value: unknown): { value?: number; error?: string } {
+  if (value === undefined) return { value: DEFAULT_LIST_LIMIT };
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return { error: `expected a positive integer, got ${JSON.stringify(value)}` };
+  }
+  return { value: Math.min(n, MAX_LIST_LIMIT) };
+}
+
+function parseEpoch(value: unknown): { value?: number; error?: string } {
+  if (value === undefined) return { value: undefined };
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    return { error: `expected an epoch-ms number, got ${JSON.stringify(value)}` };
+  }
+  return { value: n };
+}
+
+export function createOrdersListRouter(opts: OrdersListRouterOptions): Router {
+  const router = Router();
+
+  router.get("/list", async (req: Request, res: Response) => {
+    const status = req.query["status"];
+    const customer = req.query["customer"];
+    const fromRaw = req.query["from"];
+    const toRaw = req.query["to"];
+    const limitRaw = req.query["limit"];
+    const cursorRaw = req.query["cursor"];
+    const sortByRaw = req.query["sortBy"];
+    const sortDirRaw = req.query["sortDir"];
+
+    if (status !== undefined) {
+      if (typeof status !== "string" || !ALLOWED_STATUSES.includes(status as OrderStatus)) {
+        res.status(400).json({
+          ok: false,
+          error: `status must be one of: ${ALLOWED_STATUSES.join(", ")}`,
+        });
+        return;
+      }
+    }
+
+    if (customer !== undefined && typeof customer !== "string") {
+      res.status(400).json({ ok: false, error: "customer must be a string" });
+      return;
+    }
+
+    const from = parseEpoch(fromRaw);
+    if (from.error) {
+      res.status(400).json({ ok: false, error: `from: ${from.error}` });
+      return;
+    }
+
+    const to = parseEpoch(toRaw);
+    if (to.error) {
+      res.status(400).json({ ok: false, error: `to: ${to.error}` });
+      return;
+    }
+
+    if (from.value !== undefined && to.value !== undefined && from.value > to.value) {
+      res.status(400).json({ ok: false, error: "from must be <= to" });
+      return;
+    }
+
+    const limit = parseLimit(limitRaw);
+    if (limit.error) {
+      res.status(400).json({ ok: false, error: `limit: ${limit.error}` });
+      return;
+    }
+
+    let sortBy: OrderListQuery["sortBy"];
+    if (sortByRaw !== undefined) {
+      if (typeof sortByRaw !== "string" || !(ALLOWED_SORT_BY as readonly string[]).includes(sortByRaw)) {
+        res.status(400).json({ ok: false, error: `sortBy must be one of: ${ALLOWED_SORT_BY.join(", ")}` });
+        return;
+      }
+      sortBy = sortByRaw as OrderListQuery["sortBy"];
+    }
+
+    let sortDir: OrderListQuery["sortDir"];
+    if (sortDirRaw !== undefined) {
+      if (typeof sortDirRaw !== "string" || !(ALLOWED_SORT_DIR as readonly string[]).includes(sortDirRaw)) {
+        res.status(400).json({ ok: false, error: `sortDir must be one of: ${ALLOWED_SORT_DIR.join(", ")}` });
+        return;
+      }
+      sortDir = sortDirRaw as OrderListQuery["sortDir"];
+    }
+
+    const cursor = typeof cursorRaw === "string" ? cursorRaw.trim() : undefined;
+    if (cursorRaw !== undefined && !cursor) {
+      res.status(400).json({ ok: false, error: "cursor must be a non-empty string" });
+      return;
+    }
+
+    const query: OrderListQuery = {
+      status: status as OrderStatus | undefined,
+      customer: customer as string | undefined,
+      from: from.value,
+      to: to.value,
+      limit: limit.value,
+      sortBy,
+      sortDir,
+      cursor,
+      cursorSecret: opts.cursorSecret,
+    };
+
+    if (cursor) {
+      try {
+        decodeCursor(cursor, { secret: opts.cursorSecret });
+      } catch (err) {
+        res.status(400).json({
+          ok: false,
+          error: err instanceof Error ? err.message : "invalid cursor",
+        });
+        return;
+      }
+    }
+
+    const all: IndexedOrder[] = [];
+    for await (const order of opts.index.iterate({})) {
+      all.push(order);
+    }
+    const page = listOrdersWithCursor(all, query);
+    res.status(200).json({ ok: true, results: page.results, pagination: page.pagination });
+  });
+
+  return router;
+}

--- a/routes-d/routes/orders.notes.ts
+++ b/routes-d/routes/orders.notes.ts
@@ -1,0 +1,96 @@
+import { Router, type Request, type Response } from "express";
+import {
+  isOrderNoteType,
+  type OrderNotesStore,
+  type OrderNoteType,
+} from "../lib/orderNotes.js";
+
+export interface NoteAuthor {
+  authorId: string;
+  authorRole: string;
+  canViewInternal: boolean;
+}
+
+export interface OrdersNotesRouterOptions {
+  store: OrderNotesStore;
+  getAuthor?: (req: Request) => NoteAuthor | null;
+}
+
+interface CreateNoteBody {
+  type?: unknown;
+  body?: unknown;
+}
+
+interface NotesRequest extends Request {
+  user?: { role?: unknown };
+}
+
+function defaultGetAuthor(req: Request): NoteAuthor | null {
+  const authReq = req as NotesRequest;
+  const sub = authReq.jwt?.sub;
+  if (!sub) return null;
+  const role = typeof authReq.user?.role === "string" ? authReq.user.role : "user";
+  return {
+    authorId: sub,
+    authorRole: role,
+    canViewInternal: role === "admin" || role === "moderator",
+  };
+}
+
+export function createOrdersNotesRouter(opts: OrdersNotesRouterOptions): Router {
+  const router = Router({ mergeParams: true });
+  const getAuthor = opts.getAuthor ?? defaultGetAuthor;
+
+  router.post("/:orderId/notes", async (req: Request, res: Response) => {
+    const author = getAuthor(req);
+    if (!author) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    if (!author.canViewInternal) {
+      res.status(403).json({ ok: false, error: "insufficient role" });
+      return;
+    }
+
+    const { orderId } = req.params as { orderId: string };
+    const body = (req.body ?? {}) as CreateNoteBody;
+
+    if (!isOrderNoteType(body.type)) {
+      res.status(400).json({ ok: false, error: "type must be internal or customer" });
+      return;
+    }
+
+    if (typeof body.body !== "string" || body.body.trim().length === 0) {
+      res.status(400).json({ ok: false, error: "body is required" });
+      return;
+    }
+
+    const note = await opts.store.create({
+      orderId,
+      type: body.type as OrderNoteType,
+      body: body.body,
+      authorId: author.authorId,
+      authorRole: author.authorRole,
+    });
+
+    res.status(201).json({ ok: true, note });
+  });
+
+  router.get("/:orderId/notes", async (req: Request, res: Response) => {
+    const author = getAuthor(req);
+    if (!author) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    const { orderId } = req.params as { orderId: string };
+    const notes = await opts.store.listByOrder(orderId, {
+      visibleToCustomer: !author.canViewInternal,
+    });
+
+    res.status(200).json({ ok: true, notes });
+  });
+
+  return router;
+}

--- a/routes-d/tests/chaos.stellar.test.ts
+++ b/routes-d/tests/chaos.stellar.test.ts
@@ -1,0 +1,164 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import { CircuitBreaker, CircuitOpenError } from "../lib/circuitBreaker.js";
+import {
+  createResilientHorizonClient,
+  createResilientSorobanRpc,
+  type HorizonFailoverEvent,
+} from "../lib/resilientStellar.js";
+import type { HorizonFetcher } from "../lib/horizonClient.js";
+import { createSorobanHealthRouter } from "../routes/health.soroban.js";
+
+function makeFetcher(
+  handlers: Record<string, () => Promise<{ ok: boolean; status: number; body: unknown; delayMs?: number }>>,
+): HorizonFetcher {
+  return async (url) => {
+    const key = Object.keys(handlers).find((k) => url.includes(k));
+    if (!key) throw new Error(`unexpected url ${url}`);
+    const result = await handlers[key]!();
+    if (result.delayMs) {
+      await new Promise((resolve) => setTimeout(resolve, result.delayMs));
+    }
+    return {
+      ok: result.ok,
+      status: result.status,
+      json: async () => result.body,
+    };
+  };
+}
+
+describe("routes-d stellar chaos resilience", () => {
+  const PRIMARY = "https://horizon.primary.test";
+  const FALLBACK = "https://horizon.fallback.test";
+  let rejections: unknown[] = [];
+
+  beforeEach(() => {
+    rejections = [];
+    process.on("unhandledRejection", onRejection);
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", onRejection);
+  });
+
+  function onRejection(reason: unknown) {
+    rejections.push(reason);
+  }
+
+  it("opens the circuit after repeated 5xx responses and recovers after reset", async () => {
+    let mode: "fail" | "ok" = "fail";
+    const fetcher: HorizonFetcher = async (url) => {
+      if (!url.includes(PRIMARY)) throw new Error(`unexpected url ${url}`);
+      if (mode === "ok") {
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      }
+      return { ok: false, status: 503, json: async () => ({}) };
+    };
+
+    const client = createResilientHorizonClient({
+      primaryUrl: PRIMARY,
+      fetcher,
+      timeoutMs: 50,
+      circuitBreaker: { failureThreshold: 2, resetTimeoutMs: 30 },
+    });
+
+    await expect(client.getJson("/accounts/GABC")).rejects.toThrow(/HTTP 503/);
+    await expect(client.getJson("/accounts/GABC")).rejects.toThrow(/HTTP 503/);
+    await expect(client.getJson("/accounts/GABC")).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(client.circuitState()).toBe("open");
+
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    mode = "ok";
+    await expect(client.getJson("/accounts/GABC")).resolves.toEqual({ ok: true });
+    expect(client.circuitState()).toBe("closed");
+    expect(rejections).toHaveLength(0);
+  });
+
+  it("fails over from primary to fallback when primary DNS fails", async () => {
+    const events: HorizonFailoverEvent[] = [];
+    const fetcher = makeFetcher({
+      [PRIMARY]: async () => {
+        throw new Error("ENOTFOUND horizon.primary.test");
+      },
+      [FALLBACK]: async () => ({ ok: true, status: 200, body: { source: "fallback" } }),
+    });
+
+    const client = createResilientHorizonClient({
+      primaryUrl: PRIMARY,
+      fallbackUrl: FALLBACK,
+      fetcher,
+      timeoutMs: 100,
+      onFailover: (event) => events.push(event),
+      circuitBreaker: { failureThreshold: 5, resetTimeoutMs: 1_000 },
+    });
+
+    const body = await client.getJson<{ source: string }>("/ledgers?limit=1");
+    expect(body.source).toBe("fallback");
+    expect(client.lastEndpointUsed()).toBe("fallback");
+    expect(events).toHaveLength(1);
+    expect(rejections).toHaveLength(0);
+  });
+
+  it("treats slow primary responses as failures without unhandled rejections", async () => {
+    const fetcher = makeFetcher({
+      [PRIMARY]: async () => ({
+        ok: true,
+        status: 200,
+        body: { late: true },
+        delayMs: 200,
+      }),
+      [FALLBACK]: async () => ({ ok: true, status: 200, body: { source: "fallback" } }),
+    });
+
+    const client = createResilientHorizonClient({
+      primaryUrl: PRIMARY,
+      fallbackUrl: FALLBACK,
+      fetcher,
+      timeoutMs: 30,
+      circuitBreaker: { failureThreshold: 10, resetTimeoutMs: 1_000 },
+    });
+
+    const body = await client.getJson<{ source?: string; late?: boolean }>("/accounts/GABC");
+    expect(body.source ?? body.late).toBeTruthy();
+    expect(rejections).toHaveLength(0);
+  });
+
+  it("degrades Soroban health checks when RPC calls fail repeatedly", async () => {
+    let failures = 0;
+    const rpc = createResilientSorobanRpc(
+      {
+        async getLatestLedger() {
+          failures += 1;
+          throw new Error("RPC 503 storm");
+        },
+      },
+      { failureThreshold: 2, resetTimeoutMs: 50 },
+    );
+
+    const app: Express = express();
+    app.use("/health", createSorobanHealthRouter({ rpc, sleep: async () => {} }));
+
+    const first = await request(app).get("/health/soroban");
+    expect(first.status).toBe(503);
+    expect(first.body.status).toBe("unreachable");
+
+    const second = await request(app).get("/health/soroban");
+    expect(second.status).toBe(503);
+    expect(rpc.circuitState()).toBe("open");
+    expect(rejections).toHaveLength(0);
+    expect(failures).toBeGreaterThanOrEqual(2);
+  });
+
+  it("circuit breaker isolates bursts without leaking rejections", async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 10 });
+    await expect(
+      breaker.execute(async () => {
+        throw new Error("storm");
+      }),
+    ).rejects.toThrow("storm");
+    await expect(
+      breaker.execute(async () => "ok"),
+    ).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(rejections).toHaveLength(0);
+  });
+});

--- a/routes-d/tests/orderList.unit.test.ts
+++ b/routes-d/tests/orderList.unit.test.ts
@@ -1,0 +1,22 @@
+import { listOrdersWithCursor } from "../lib/orderList.js";
+import type { IndexedOrder } from "../lib/orderIndex.js";
+
+const orders: IndexedOrder[] = [
+  { id: "a", customer: "alice", status: "paid", amount: 10, createdAt: 3000 },
+  { id: "b", customer: "bob", status: "paid", amount: 20, createdAt: 2000 },
+  { id: "c", customer: "carol", status: "pending", amount: 30, createdAt: 1000 },
+];
+
+describe("listOrdersWithCursor", () => {
+  it("filters by status and returns a next cursor", () => {
+    const page = listOrdersWithCursor(orders, {
+      status: "paid",
+      limit: 1,
+      cursorSecret: "test-cursor-secret-value",
+    });
+
+    expect(page.results).toHaveLength(1);
+    expect(page.pagination.hasMore).toBe(true);
+    expect(page.pagination.nextCursor).toBeTruthy();
+  });
+});

--- a/routes-d/tests/orders.list.test.ts
+++ b/routes-d/tests/orders.list.test.ts
@@ -1,0 +1,74 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import { InMemoryOrderIndex } from "../lib/orderIndex.js";
+import { createOrdersListRouter } from "../routes/orders.list.js";
+
+const CURSOR_SECRET = "test-cursor-secret-value";
+
+function seed(): InMemoryOrderIndex {
+  const idx = new InMemoryOrderIndex();
+  const orders = [
+    { id: "1", customer: "alice", status: "pending" as const, amount: 100, createdAt: 1000 },
+    { id: "2", customer: "bob", status: "paid" as const, amount: 200, createdAt: 2000 },
+    { id: "3", customer: "alice", status: "shipped" as const, amount: 50, createdAt: 3000 },
+    { id: "4", customer: "carol", status: "delivered" as const, amount: 500, createdAt: 4000 },
+    { id: "5", customer: "alice", status: "paid" as const, amount: 25, createdAt: 5000 },
+  ];
+  for (const o of orders) idx.add(o);
+  return idx;
+}
+
+function buildApp(idx: InMemoryOrderIndex): Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/orders", createOrdersListRouter({ index: idx, cursorSecret: CURSOR_SECRET }));
+  return app;
+}
+
+describe("GET /orders/list", () => {
+  it("returns the first page with a default limit", async () => {
+    const app = buildApp(seed());
+    const res = await request(app).get("/orders/list").query({ limit: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.pagination).toMatchObject({ limit: 2, hasMore: true });
+    expect(res.body.pagination.nextCursor).toBeTruthy();
+  });
+
+  it("returns a subsequent page when a valid cursor is supplied", async () => {
+    const app = buildApp(seed());
+    const first = await request(app).get("/orders/list").query({ limit: 2 });
+    const second = await request(app)
+      .get("/orders/list")
+      .query({ limit: 2, cursor: first.body.pagination.nextCursor });
+
+    expect(second.status).toBe(200);
+    expect(second.body.results).toHaveLength(2);
+    expect(first.body.results[0].id).not.toBe(second.body.results[0].id);
+  });
+
+  it("rejects an invalid cursor with 400", async () => {
+    const app = buildApp(seed());
+    const res = await request(app).get("/orders/list").query({ cursor: "not-a-valid-cursor" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cursor|Invalid/i);
+  });
+
+  it("rejects invalid status with 400", async () => {
+    const app = buildApp(seed());
+    const res = await request(app).get("/orders/list").query({ status: "exploded" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/status must be/);
+  });
+
+  it("caps limit at the configured maximum", async () => {
+    const app = buildApp(seed());
+    const res = await request(app).get("/orders/list").query({ limit: 500 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.limit).toBe(100);
+  });
+});

--- a/routes-d/tests/orders.notes.test.ts
+++ b/routes-d/tests/orders.notes.test.ts
@@ -1,0 +1,107 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import {
+  InMemoryOrderNotesStore,
+  __resetOrderNoteIds,
+  type OrderNote,
+} from "../lib/orderNotes.js";
+import { createOrdersNotesRouter, type NoteAuthor } from "../routes/orders.notes.js";
+
+function buildApp(author: NoteAuthor | null, store = new InMemoryOrderNotesStore()): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/orders",
+    createOrdersNotesRouter({
+      store,
+      getAuthor: () => author,
+    }),
+  );
+  return app;
+}
+
+describe("orders notes routes", () => {
+  beforeEach(() => {
+    __resetOrderNoteIds();
+  });
+
+  it("creates an internal note with author audit fields", async () => {
+    const app = buildApp({ authorId: "admin-1", authorRole: "admin", canViewInternal: true });
+
+    const res = await request(app).post("/orders/o-1/notes").send({
+      type: "internal",
+      body: "Refund approved offline",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.note).toMatchObject({
+      orderId: "o-1",
+      type: "internal",
+      body: "Refund approved offline",
+      authorId: "admin-1",
+      authorRole: "admin",
+    });
+    expect(res.body.note.createdAt).toEqual(expect.any(Number));
+  });
+
+  it("lists all notes for admins", async () => {
+    const store = new InMemoryOrderNotesStore();
+    await store.create({
+      orderId: "o-1",
+      type: "internal",
+      body: "ops only",
+      authorId: "admin-1",
+      authorRole: "admin",
+    });
+    await store.create({
+      orderId: "o-1",
+      type: "customer",
+      body: "Your package ships tomorrow",
+      authorId: "admin-1",
+      authorRole: "admin",
+    });
+
+    const app = buildApp({ authorId: "admin-1", authorRole: "admin", canViewInternal: true }, store);
+    const res = await request(app).get("/orders/o-1/notes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.notes).toHaveLength(2);
+  });
+
+  it("filters customer-visible notes for non-admin callers", async () => {
+    const store = new InMemoryOrderNotesStore();
+    await store.create({
+      orderId: "o-1",
+      type: "internal",
+      body: "ops only",
+      authorId: "admin-1",
+      authorRole: "admin",
+    });
+    await store.create({
+      orderId: "o-1",
+      type: "customer",
+      body: "Your package ships tomorrow",
+      authorId: "admin-1",
+      authorRole: "admin",
+    });
+
+    const app = buildApp({ authorId: "user-1", authorRole: "user", canViewInternal: false }, store);
+    const res = await request(app).get("/orders/o-1/notes");
+
+    expect(res.status).toBe(200);
+    const notes = res.body.notes as OrderNote[];
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.type).toBe("customer");
+  });
+
+  it("returns 403 when a non-admin tries to create a note", async () => {
+    const app = buildApp({ authorId: "user-1", authorRole: "user", canViewInternal: false });
+
+    const res = await request(app).post("/orders/o-1/notes").send({
+      type: "customer",
+      body: "hello",
+    });
+
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
closes #296 
closes #315 
closes #337 
closes #304 


## Summary
- Add cursor-paginated `GET /orders/list` with validated sort/filter params
- Add order notes endpoints with internal vs customer visibility
- Add circuit-breaker wrappers and chaos tests for Horizon/Soroban degradation
- Add `routes-d/docs/setup.md` contributor guide

## Scope
All changes are under `routes-d/` only.

## Test plan
- [ ] `cd routes-d && npm install && npm test`
- [ ] Verify `tests/orders.list.test.ts`, `tests/orders.notes.test.ts`, `tests/chaos.stellar.test.ts` pass