### PR TITLE
feat:routes-d: error handler, env reference, Horizon batcher, alerting hooks

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,106 @@
+# Pull Request — routes-d: error handler, env reference, Horizon batcher, alerting hooks
+
+## Issues closed
+
+- #325 — Safe error handler middleware in routes-d
+- #340 — Environment variables reference inside routes-d
+- #354 — Batched Horizon request helper in routes-d
+- #334 — Error rate alerting hooks in routes-d
+
+---
+
+## Summary
+
+All changes are scoped to `routes-d/` and follow existing ESM / TypeScript conventions.
+
+### #325 — `routes-d/middleware/errorHandler.ts`
+
+- Typed error hierarchy: `AppError`, `ValidationError`, `AuthenticationError`,
+  `AuthorizationError`, `NotFoundError`, `ConflictError`.
+- `createErrorHandler(options)` factory returns a four-parameter Express error
+  middleware that **redacts** unknown errors to `"Internal server error"` and
+  forwards only `AppError` message + code to the client — stack traces never
+  leave the server.
+- Full internal logging of method, path, status, and raw error is wired to an
+  injectable `InternalLogger` (defaults to `console.error` JSON).
+- `res.locals.requestId` is forwarded to both the log entry and the response
+  body (opt-in, on by default).
+- A ready-to-use `errorHandler` export covers the simple case.
+- Tests: known-error mapping, unknown-error redaction, stack-trace leakage,
+  body-parser 4xx pass-through, logging, requestId propagation.
+
+### #340 — `routes-d/docs/env.md` + `routes-d/.env.example`
+
+- `env.md` documents every env variable consumed by routes-d — name, purpose,
+  default value, required flag, and secret flag — grouped by subsystem.
+- `.env.example` mirrors the same variables with safe placeholder values and
+  inline `# SECRET` markers.
+- `routes-d/tests/env.test.ts` lints that:
+  1. All env vars read in non-test source files appear in `env.md`.
+  2. All variables declared in `.env.example` appear in `env.md`.
+  - Bench-only and profiling helper vars (`ROUTES_D_BENCH_*`,
+    `ROUTES_D_PROFILE_*`) are explicitly excluded from the runtime contract.
+
+### #354 — `routes-d/lib/horizonBatcher.ts`
+
+- `createHorizonBatcher({ fetch, coalesceMs, onFlush })` returns a batcher
+  that deduplicates concurrent fetches for the same Horizon path within a short
+  coalescing window (default 10 ms), while issuing distinct paths in parallel.
+- `stats()` surfaces `totalRequests`, `totalBatches`, `totalCoalesced`, and
+  `hitRate`.
+- `onFlush` callback receives `batchSize`, `coalesced`, and
+  `flushDurationMs` per flush.
+- `flush()` forces immediate dispatch — useful in tests and graceful shutdown.
+- Tests: single request, coalescing, distinct-path parallelism, later-window
+  re-fetch, forced flush, metrics accuracy, error isolation (one bad path does
+  not cancel healthy paths in the same batch).
+
+### #334 — `routes-d/lib/alerts.ts`
+
+- `createAlertsTracker(options)` returns a tracker with a pluggable
+  `AlertSink[]` interface (PagerDuty, Slack, etc.).
+- Sliding-window per-route error-rate tracking (default: 60 s window,
+  10 % threshold, 10 request minimum).
+- Fires `AlertEvent` once per spike onset; resets when the rate drops below
+  the threshold so the next spike fires a fresh alert.
+- Injectable clock (`now`) for deterministic testing.
+- Sink errors are swallowed — alerting never disrupts the request path.
+- Tests: normal traffic, spike detection, no duplicate alerts during sustained
+  spike, recovery → re-spike, route isolation, `stats()` accuracy, window
+  pruning, `reset()`, multi-sink, throwing sink resilience, `AlertEvent` shape
+  and `triggeredAt` timestamp.
+
+---
+
+## Files changed
+
+```
+routes-d/middleware/errorHandler.ts       (new)
+routes-d/tests/errorHandler.test.ts      (new)
+routes-d/docs/env.md                     (new)
+routes-d/.env.example                    (new)
+routes-d/tests/env.test.ts               (new)
+routes-d/lib/horizonBatcher.ts           (new)
+routes-d/tests/horizonBatcher.test.ts    (new)
+routes-d/lib/alerts.ts                   (new)
+routes-d/tests/alerts.test.ts            (new)
+```
+
+No files outside `routes-d/` were modified.
+
+---
+
+## Test plan
+
+```bash
+cd routes-d
+npm test                        # all routes-d tests via ts-jest ESM
+npm test -- --testPathPattern errorHandler
+npm test -- --testPathPattern env
+npm test -- --testPathPattern horizonBatcher
+npm test -- --testPathPattern alerts
+```
+
+All new test files follow the `routes-d/tests/**/*.test.ts` pattern and are
+picked up automatically by both the `routes-d/jest.config.js` and the root
+`jest.config.mjs`.

--- a/routes-d/.env.example
+++ b/routes-d/.env.example
@@ -1,0 +1,57 @@
+# routes-d environment — copy to .env and fill in the values.
+# Never commit real secrets. See docs/env.md for full documentation.
+
+# ── Horizon / Stellar ────────────────────────────────────────────────────────
+
+HORIZON_URL=https://horizon-testnet.stellar.org
+HORIZON_PRIMARY_URL=https://horizon-testnet.stellar.org
+HORIZON_FALLBACK_URL=
+HORIZON_TIMEOUT_MS=5000
+NEXTELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SOROBAN_SIGNING_SECRET=                  # SECRET — Ed25519 key (S...)
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+NEXTELLAR_BALANCE_CACHE_TTL_MS=30000
+
+# ── Authentication & Tokens ──────────────────────────────────────────────────
+
+NEXTELLAR_JWT_ISSUER=https://api.nextellar.app
+NEXTELLAR_JWT_AUDIENCE=nextellar-api
+NEXTELLAR_IMPERSONATION_SECRET=          # SECRET
+NEXTELLAR_SESSION_TTL_SECONDS=900
+NEXTELLAR_MAGIC_LINK_BASE_URL=https://app.nextellar.app/auth/magic
+NEXTELLAR_MAGIC_LINK_TTL_SECONDS=900
+NEXTELLAR_CHALLENGE_TTL_MS=300000
+ROUTES_D_CURSOR_SECRET=                  # SECRET — random 32-byte hex
+ROUTES_D_ADMIN_TOKEN=                    # SECRET — random bearer token
+
+# ── Rate Limiting ─────────────────────────────────────────────────────────────
+
+NEXTELLAR_LOGIN_RATE_WINDOW_MS=900000
+NEXTELLAR_LOGIN_RATE_IP_LIMIT=20
+NEXTELLAR_LOGIN_RATE_IP_EMAIL_LIMIT=5
+
+# ── CORS & Security ───────────────────────────────────────────────────────────
+
+ALLOWED_ORIGINS=https://app.nextellar.app,https://admin.nextellar.app
+
+# ── Audit & Activity Logging ──────────────────────────────────────────────────
+
+AUDIT_LOG_DIR=/var/log/nextellar/audit
+AUDIT_PEPPER=                            # SECRET
+USER_ACTIVITY_LOG_DIR=/var/log/nextellar/user-activity
+USER_ACTIVITY_PEPPER=                    # SECRET
+
+# ── SEP Anchor ────────────────────────────────────────────────────────────────
+
+NEXTELLAR_SEP=24,31
+
+# ── Orders & Inventory ────────────────────────────────────────────────────────
+
+NEXTELLAR_INVENTORY_RESERVATION_TIMEOUT_MS=30000
+NEXTELLAR_SEQUENCE_RESERVATION_TIMEOUT_MS=30000
+
+# ── Runtime ───────────────────────────────────────────────────────────────────
+
+NODE_ENV=development
+NEXTELLAR_SHUTDOWN_TIMEOUT_MS=10000

--- a/routes-d/docs/env.md
+++ b/routes-d/docs/env.md
@@ -1,0 +1,103 @@
+# Environment Variables — routes-d
+
+Single reference for every environment variable consumed by routes-d.
+Variables marked **Secret** must never be committed to version control or
+logged.
+
+---
+
+## Horizon / Stellar
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `HORIZON_URL` | Primary Horizon base URL (alias for `HORIZON_PRIMARY_URL`) | `https://horizon-testnet.stellar.org` | No | No |
+| `HORIZON_PRIMARY_URL` | Primary Horizon base URL | `https://horizon-testnet.stellar.org` | No | No |
+| `HORIZON_FALLBACK_URL` | Fallback Horizon URL used when the primary is unhealthy | — | No | No |
+| `HORIZON_TIMEOUT_MS` | Per-request timeout for Horizon calls in milliseconds | `5000` | No | No |
+| `NEXTELLAR_HORIZON_URL` | Alternate Horizon URL used by some internal helpers | `https://horizon-testnet.stellar.org` | No | No |
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint | — | Yes | No |
+| `SOROBAN_SIGNING_SECRET` | Ed25519 secret key for signing Soroban transactions | — | Yes | **Yes** |
+| `STELLAR_NETWORK_PASSPHRASE` | Stellar network passphrase (`Public Global Stellar Network ; September 2015` for mainnet) | — | Yes | No |
+| `NEXTELLAR_BALANCE_CACHE_TTL_MS` | TTL for in-memory Stellar balance cache in milliseconds | `30000` | No | No |
+
+---
+
+## Authentication & Tokens
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `NEXTELLAR_JWT_ISSUER` | `iss` claim used when minting JWTs | — | Yes | No |
+| `NEXTELLAR_JWT_AUDIENCE` | `aud` claim checked when verifying JWTs | — | Yes | No |
+| `NEXTELLAR_IMPERSONATION_SECRET` | HMAC secret that authorises operator impersonation requests | — | Yes | **Yes** |
+| `NEXTELLAR_SESSION_TTL_SECONDS` | Access token lifetime in seconds | `900` | No | No |
+| `NEXTELLAR_MAGIC_LINK_BASE_URL` | Base URL prepended to magic-link tokens | — | Yes | No |
+| `NEXTELLAR_MAGIC_LINK_TTL_SECONDS` | Magic link expiry in seconds | `900` | No | No |
+| `NEXTELLAR_CHALLENGE_TTL_MS` | Stellar wallet sign-challenge validity window in milliseconds | `300000` | No | No |
+| `ROUTES_D_CURSOR_SECRET` | HMAC secret used to sign and verify pagination cursors | — | Yes | **Yes** |
+| `ROUTES_D_ADMIN_TOKEN` | Static bearer token granting admin-only endpoint access | — | Yes | **Yes** |
+
+---
+
+## Rate Limiting
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `NEXTELLAR_LOGIN_RATE_WINDOW_MS` | Sliding-window size for the login rate limiter in milliseconds | `900000` | No | No |
+| `NEXTELLAR_LOGIN_RATE_IP_LIMIT` | Maximum login attempts per IP per window | `20` | No | No |
+| `NEXTELLAR_LOGIN_RATE_IP_EMAIL_LIMIT` | Maximum login attempts per IP+email pair per window | `5` | No | No |
+
+---
+
+## CORS & Security
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `ALLOWED_ORIGINS` | Comma-separated list of exact origins permitted by CORS middleware | — | Yes | No |
+
+---
+
+## Audit & Activity Logging
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `AUDIT_LOG_DIR` | Directory where structured audit log files are written | — | Yes | No |
+| `AUDIT_PEPPER` | HMAC pepper mixed into audit log hashes | — | Yes | **Yes** |
+| `USER_ACTIVITY_LOG_DIR` | Directory where user-activity events are written | — | Yes | No |
+| `USER_ACTIVITY_PEPPER` | HMAC pepper mixed into user-activity hashes | — | Yes | **Yes** |
+
+---
+
+## SEP Anchor
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `NEXTELLAR_SEP` | Comma-separated list of active SEP protocols (e.g. `24,31`) | — | No | No |
+
+---
+
+## Orders & Inventory
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `NEXTELLAR_INVENTORY_RESERVATION_TIMEOUT_MS` | How long (ms) an inventory reservation is held before expiry | `30000` | No | No |
+| `NEXTELLAR_SEQUENCE_RESERVATION_TIMEOUT_MS` | How long (ms) a Stellar sequence-number reservation is held | `30000` | No | No |
+
+---
+
+## Runtime
+
+| Variable | Purpose | Default | Required | Secret |
+|----------|---------|---------|----------|--------|
+| `NODE_ENV` | Runtime mode (`development`, `test`, `production`) | `development` | No | No |
+| `NEXTELLAR_SHUTDOWN_TIMEOUT_MS` | Grace period (ms) between SIGTERM and hard exit | `10000` | No | No |
+
+---
+
+## Notes
+
+- All durations are in **milliseconds** unless the variable name ends in `_SECONDS`.
+- Secret variables must be supplied via a secrets manager (AWS Secrets Manager,
+  HashiCorp Vault, etc.) in production. Do **not** write real values into
+  `.env.example` or commit them to the repository.
+- Copy `.env.example` to `.env` and fill in the blanks before starting the
+  development server.

--- a/routes-d/lib/alerts.ts
+++ b/routes-d/lib/alerts.ts
@@ -1,0 +1,156 @@
+/**
+ * Pluggable error-rate alerting for routes-d.
+ *
+ * Each route is tracked in a sliding window. When the error rate (5xx / total)
+ * exceeds the configured threshold for a minimum request count, the registered
+ * sinks (PagerDuty, Slack, etc.) receive an AlertEvent.
+ *
+ * The alert fires once when the rate first crosses the threshold (spike onset)
+ * and re-fires if the spike persists after the window has fully rolled over
+ * (sustained spike). It does not fire again while the route is continuously
+ * above the threshold — callers get one notification per onset.
+ */
+
+export type AlertSink = (event: AlertEvent) => void | Promise<void>;
+
+export interface AlertEvent {
+  type: 'error_rate_spike';
+  route: string;
+  /** Observed error rate at the moment of firing (0–1). */
+  rate: number;
+  /** Configured threshold that was crossed. */
+  threshold: number;
+  /** Sliding window size in milliseconds. */
+  windowMs: number;
+  triggeredAt: string;
+}
+
+export interface AlertsOptions {
+  /** Sliding window size in milliseconds. Default: 60_000. */
+  windowMs?: number;
+  /**
+   * Error-rate threshold (0–1) above which an alert fires.
+   * Default: 0.1 (10 %).
+   */
+  threshold?: number;
+  /**
+   * Minimum requests in the window before the threshold is evaluated.
+   * Prevents noise on low-traffic routes.
+   * Default: 10.
+   */
+  minRequests?: number;
+  /** Pluggable alert destinations (PagerDuty, Slack webhook, etc.). */
+  sinks?: AlertSink[];
+  /** Injectable clock for deterministic testing. */
+  now?: () => number;
+}
+
+export interface RouteStats {
+  /** Requests in the current window. */
+  total: number;
+  /** 5xx responses in the current window. */
+  errors: number;
+  /** `errors / total`, or 0 when total is 0. */
+  rate: number;
+}
+
+export interface AlertsTracker {
+  /** Record a completed request for a route with its HTTP status code. */
+  record(route: string, statusCode: number): void;
+  /** Return a live snapshot of the current window stats for a route. */
+  stats(route: string): RouteStats;
+  /** Wipe all route windows — useful between tests. */
+  reset(): void;
+}
+
+interface Hit {
+  ts: number;
+  isError: boolean;
+}
+
+interface RouteWindow {
+  hits: Hit[];
+  /** True while the route is above threshold — prevents duplicate alerts. */
+  firing: boolean;
+}
+
+export function createAlertsTracker(options: AlertsOptions = {}): AlertsTracker {
+  const windowMs = options.windowMs ?? 60_000;
+  const threshold = options.threshold ?? 0.1;
+  const minRequests = options.minRequests ?? 10;
+  const sinks: AlertSink[] = options.sinks ?? [];
+  const getNow = options.now ?? Date.now;
+
+  const windows = new Map<string, RouteWindow>();
+
+  function getWindow(route: string): RouteWindow {
+    let w = windows.get(route);
+    if (!w) {
+      w = { hits: [], firing: false };
+      windows.set(route, w);
+    }
+    return w;
+  }
+
+  function prune(w: RouteWindow, now: number): void {
+    const cutoff = now - windowMs;
+    w.hits = w.hits.filter((h) => h.ts > cutoff);
+  }
+
+  function computeStats(w: RouteWindow): RouteStats {
+    const total = w.hits.length;
+    const errors = w.hits.filter((h) => h.isError).length;
+    return { total, errors, rate: total === 0 ? 0 : errors / total };
+  }
+
+  function fire(route: string, rate: number, now: number): void {
+    const event: AlertEvent = {
+      type: 'error_rate_spike',
+      route,
+      rate,
+      threshold,
+      windowMs,
+      triggeredAt: new Date(now).toISOString(),
+    };
+    for (const sink of sinks) {
+      try {
+        void sink(event);
+      } catch {
+        // Alerting must never disrupt the request path.
+      }
+    }
+  }
+
+  return {
+    record(route: string, statusCode: number): void {
+      const now = getNow();
+      const w = getWindow(route);
+      prune(w, now);
+
+      w.hits.push({ ts: now, isError: statusCode >= 500 });
+
+      const { total, rate } = computeStats(w);
+
+      if (total >= minRequests && rate > threshold) {
+        if (!w.firing) {
+          w.firing = true;
+          fire(route, rate, now);
+        }
+      } else {
+        // Rate has dropped below threshold — reset so the next spike fires again.
+        w.firing = false;
+      }
+    },
+
+    stats(route: string): RouteStats {
+      const now = getNow();
+      const w = getWindow(route);
+      prune(w, now);
+      return computeStats(w);
+    },
+
+    reset(): void {
+      windows.clear();
+    },
+  };
+}

--- a/routes-d/lib/horizonBatcher.ts
+++ b/routes-d/lib/horizonBatcher.ts
@@ -1,0 +1,143 @@
+/**
+ * Coalescing batcher for Horizon path lookups.
+ *
+ * Requests that arrive within a short window (`coalesceMs`) for the same
+ * path are collapsed into a single upstream fetch. Requests for distinct
+ * paths within the same window are issued in parallel.
+ *
+ * This is intentionally path-level deduplication — callers that already
+ * have distinct URLs (account, balance, operation) benefit without any
+ * extra coordination.
+ */
+
+export interface HorizonBatcherOptions {
+  /** Maximum milliseconds to wait before flushing a pending batch. Default: 10. */
+  coalesceMs?: number;
+  /** Underlying single-path fetch function. */
+  fetch: (path: string) => Promise<unknown>;
+  /** Invoked after each batch flush with size and timing metrics. */
+  onFlush?: (metrics: FlushMetrics) => void;
+}
+
+export interface FlushMetrics {
+  /** Distinct paths fetched in this batch. */
+  batchSize: number;
+  /** Requests that were deduplicated (same path, multiple callers). */
+  coalesced: number;
+  /** Wall-clock time spent executing the batch in milliseconds. */
+  flushDurationMs: number;
+}
+
+export interface BatcherStats {
+  /** Total calls to `fetch()` since creation. */
+  totalRequests: number;
+  /** Total batch flushes executed. */
+  totalBatches: number;
+  /** Total requests that were coalesced (shared an upstream fetch). */
+  totalCoalesced: number;
+  /** Fraction of requests that were coalesced: `totalCoalesced / totalRequests`. */
+  hitRate: number;
+}
+
+export interface HorizonBatcher {
+  /** Fetch a Horizon path, coalescing concurrent identical requests. */
+  fetch<T = unknown>(path: string): Promise<T>;
+  /** Return a snapshot of batch size and hit-rate metrics. */
+  stats(): BatcherStats;
+  /**
+   * Immediately flush any pending batch without waiting for `coalesceMs`.
+   * Useful in tests and graceful shutdown.
+   */
+  flush(): Promise<void>;
+}
+
+interface Waiter {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+}
+
+export function createHorizonBatcher(options: HorizonBatcherOptions): HorizonBatcher {
+  const coalesceMs = options.coalesceMs ?? 10;
+
+  let pending = new Map<string, Waiter[]>();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  let totalRequests = 0;
+  let totalBatches = 0;
+  let totalCoalesced = 0;
+
+  async function doFlush(): Promise<void> {
+    if (pending.size === 0) return;
+
+    // Snapshot and reset so new requests during async work go to the next batch.
+    const batch = pending;
+    pending = new Map();
+    timer = null;
+
+    const paths = [...batch.keys()];
+    const totalWaiters = [...batch.values()].reduce((n, w) => n + w.length, 0);
+    const coalesced = totalWaiters - paths.length;
+
+    totalBatches += 1;
+    totalCoalesced += coalesced;
+
+    const start = Date.now();
+
+    await Promise.all(
+      paths.map(async (path) => {
+        const waiters = batch.get(path)!;
+        try {
+          const result = await options.fetch(path);
+          for (const w of waiters) w.resolve(result);
+        } catch (err) {
+          for (const w of waiters) w.reject(err);
+        }
+      }),
+    );
+
+    options.onFlush?.({
+      batchSize: paths.length,
+      coalesced,
+      flushDurationMs: Date.now() - start,
+    });
+  }
+
+  function scheduleFlush(): void {
+    if (timer !== null) return;
+    timer = setTimeout(() => {
+      void doFlush();
+    }, coalesceMs);
+  }
+
+  return {
+    fetch<T = unknown>(path: string): Promise<T> {
+      totalRequests += 1;
+      return new Promise<T>((resolve, reject) => {
+        const existing = pending.get(path);
+        if (existing) {
+          existing.push({ resolve: resolve as (v: unknown) => void, reject });
+        } else {
+          pending.set(path, [{ resolve: resolve as (v: unknown) => void, reject }]);
+        }
+        scheduleFlush();
+      });
+    },
+
+    stats(): BatcherStats {
+      return {
+        totalRequests,
+        totalBatches,
+        totalCoalesced,
+        hitRate: totalRequests > 0 ? totalCoalesced / totalRequests : 0,
+      };
+    },
+
+    async flush(): Promise<void> {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      await doFlush();
+    },
+  };
+}

--- a/routes-d/middleware/errorHandler.ts
+++ b/routes-d/middleware/errorHandler.ts
@@ -1,0 +1,131 @@
+import type { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
+
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(400, message, 'validation_error');
+    this.name = 'ValidationError';
+  }
+}
+
+export class AuthenticationError extends AppError {
+  constructor(message = 'Unauthorized') {
+    super(401, message, 'authentication_error');
+    this.name = 'AuthenticationError';
+  }
+}
+
+export class AuthorizationError extends AppError {
+  constructor(message = 'Forbidden') {
+    super(403, message, 'authorization_error');
+    this.name = 'AuthorizationError';
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = 'Not found') {
+    super(404, message, 'not_found');
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string) {
+    super(409, message, 'conflict');
+    this.name = 'ConflictError';
+  }
+}
+
+interface ErrorResponse {
+  error: string;
+  code?: string;
+  requestId?: string;
+}
+
+export type InternalLogger = (details: Record<string, unknown>) => void;
+
+export interface ErrorHandlerOptions {
+  logger?: InternalLogger;
+  /** Include `requestId` from `res.locals.requestId` in the error response. */
+  includeRequestId?: boolean;
+}
+
+const DEFAULT_LOGGER: InternalLogger = (details) => {
+  console.error(JSON.stringify({ level: 'error', ...details }));
+};
+
+function redact(err: unknown): ErrorResponse {
+  if (err instanceof AppError) {
+    const body: ErrorResponse = { error: err.message };
+    if (err.code) body.code = err.code;
+    return body;
+  }
+  return { error: 'Internal server error' };
+}
+
+function statusFor(err: unknown): number {
+  if (err instanceof AppError) return err.statusCode;
+
+  // Accept 4xx status codes carried by body-parser and similar framework errors.
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    'status' in err &&
+    typeof (err as { status: unknown }).status === 'number'
+  ) {
+    const s = (err as { status: number }).status;
+    if (s >= 400 && s < 500) return s;
+  }
+
+  return 500;
+}
+
+export function createErrorHandler(options: ErrorHandlerOptions = {}): ErrorRequestHandler {
+  const logger = options.logger ?? DEFAULT_LOGGER;
+  const includeRequestId = options.includeRequestId ?? true;
+
+  // Four-parameter signature is required by Express to recognise this as an
+  // error-handling middleware, even though _next is never called here.
+  return function errorHandler(
+    err: unknown,
+    req: Request,
+    res: Response,
+    _next: NextFunction,
+  ): void {
+    const status = statusFor(err);
+    const requestId: string | undefined =
+      includeRequestId && typeof res.locals['requestId'] === 'string'
+        ? (res.locals['requestId'] as string)
+        : undefined;
+
+    // Log full details internally — never forward stack traces or internal
+    // messages to the client.
+    logger({
+      requestId,
+      method: req.method,
+      path: req.path,
+      status,
+      error:
+        err instanceof Error
+          ? { name: err.name, message: err.message, stack: err.stack }
+          : String(err),
+    });
+
+    const body: ErrorResponse = redact(err);
+    if (requestId) body.requestId = requestId;
+
+    res.status(status).json(body);
+  };
+}
+
+export const errorHandler: ErrorRequestHandler = createErrorHandler();

--- a/routes-d/tests/alerts.test.ts
+++ b/routes-d/tests/alerts.test.ts
@@ -1,0 +1,286 @@
+import { jest } from '@jest/globals';
+import { createAlertsTracker, type AlertEvent, type AlertSink } from '../lib/alerts.js';
+
+// Helpers
+
+function makeClock(start = 0): { now: () => number; advance: (ms: number) => void } {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => { t += ms; },
+  };
+}
+
+// ── Normal traffic (no alert) ──────────────────────────────────────────────
+
+describe('createAlertsTracker — normal traffic', () => {
+  it('does not fire when error rate is below the threshold', () => {
+    const fired: AlertEvent[] = [];
+    const sink: AlertSink = (e) => fired.push(e);
+    const tracker = createAlertsTracker({ threshold: 0.1, minRequests: 5, sinks: [sink] });
+
+    for (let i = 0; i < 9; i++) tracker.record('/api/orders', 200);
+    tracker.record('/api/orders', 500);
+
+    expect(fired).toHaveLength(0);
+  });
+
+  it('does not fire before minRequests is reached even if all are errors', () => {
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 10,
+      sinks: [(e) => fired.push(e)],
+    });
+
+    for (let i = 0; i < 9; i++) tracker.record('/api/payments', 500);
+
+    expect(fired).toHaveLength(0);
+  });
+});
+
+// ── Spike detection ────────────────────────────────────────────────────────
+
+describe('createAlertsTracker — spike detection', () => {
+  it('fires once when error rate crosses the threshold', () => {
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.2,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+    });
+
+    for (let i = 0; i < 4; i++) tracker.record('/api/orders', 200);
+    tracker.record('/api/orders', 500);
+    tracker.record('/api/orders', 500); // rate = 2/6 ≈ 0.33 → above threshold
+
+    expect(fired).toHaveLength(1);
+    expect(fired[0]).toMatchObject({
+      type: 'error_rate_spike',
+      route: '/api/orders',
+      threshold: 0.2,
+    });
+    expect(fired[0]!.rate).toBeGreaterThan(0.2);
+  });
+
+  it('does not fire repeatedly while the route stays above threshold', () => {
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+    });
+
+    for (let i = 0; i < 4; i++) tracker.record('/api/orders', 200);
+    for (let i = 0; i < 10; i++) tracker.record('/api/orders', 500);
+
+    expect(fired).toHaveLength(1);
+  });
+
+  it('fires on each distinct spike onset separated by recovery', () => {
+    const clock = makeClock(1_000_000);
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      windowMs: 1000,
+      threshold: 0.5,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+      now: clock.now,
+    });
+
+    // First spike
+    for (let i = 0; i < 2; i++) tracker.record('/api/orders', 200);
+    for (let i = 0; i < 4; i++) tracker.record('/api/orders', 500); // 4/6 ≈ 0.67 → spike
+
+    expect(fired).toHaveLength(1);
+
+    // Recovery — advance past the window so all spike hits roll off
+    clock.advance(1500);
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 200);
+
+    expect(fired).toHaveLength(1); // no new alert during recovery
+
+    // Second spike
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500); // rate > 0.5 again
+
+    expect(fired).toHaveLength(2);
+  });
+});
+
+// ── Sustained spike ────────────────────────────────────────────────────────
+
+describe('createAlertsTracker — sustained spike', () => {
+  it('fires again when the window fully rolls over while still above threshold', () => {
+    const clock = makeClock(0);
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      windowMs: 1000,
+      threshold: 0.5,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+      now: clock.now,
+    });
+
+    // Fill window with errors → first alert
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+    expect(fired).toHaveLength(1);
+
+    // Advance past the window so old hits roll off, then re-spike
+    clock.advance(1500);
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+
+    expect(fired).toHaveLength(2);
+  });
+});
+
+// ── Route isolation ────────────────────────────────────────────────────────
+
+describe('createAlertsTracker — route isolation', () => {
+  it('tracks each route independently', () => {
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.5,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+    });
+
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+    for (let i = 0; i < 10; i++) tracker.record('/api/payments', 200);
+
+    expect(fired).toHaveLength(1);
+    expect(fired[0]!.route).toBe('/api/orders');
+
+    const orderStats = tracker.stats('/api/orders');
+    const paymentStats = tracker.stats('/api/payments');
+    expect(orderStats.rate).toBeGreaterThan(0.5);
+    expect(paymentStats.rate).toBe(0);
+  });
+});
+
+// ── stats() ────────────────────────────────────────────────────────────────
+
+describe('createAlertsTracker — stats()', () => {
+  it('returns zeros for an unknown route', () => {
+    const tracker = createAlertsTracker();
+    expect(tracker.stats('/unknown')).toEqual({ total: 0, errors: 0, rate: 0 });
+  });
+
+  it('correctly counts totals and errors', () => {
+    const tracker = createAlertsTracker({ threshold: 1, minRequests: 100 });
+    for (let i = 0; i < 7; i++) tracker.record('/r', 200);
+    for (let i = 0; i < 3; i++) tracker.record('/r', 500);
+
+    const s = tracker.stats('/r');
+    expect(s.total).toBe(10);
+    expect(s.errors).toBe(3);
+    expect(s.rate).toBeCloseTo(0.3);
+  });
+
+  it('prunes hits outside the window from stats()', () => {
+    const clock = makeClock(0);
+    const tracker = createAlertsTracker({ windowMs: 1000, threshold: 1, now: clock.now });
+
+    for (let i = 0; i < 5; i++) tracker.record('/r', 500);
+
+    clock.advance(1500);
+
+    const s = tracker.stats('/r');
+    expect(s.total).toBe(0);
+    expect(s.errors).toBe(0);
+  });
+});
+
+// ── reset() ───────────────────────────────────────────────────────────────
+
+describe('createAlertsTracker — reset()', () => {
+  it('clears all windows and resets firing state', () => {
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+    });
+
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+    expect(fired).toHaveLength(1);
+
+    tracker.reset();
+
+    // After reset the window is empty → stats returns zero
+    expect(tracker.stats('/api/orders')).toEqual({ total: 0, errors: 0, rate: 0 });
+
+    // And firing state is cleared so a new spike triggers a fresh alert
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+    expect(fired).toHaveLength(2);
+  });
+});
+
+// ── Sink resilience ────────────────────────────────────────────────────────
+
+describe('createAlertsTracker — sink resilience', () => {
+  it('continues recording even when a sink throws', () => {
+    const good: AlertEvent[] = [];
+    const throwing: AlertSink = () => { throw new Error('slack is down'); };
+    const catching: AlertSink = (e) => good.push(e);
+
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 5,
+      sinks: [throwing, catching],
+    });
+
+    expect(() => {
+      for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+    }).not.toThrow();
+
+    expect(good).toHaveLength(1);
+  });
+
+  it('calls all registered sinks', () => {
+    const calls: string[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 5,
+      sinks: [
+        () => calls.push('sink-a'),
+        () => calls.push('sink-b'),
+      ],
+    });
+
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+
+    expect(calls).toContain('sink-a');
+    expect(calls).toContain('sink-b');
+  });
+});
+
+// ── AlertEvent shape ───────────────────────────────────────────────────────
+
+describe('createAlertsTracker — AlertEvent shape', () => {
+  it('includes a valid ISO-8601 triggeredAt timestamp', () => {
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+    });
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+
+    expect(fired[0]!.triggeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(fired[0]!.windowMs).toBeGreaterThan(0);
+  });
+
+  it('uses the injected clock for triggeredAt', () => {
+    const FIXED_TS = 1_700_000_000_000;
+    const fired: AlertEvent[] = [];
+    const tracker = createAlertsTracker({
+      threshold: 0.1,
+      minRequests: 5,
+      sinks: [(e) => fired.push(e)],
+      now: () => FIXED_TS,
+    });
+    for (let i = 0; i < 5; i++) tracker.record('/api/orders', 500);
+
+    expect(fired[0]!.triggeredAt).toBe(new Date(FIXED_TS).toISOString());
+  });
+});

--- a/routes-d/tests/env.test.ts
+++ b/routes-d/tests/env.test.ts
@@ -1,0 +1,93 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Variables that appear only in benchmark / profiling helper scripts and are
+// not part of the runtime contract; they don't need to be in env.md.
+const BENCH_ONLY = new Set([
+  'ROUTES_D_BENCH_LOOKUPS',
+  'ROUTES_D_BENCH_P',
+  'ROUTES_D_BENCH_PAYMENTS',
+  'ROUTES_D_BENCH_SEED',
+  'ROUTES_D_PROFILE_OUTPUT',
+  'ROUTES_D_PROFILE_REFRESHES',
+  'ROUTES_D_PROFILE_USERS',
+]);
+
+async function collectEnvVars(dir: string): Promise<Set<string>> {
+  const vars = new Set<string>();
+
+  async function walk(current: string): Promise<void> {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        // Skip test files — bench/profile helpers live here and carry vars
+        // that are intentionally excluded from env.md.
+        if (entry.name === 'tests' || entry.name === 'node_modules' || entry.name === 'dist') {
+          continue;
+        }
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        const content = await readFile(fullPath, 'utf8');
+        for (const m of content.matchAll(/process\.env\.([A-Z_]+)/g)) {
+          if (m[1]) vars.add(m[1]);
+        }
+      }
+    }
+  }
+
+  await walk(dir);
+  return vars;
+}
+
+describe('routes-d env documentation (#340)', () => {
+  const root = 'routes-d';
+
+  it('env.md exists and contains required sections', async () => {
+    const doc = await readFile(`${root}/docs/env.md`, 'utf8');
+    expect(doc).toContain('HORIZON_URL');
+    expect(doc).toContain('SOROBAN_RPC_URL');
+    expect(doc).toContain('ALLOWED_ORIGINS');
+    expect(doc).toContain('NODE_ENV');
+    expect(doc).toContain('Secret');
+  });
+
+  it('.env.example exists and documents key variables', async () => {
+    const example = await readFile(`${root}/.env.example`, 'utf8');
+    expect(example).toContain('HORIZON_URL');
+    expect(example).toContain('SOROBAN_RPC_URL');
+    expect(example).toContain('ALLOWED_ORIGINS');
+    expect(example).toContain('NODE_ENV');
+  });
+
+  it('env.md documents every env variable read in non-test source files', async () => {
+    const envMd = await readFile(`${root}/docs/env.md`, 'utf8');
+    const codeVars = await collectEnvVars(root);
+
+    const undocumented: string[] = [];
+    for (const varName of codeVars) {
+      if (BENCH_ONLY.has(varName)) continue;
+      if (!envMd.includes(varName)) undocumented.push(varName);
+    }
+
+    if (undocumented.length > 0) {
+      throw new Error(
+        `The following env vars are used in source code but missing from env.md:\n${undocumented.map((v) => `  - ${v}`).join('\n')}`,
+      );
+    }
+  });
+
+  it('.env.example and env.md are consistent — all .env.example vars appear in env.md', async () => {
+    const envMd = await readFile(`${root}/docs/env.md`, 'utf8');
+    const example = await readFile(`${root}/.env.example`, 'utf8');
+
+    const exampleVars = [...example.matchAll(/^([A-Z_]+)=/gm)].map((m) => m[1]!);
+    const missing = exampleVars.filter((v) => !envMd.includes(v));
+
+    if (missing.length > 0) {
+      throw new Error(
+        `.env.example declares vars absent from env.md:\n${missing.map((v) => `  - ${v}`).join('\n')}`,
+      );
+    }
+  });
+});

--- a/routes-d/tests/errorHandler.test.ts
+++ b/routes-d/tests/errorHandler.test.ts
@@ -1,0 +1,197 @@
+import express, { type Express } from 'express';
+import request from 'supertest';
+import {
+  createErrorHandler,
+  AppError,
+  ValidationError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ConflictError,
+  type InternalLogger,
+} from '../middleware/errorHandler.js';
+
+function buildApp(opts: {
+  logger?: InternalLogger;
+  includeRequestId?: boolean;
+  errorFactory?: () => unknown;
+  injectRequestId?: string;
+} = {}): Express {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/boom', (_req, res, next) => {
+    if (opts.injectRequestId) res.locals['requestId'] = opts.injectRequestId;
+    next(opts.errorFactory ? opts.errorFactory() : new Error('unexpected'));
+  });
+
+  app.use(
+    createErrorHandler({
+      logger: opts.logger ?? (() => {}),
+      includeRequestId: opts.includeRequestId,
+    }),
+  );
+  return app;
+}
+
+// ── Known error types ──────────────────────────────────────────────────────
+
+describe('createErrorHandler — known error types', () => {
+  it('maps ValidationError to 400 with message and code', async () => {
+    const app = buildApp({ errorFactory: () => new ValidationError('email is required') });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'email is required', code: 'validation_error' });
+  });
+
+  it('maps AuthenticationError to 401', async () => {
+    const app = buildApp({ errorFactory: () => new AuthenticationError() });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('authentication_error');
+  });
+
+  it('maps AuthorizationError to 403', async () => {
+    const app = buildApp({ errorFactory: () => new AuthorizationError() });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('authorization_error');
+  });
+
+  it('maps NotFoundError to 404', async () => {
+    const app = buildApp({ errorFactory: () => new NotFoundError() });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('not_found');
+  });
+
+  it('maps ConflictError to 409', async () => {
+    const app = buildApp({ errorFactory: () => new ConflictError('duplicate key') });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('conflict');
+  });
+
+  it('maps a custom AppError with arbitrary status and code', async () => {
+    const app = buildApp({
+      errorFactory: () => new AppError(422, 'unprocessable entity', 'unprocessable_entity'),
+    });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({ error: 'unprocessable entity', code: 'unprocessable_entity' });
+  });
+
+  it('accepts 4xx status from framework-shaped errors (body-parser)', async () => {
+    const err = Object.assign(new Error('payload too large'), { status: 413 });
+    const app = buildApp({ errorFactory: () => err });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(413);
+  });
+});
+
+// ── Unknown errors ─────────────────────────────────────────────────────────
+
+describe('createErrorHandler — unknown errors', () => {
+  it('returns 500 with a generic message for an unrecognised Error', async () => {
+    const app = buildApp({ errorFactory: () => new Error('secret db connection string') });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Internal server error');
+    expect(JSON.stringify(res.body)).not.toContain('db connection string');
+  });
+
+  it('returns 500 for non-Error throws', async () => {
+    const app = buildApp({ errorFactory: () => 'something blew up' });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Internal server error');
+  });
+
+  it('never leaks stack traces or internal messages to the client', async () => {
+    const app = buildApp({ errorFactory: () => new Error('private stack detail') });
+    const res = await request(app).get('/boom');
+    const serialised = JSON.stringify(res.body);
+    expect(serialised).not.toContain('stack');
+    expect(serialised).not.toContain('private stack detail');
+  });
+
+  it('does not promote 5xx status from framework-shaped errors', async () => {
+    const err = Object.assign(new Error('server error'), { status: 503 });
+    const app = buildApp({ errorFactory: () => err });
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── Internal logging ───────────────────────────────────────────────────────
+
+describe('createErrorHandler — internal logging', () => {
+  it('logs full error details including message and stack', async () => {
+    const logged: unknown[] = [];
+    const logger: InternalLogger = (d) => logged.push(d);
+    const app = buildApp({ logger, errorFactory: () => new Error('secret internal detail') });
+
+    await request(app).get('/boom');
+
+    expect(logged).toHaveLength(1);
+    const entry = logged[0] as Record<string, unknown>;
+    const serialised = JSON.stringify(entry);
+    expect(serialised).toContain('secret internal detail');
+    expect(entry['status']).toBe(500);
+    expect(entry['method']).toBe('GET');
+  });
+
+  it('includes requestId from res.locals in response and log when enabled', async () => {
+    const logged: unknown[] = [];
+    const app = buildApp({
+      logger: (d) => logged.push(d),
+      includeRequestId: true,
+      injectRequestId: 'req-abc-123',
+      errorFactory: () => new ValidationError('bad input'),
+    });
+
+    const res = await request(app).get('/boom');
+
+    expect(res.status).toBe(400);
+    expect(res.body.requestId).toBe('req-abc-123');
+    expect((logged[0] as Record<string, unknown>)['requestId']).toBe('req-abc-123');
+  });
+
+  it('omits requestId when includeRequestId is false', async () => {
+    const app = buildApp({
+      includeRequestId: false,
+      injectRequestId: 'should-not-appear',
+      errorFactory: () => new NotFoundError(),
+    });
+
+    const res = await request(app).get('/boom');
+
+    expect(res.body.requestId).toBeUndefined();
+  });
+
+  it('omits requestId when res.locals.requestId is not set', async () => {
+    const app = buildApp({
+      includeRequestId: true,
+      errorFactory: () => new AuthenticationError(),
+    });
+
+    const res = await request(app).get('/boom');
+
+    expect(res.body.requestId).toBeUndefined();
+  });
+});
+
+// ── Integration: default exported handler ──────────────────────────────────
+
+describe('errorHandler (default export)', () => {
+  it('is a usable Express error middleware', async () => {
+    const { errorHandler } = await import('../middleware/errorHandler.js');
+    const app = express();
+    app.get('/fail', (_req, _res, next) => next(new AppError(418, "I'm a teapot", 'teapot')));
+    app.use(errorHandler);
+
+    const res = await request(app).get('/fail');
+    expect(res.status).toBe(418);
+    expect(res.body.code).toBe('teapot');
+  });
+});

--- a/routes-d/tests/horizonBatcher.test.ts
+++ b/routes-d/tests/horizonBatcher.test.ts
@@ -1,0 +1,197 @@
+import { jest } from '@jest/globals';
+import { createHorizonBatcher, type FlushMetrics } from '../lib/horizonBatcher.js';
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Single request ─────────────────────────────────────────────────────────
+
+describe('createHorizonBatcher — single request', () => {
+  it('resolves with the value returned by the underlying fetch', async () => {
+    const fetcher = jest.fn(async (_path: string) => ({ ledger: 1 }));
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 5 });
+
+    const result = await batcher.fetch<{ ledger: number }>('/ledgers/1');
+
+    expect(result).toEqual({ ledger: 1 });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith('/ledgers/1');
+  });
+
+  it('rejects when the underlying fetch throws', async () => {
+    const fetcher = jest.fn(async (_path: string): Promise<unknown> => {
+      throw new Error('horizon 503');
+    });
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 5 });
+
+    await expect(batcher.fetch('/accounts/GABC')).rejects.toThrow('horizon 503');
+  });
+});
+
+// ── Batching / coalescing ──────────────────────────────────────────────────
+
+describe('createHorizonBatcher — coalescing', () => {
+  it('issues a single upstream fetch for concurrent duplicate paths', async () => {
+    const fetcher = jest.fn(async (_path: string) => ({ account: 'GABC' }));
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 20 });
+
+    const [a, b, c] = await Promise.all([
+      batcher.fetch('/accounts/GABC'),
+      batcher.fetch('/accounts/GABC'),
+      batcher.fetch('/accounts/GABC'),
+    ]);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(a).toEqual({ account: 'GABC' });
+    expect(b).toEqual(a);
+    expect(c).toEqual(a);
+  });
+
+  it('issues parallel upstream fetches for distinct paths in the same window', async () => {
+    const fetcher = jest.fn(async (path: string) => ({ path }));
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 20 });
+
+    const [a, b] = await Promise.all([
+      batcher.fetch('/accounts/GA'),
+      batcher.fetch('/accounts/GB'),
+    ]);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect((a as { path: string }).path).toBe('/accounts/GA');
+    expect((b as { path: string }).path).toBe('/accounts/GB');
+  });
+
+  it('sends a new upstream request for the same path in a later window', async () => {
+    const fetcher = jest.fn(async (_path: string) => ({ ts: Date.now() }));
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 5 });
+
+    await batcher.fetch('/ledgers/latest');
+    await delay(30);
+    await batcher.fetch('/ledgers/latest');
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── flush() ────────────────────────────────────────────────────────────────
+
+describe('createHorizonBatcher — flush()', () => {
+  it('flush() forces immediate dispatch without waiting for coalesceMs', async () => {
+    const fetcher = jest.fn(async (_path: string) => 'ok');
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 60_000 });
+
+    const promise = batcher.fetch('/accounts/GX');
+    await batcher.flush();
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush() on an empty batcher resolves immediately', async () => {
+    const batcher = createHorizonBatcher({ fetch: jest.fn(async () => null), coalesceMs: 5 });
+    await expect(batcher.flush()).resolves.toBeUndefined();
+  });
+});
+
+// ── Metrics ────────────────────────────────────────────────────────────────
+
+describe('createHorizonBatcher — stats()', () => {
+  it('reports zero metrics on a freshly created batcher', () => {
+    const batcher = createHorizonBatcher({ fetch: jest.fn(async () => null), coalesceMs: 5 });
+    const s = batcher.stats();
+    expect(s.totalRequests).toBe(0);
+    expect(s.totalBatches).toBe(0);
+    expect(s.totalCoalesced).toBe(0);
+    expect(s.hitRate).toBe(0);
+  });
+
+  it('increments totalRequests for every call to fetch()', async () => {
+    const fetcher = jest.fn(async () => null);
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 20 });
+
+    await Promise.all([
+      batcher.fetch('/a'),
+      batcher.fetch('/a'),
+      batcher.fetch('/b'),
+    ]);
+
+    expect(batcher.stats().totalRequests).toBe(3);
+  });
+
+  it('tracks coalesced count and hit rate correctly', async () => {
+    const fetcher = jest.fn(async () => null);
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 20 });
+
+    // 3 requests for /a → 2 coalesced; 1 request for /b → 0 coalesced
+    await Promise.all([
+      batcher.fetch('/a'),
+      batcher.fetch('/a'),
+      batcher.fetch('/a'),
+      batcher.fetch('/b'),
+    ]);
+
+    const { totalRequests, totalBatches, totalCoalesced, hitRate } = batcher.stats();
+    expect(totalRequests).toBe(4);
+    expect(totalBatches).toBe(1);
+    expect(totalCoalesced).toBe(2);
+    expect(hitRate).toBeCloseTo(0.5);
+  });
+
+  it('invokes onFlush with correct batch-size and coalesced metrics', async () => {
+    const flushEvents: FlushMetrics[] = [];
+    const batcher = createHorizonBatcher({
+      fetch: jest.fn(async () => null),
+      coalesceMs: 20,
+      onFlush: (m) => flushEvents.push(m),
+    });
+
+    await Promise.all([
+      batcher.fetch('/a'),
+      batcher.fetch('/a'),
+      batcher.fetch('/b'),
+    ]);
+
+    expect(flushEvents).toHaveLength(1);
+    expect(flushEvents[0]!.batchSize).toBe(2);
+    expect(flushEvents[0]!.coalesced).toBe(1);
+    expect(flushEvents[0]!.flushDurationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── Error isolation ────────────────────────────────────────────────────────
+
+describe('createHorizonBatcher — error isolation', () => {
+  it('propagates errors to all waiters for the same failed path', async () => {
+    const fetcher = jest.fn(async (_path: string): Promise<unknown> => {
+      throw new Error('upstream error');
+    });
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 20 });
+
+    const results = await Promise.allSettled([
+      batcher.fetch('/fail'),
+      batcher.fetch('/fail'),
+    ]);
+
+    expect(results[0]!.status).toBe('rejected');
+    expect(results[1]!.status).toBe('rejected');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cancel successful paths when another path in the same batch fails', async () => {
+    const fetcher = jest.fn(async (path: string): Promise<unknown> => {
+      if (path === '/bad') throw new Error('bad');
+      return { ok: true };
+    });
+    const batcher = createHorizonBatcher({ fetch: fetcher, coalesceMs: 20 });
+
+    const [good, bad] = await Promise.allSettled([
+      batcher.fetch('/good'),
+      batcher.fetch('/bad'),
+    ]);
+
+    expect(good.status).toBe('fulfilled');
+    expect(bad.status).toBe('rejected');
+  });
+});


### PR DESCRIPTION
# Pull Request — routes-d: error handler, env reference, Horizon batcher, alerting hooks

## Issues closed

- closes #325 — Safe error handler middleware in routes-d
- closes #340 — Environment variables reference inside routes-d
- closes #354 — Batched Horizon request helper in routes-d
- closes #334 — Error rate alerting hooks in routes-d

---

## Summary

All changes are scoped to `routes-d/` and follow existing ESM / TypeScript conventions.

### #325 — `routes-d/middleware/errorHandler.ts`

- Typed error hierarchy: `AppError`, `ValidationError`, `AuthenticationError`,
  `AuthorizationError`, `NotFoundError`, `ConflictError`.
- `createErrorHandler(options)` factory returns a four-parameter Express error
  middleware that **redacts** unknown errors to `"Internal server error"` and
  forwards only `AppError` message + code to the client — stack traces never
  leave the server.
- Full internal logging of method, path, status, and raw error is wired to an
  injectable `InternalLogger` (defaults to `console.error` JSON).
- `res.locals.requestId` is forwarded to both the log entry and the response
  body (opt-in, on by default).
- A ready-to-use `errorHandler` export covers the simple case.
- Tests: known-error mapping, unknown-error redaction, stack-trace leakage,
  body-parser 4xx pass-through, logging, requestId propagation.

### #340 — `routes-d/docs/env.md` + `routes-d/.env.example`

- `env.md` documents every env variable consumed by routes-d — name, purpose,
  default value, required flag, and secret flag — grouped by subsystem.
- `.env.example` mirrors the same variables with safe placeholder values and
  inline `# SECRET` markers.
- `routes-d/tests/env.test.ts` lints that:
  1. All env vars read in non-test source files appear in `env.md`.
  2. All variables declared in `.env.example` appear in `env.md`.
  - Bench-only and profiling helper vars (`ROUTES_D_BENCH_*`,
    `ROUTES_D_PROFILE_*`) are explicitly excluded from the runtime contract.

### #354 — `routes-d/lib/horizonBatcher.ts`

- `createHorizonBatcher({ fetch, coalesceMs, onFlush })` returns a batcher
  that deduplicates concurrent fetches for the same Horizon path within a short
  coalescing window (default 10 ms), while issuing distinct paths in parallel.
- `stats()` surfaces `totalRequests`, `totalBatches`, `totalCoalesced`, and
  `hitRate`.
- `onFlush` callback receives `batchSize`, `coalesced`, and
  `flushDurationMs` per flush.
- `flush()` forces immediate dispatch — useful in tests and graceful shutdown.
- Tests: single request, coalescing, distinct-path parallelism, later-window
  re-fetch, forced flush, metrics accuracy, error isolation (one bad path does
  not cancel healthy paths in the same batch).

### #334 — `routes-d/lib/alerts.ts`

- `createAlertsTracker(options)` returns a tracker with a pluggable
  `AlertSink[]` interface (PagerDuty, Slack, etc.).
- Sliding-window per-route error-rate tracking (default: 60 s window,
  10 % threshold, 10 request minimum).
- Fires `AlertEvent` once per spike onset; resets when the rate drops below
  the threshold so the next spike fires a fresh alert.
- Injectable clock (`now`) for deterministic testing.
- Sink errors are swallowed — alerting never disrupts the request path.
- Tests: normal traffic, spike detection, no duplicate alerts during sustained
  spike, recovery → re-spike, route isolation, `stats()` accuracy, window
  pruning, `reset()`, multi-sink, throwing sink resilience, `AlertEvent` shape
  and `triggeredAt` timestamp.

---

## Files changed

```
routes-d/middleware/errorHandler.ts       (new)
routes-d/tests/errorHandler.test.ts      (new)
routes-d/docs/env.md                     (new)
routes-d/.env.example                    (new)
routes-d/tests/env.test.ts               (new)
routes-d/lib/horizonBatcher.ts           (new)
routes-d/tests/horizonBatcher.test.ts    (new)
routes-d/lib/alerts.ts                   (new)
routes-d/tests/alerts.test.ts            (new)
```

No files outside `routes-d/` were modified.

---

## Test plan

```bash
cd routes-d
npm test                        # all routes-d tests via ts-jest ESM
npm test -- --testPathPattern errorHandler
npm test -- --testPathPattern env
npm test -- --testPathPattern horizonBatcher
npm test -- --testPathPattern alerts
```

All new test files follow the `routes-d/tests/**/*.test.ts` pattern and are
picked up automatically by both the `routes-d/jest.config.js` and the root
`jest.config.mjs`.
