### PR TITLE
feat(routes-d): fix #278 Stellar transaction webhook dispatcher

### DIFF
--- a/routes-d/lib/webhookDispatcher.ts
+++ b/routes-d/lib/webhookDispatcher.ts
@@ -1,0 +1,303 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+export const STELLAR_TRANSACTION_CONFIRMED_EVENT =
+  "stellar.transaction.confirmed" as const;
+
+const SIGNATURE_HEADER = "X-Nextellar-Signature";
+const TIMESTAMP_HEADER = "X-Nextellar-Timestamp";
+const EVENT_HEADER = "X-Nextellar-Event";
+const DELIVERY_HEADER = "X-Nextellar-Delivery";
+
+export const WEBHOOK_DISPATCHER_HEADERS = Object.freeze({
+  signature: SIGNATURE_HEADER,
+  timestamp: TIMESTAMP_HEADER,
+  event: EVENT_HEADER,
+  delivery: DELIVERY_HEADER,
+});
+
+export interface StellarConfirmedTransaction {
+  hash: string;
+  ledger: number;
+  createdAt: string;
+  sourceAccount: string;
+  successful: true;
+  feeCharged?: string;
+  pagingToken?: string;
+  memo?: string;
+  envelopeXdr?: string;
+  resultXdr?: string;
+}
+
+export interface StellarTransactionWebhookPayload {
+  event: typeof STELLAR_TRANSACTION_CONFIRMED_EVENT;
+  accountId: string;
+  occurredAt: string;
+  transaction: StellarConfirmedTransaction;
+}
+
+export interface WebhookSubscription {
+  id: string;
+  accountId: string;
+  url: string;
+  secret: string;
+  createdAt: string;
+}
+
+export interface PublicWebhookSubscription {
+  id: string;
+  accountId: string;
+  url: string;
+  createdAt: string;
+}
+
+export interface WebhookSubscriptionStore {
+  save(subscription: WebhookSubscription): Promise<void>;
+  listByAccount(accountId: string): Promise<WebhookSubscription[]>;
+}
+
+export interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+}
+
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<FetchResponseLike>;
+
+export interface WebhookDispatchOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  fetcher?: FetchLike;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  nextDeliveryId?: () => string;
+}
+
+export interface WebhookDispatchResult {
+  ok: boolean;
+  subscriptionId: string;
+  attempts: number;
+  lastStatus?: number;
+  lastError?: string;
+}
+
+export interface AccountDispatchResult {
+  accountId: string;
+  delivered: number;
+  failed: number;
+  results: WebhookDispatchResult[];
+}
+
+const DEFAULT_MAX_ATTEMPTS = 4;
+const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 8_000;
+const MAX_ATTEMPTS_LIMIT = 10;
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const defaultFetcher: FetchLike = async (url, init) => {
+  const response = await fetch(url, init);
+  return { ok: response.ok, status: response.status };
+};
+
+export function toPublicSubscription(
+  subscription: WebhookSubscription,
+): PublicWebhookSubscription {
+  return {
+    id: subscription.id,
+    accountId: subscription.accountId,
+    url: subscription.url,
+    createdAt: subscription.createdAt,
+  };
+}
+
+export function createInMemoryWebhookSubscriptionStore(): WebhookSubscriptionStore {
+  const byAccount = new Map<string, Map<string, WebhookSubscription>>();
+
+  return {
+    async save(subscription: WebhookSubscription): Promise<void> {
+      const accountSubscriptions =
+        byAccount.get(subscription.accountId) ?? new Map<string, WebhookSubscription>();
+      accountSubscriptions.set(subscription.id, subscription);
+      byAccount.set(subscription.accountId, accountSubscriptions);
+    },
+
+    async listByAccount(accountId: string): Promise<WebhookSubscription[]> {
+      return Array.from(byAccount.get(accountId)?.values() ?? []);
+    },
+  };
+}
+
+export function signWebhookPayload(
+  secret: string,
+  timestamp: string,
+  body: string,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${timestamp}.${body}`)
+    .digest("hex");
+}
+
+export function verifyWebhookSignature(
+  secret: string,
+  timestamp: string,
+  body: string,
+  signature: string,
+): boolean {
+  if (!signature || !/^[a-f0-9]{64}$/i.test(signature)) {
+    return false;
+  }
+
+  const expected = Buffer.from(
+    signWebhookPayload(secret, timestamp, body),
+    "hex",
+  );
+  const actual = Buffer.from(signature, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+export function buildStellarTransactionPayload(params: {
+  accountId: string;
+  transaction: StellarConfirmedTransaction;
+}): StellarTransactionWebhookPayload {
+  if (params.transaction.successful !== true) {
+    throw new Error("only successful Stellar transactions can be dispatched");
+  }
+
+  return {
+    event: STELLAR_TRANSACTION_CONFIRMED_EVENT,
+    accountId: params.accountId,
+    occurredAt: params.transaction.createdAt,
+    transaction: params.transaction,
+  };
+}
+
+function normalizeAttempts(value: number | undefined): number {
+  const attempts = value ?? DEFAULT_MAX_ATTEMPTS;
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > MAX_ATTEMPTS_LIMIT) {
+    throw new Error(`maxAttempts must be an integer between 1 and ${MAX_ATTEMPTS_LIMIT}`);
+  }
+  return attempts;
+}
+
+function retryDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  return Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+}
+
+function shouldRetryStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+export class StellarWebhookDispatcher {
+  private readonly maxAttempts: number;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly fetcher: FetchLike;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => number;
+  private readonly nextDeliveryId: () => string;
+
+  constructor(
+    private readonly store: WebhookSubscriptionStore,
+    options: WebhookDispatchOptions = {},
+  ) {
+    this.maxAttempts = normalizeAttempts(options.maxAttempts);
+    this.baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+    this.maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+    this.fetcher = options.fetcher ?? defaultFetcher;
+    this.sleep = options.sleep ?? defaultSleep;
+    this.now = options.now ?? (() => Date.now());
+    this.nextDeliveryId = options.nextDeliveryId ?? (() => randomUUID());
+
+    if (this.baseDelayMs < 0 || this.maxDelayMs < this.baseDelayMs) {
+      throw new Error("backoff delays must be non-negative and ordered");
+    }
+  }
+
+  async dispatchToSubscription(
+    subscription: WebhookSubscription,
+    payload: StellarTransactionWebhookPayload,
+  ): Promise<WebhookDispatchResult> {
+    const body = JSON.stringify(payload);
+    const timestamp = String(this.now());
+    const signature = signWebhookPayload(subscription.secret, timestamp, body);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      [SIGNATURE_HEADER]: signature,
+      [TIMESTAMP_HEADER]: timestamp,
+      [EVENT_HEADER]: payload.event,
+      [DELIVERY_HEADER]: this.nextDeliveryId(),
+    };
+
+    let lastStatus: number | undefined;
+    let lastError: string | undefined;
+
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt += 1) {
+      try {
+        const response = await this.fetcher(subscription.url, {
+          method: "POST",
+          headers,
+          body,
+        });
+        lastStatus = response.status;
+        lastError = undefined;
+
+        if (response.ok) {
+          return {
+            ok: true,
+            subscriptionId: subscription.id,
+            attempts: attempt,
+            lastStatus,
+          };
+        }
+
+        if (!shouldRetryStatus(response.status)) {
+          return {
+            ok: false,
+            subscriptionId: subscription.id,
+            attempts: attempt,
+            lastStatus,
+          };
+        }
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+
+      if (attempt < this.maxAttempts) {
+        await this.sleep(retryDelayMs(attempt, this.baseDelayMs, this.maxDelayMs));
+      }
+    }
+
+    return {
+      ok: false,
+      subscriptionId: subscription.id,
+      attempts: this.maxAttempts,
+      lastStatus,
+      lastError,
+    };
+  }
+
+  async dispatchConfirmedTransaction(params: {
+    accountId: string;
+    transaction: StellarConfirmedTransaction;
+  }): Promise<AccountDispatchResult> {
+    const payload = buildStellarTransactionPayload(params);
+    const subscriptions = await this.store.listByAccount(params.accountId);
+    const results = await Promise.all(
+      subscriptions.map((subscription) =>
+        this.dispatchToSubscription(subscription, payload),
+      ),
+    );
+
+    const delivered = results.filter((result) => result.ok).length;
+    return {
+      accountId: params.accountId,
+      delivered,
+      failed: results.length - delivered,
+      results,
+    };
+  }
+}

--- a/routes-d/routes/webhooks.subscribe.ts
+++ b/routes-d/routes/webhooks.subscribe.ts
@@ -1,0 +1,100 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { Router, type Request, type Response } from "express";
+import {
+  type WebhookSubscription,
+  type WebhookSubscriptionStore,
+  toPublicSubscription,
+} from "../lib/webhookDispatcher.js";
+
+export interface WebhooksSubscribeRouterOptions {
+  store: WebhookSubscriptionStore;
+  now?: () => Date;
+  nextId?: () => string;
+  nextSecret?: () => string;
+}
+
+const STELLAR_ACCOUNT_RE = /^G[A-Z2-7]{55}$/;
+
+function parseUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.hostname !== "localhost") {
+      return undefined;
+    }
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function parseAccountId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const accountId = value.trim();
+  return STELLAR_ACCOUNT_RE.test(accountId) ? accountId : undefined;
+}
+
+function parseSecret(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const secret = value.trim();
+  return secret.length >= 16 ? secret : undefined;
+}
+
+export function createWebhooksSubscribeRouter(
+  options: WebhooksSubscribeRouterOptions,
+): Router {
+  const router = Router();
+  const now = options.now ?? (() => new Date());
+  const nextId = options.nextId ?? (() => randomUUID());
+  const nextSecret =
+    options.nextSecret ?? (() => randomBytes(32).toString("base64url"));
+
+  router.post("/", async (req: Request, res: Response) => {
+    const accountId = parseAccountId(req.body?.accountId);
+    if (!accountId) {
+      res.status(400).json({ ok: false, error: "accountId must be a Stellar account ID" });
+      return;
+    }
+
+    const url = parseUrl(req.body?.url);
+    if (!url) {
+      res.status(400).json({ ok: false, error: "url must be a valid HTTPS URL" });
+      return;
+    }
+
+    const providedSecret = parseSecret(req.body?.secret);
+    if (req.body?.secret !== undefined && !providedSecret) {
+      res.status(400).json({ ok: false, error: "secret must be at least 16 characters" });
+      return;
+    }
+
+    const secret = providedSecret ?? nextSecret();
+    const subscription: WebhookSubscription = {
+      id: nextId(),
+      accountId,
+      url,
+      secret,
+      createdAt: now().toISOString(),
+    };
+
+    await options.store.save(subscription);
+
+    res.status(201).json({
+      ok: true,
+      subscription: toPublicSubscription(subscription),
+      secret: providedSecret ? undefined : secret,
+    });
+  });
+
+  return router;
+}

--- a/routes-d/tests/webhookDispatcher.test.ts
+++ b/routes-d/tests/webhookDispatcher.test.ts
@@ -1,0 +1,208 @@
+import {
+  STELLAR_TRANSACTION_CONFIRMED_EVENT,
+  StellarWebhookDispatcher,
+  WEBHOOK_DISPATCHER_HEADERS,
+  buildStellarTransactionPayload,
+  createInMemoryWebhookSubscriptionStore,
+  signWebhookPayload,
+  verifyWebhookSignature,
+  type FetchLike,
+  type StellarConfirmedTransaction,
+  type WebhookSubscription,
+} from "../lib/webhookDispatcher.js";
+
+const accountId = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function transaction(
+  overrides: Partial<StellarConfirmedTransaction> = {},
+): StellarConfirmedTransaction {
+  return {
+    hash: "9f0f4c9e8d2d5f6a4b3c2a1908172635445362718071625344a3b2c1d0e9f8a7",
+    ledger: 55_123,
+    createdAt: "2026-06-01T18:30:00Z",
+    sourceAccount: accountId,
+    successful: true,
+    feeCharged: "100",
+    pagingToken: "236746978123776",
+    ...overrides,
+  };
+}
+
+function subscription(
+  overrides: Partial<WebhookSubscription> = {},
+): WebhookSubscription {
+  return {
+    id: "sub_1",
+    accountId,
+    url: "https://downstream.example/webhooks/stellar",
+    secret: "super-secret-value",
+    createdAt: "2026-06-01T18:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Stellar transaction webhook signatures", () => {
+  it("signs and verifies the timestamped JSON body", () => {
+    const body = JSON.stringify(
+      buildStellarTransactionPayload({ accountId, transaction: transaction() }),
+    );
+    const timestamp = "1780338600000";
+    const signature = signWebhookPayload("secret", timestamp, body);
+
+    expect(verifyWebhookSignature("secret", timestamp, body, signature)).toBe(true);
+    expect(verifyWebhookSignature("secret", timestamp, `${body} `, signature)).toBe(false);
+    expect(verifyWebhookSignature("wrong", timestamp, body, signature)).toBe(false);
+    expect(verifyWebhookSignature("secret", timestamp, body, "not-hex")).toBe(false);
+  });
+
+  it("rejects non-successful transaction payloads", () => {
+    expect(() =>
+      buildStellarTransactionPayload({
+        accountId,
+        transaction: {
+          ...transaction(),
+          successful: false as unknown as true,
+        },
+      }),
+    ).toThrow("only successful Stellar transactions");
+  });
+});
+
+describe("StellarWebhookDispatcher", () => {
+  it("dispatches a confirmed transaction with HMAC headers", async () => {
+    const seen: { url: string; headers: Record<string, string>; body: string }[] = [];
+    const fetcher: FetchLike = async (url, init) => {
+      seen.push({ url, headers: init.headers, body: init.body });
+      return { ok: true, status: 204 };
+    };
+    const dispatcher = new StellarWebhookDispatcher(
+      createInMemoryWebhookSubscriptionStore(),
+      {
+        fetcher,
+        now: () => 1_780_338_600_000,
+        nextDeliveryId: () => "delivery_1",
+      },
+    );
+
+    const payload = buildStellarTransactionPayload({
+      accountId,
+      transaction: transaction(),
+    });
+    const result = await dispatcher.dispatchToSubscription(subscription(), payload);
+
+    expect(result).toEqual({
+      ok: true,
+      subscriptionId: "sub_1",
+      attempts: 1,
+      lastStatus: 204,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.url).toBe("https://downstream.example/webhooks/stellar");
+    expect(seen[0]!.headers[WEBHOOK_DISPATCHER_HEADERS.event]).toBe(
+      STELLAR_TRANSACTION_CONFIRMED_EVENT,
+    );
+    expect(seen[0]!.headers[WEBHOOK_DISPATCHER_HEADERS.timestamp]).toBe(
+      "1780338600000",
+    );
+    expect(seen[0]!.headers[WEBHOOK_DISPATCHER_HEADERS.delivery]).toBe(
+      "delivery_1",
+    );
+    expect(
+      verifyWebhookSignature(
+        "super-secret-value",
+        seen[0]!.headers[WEBHOOK_DISPATCHER_HEADERS.timestamp]!,
+        seen[0]!.body,
+        seen[0]!.headers[WEBHOOK_DISPATCHER_HEADERS.signature]!,
+      ),
+    ).toBe(true);
+  });
+
+  it("retries transient failures with exponential backoff", async () => {
+    let calls = 0;
+    const fetcher: FetchLike = async () => {
+      calls += 1;
+      return calls < 3 ? { ok: false, status: 503 } : { ok: true, status: 200 };
+    };
+    const delays: number[] = [];
+    const sleep = async (ms: number) => {
+      delays.push(ms);
+    };
+    const dispatcher = new StellarWebhookDispatcher(
+      createInMemoryWebhookSubscriptionStore(),
+      {
+        fetcher,
+        sleep,
+        maxAttempts: 4,
+        baseDelayMs: 25,
+        maxDelayMs: 100,
+      },
+    );
+
+    const result = await dispatcher.dispatchToSubscription(
+      subscription(),
+      buildStellarTransactionPayload({ accountId, transaction: transaction() }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(delays).toEqual([25, 50]);
+  });
+
+  it("does not retry permanent 4xx responses except rate limits", async () => {
+    let calls = 0;
+    const fetcher: FetchLike = async () => {
+      calls += 1;
+      return { ok: false, status: 400 };
+    };
+    const dispatcher = new StellarWebhookDispatcher(
+      createInMemoryWebhookSubscriptionStore(),
+      {
+        fetcher,
+        sleep: async () => {},
+        maxAttempts: 4,
+      },
+    );
+
+    const result = await dispatcher.dispatchToSubscription(
+      subscription(),
+      buildStellarTransactionPayload({ accountId, transaction: transaction() }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it("dispatches to subscribers watching the confirmed account", async () => {
+    const store = createInMemoryWebhookSubscriptionStore();
+    await store.save(subscription({ id: "sub_1", url: "https://a.example/hook" }));
+    await store.save(subscription({ id: "sub_2", url: "https://b.example/hook" }));
+    await store.save(
+      subscription({
+        id: "sub_other",
+        accountId: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        url: "https://c.example/hook",
+      }),
+    );
+
+    const urls: string[] = [];
+    const dispatcher = new StellarWebhookDispatcher(store, {
+      fetcher: async (url) => {
+        urls.push(url);
+        return { ok: true, status: 200 };
+      },
+    });
+
+    const result = await dispatcher.dispatchConfirmedTransaction({
+      accountId,
+      transaction: transaction(),
+    });
+
+    expect(result.delivered).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(urls.sort()).toEqual([
+      "https://a.example/hook",
+      "https://b.example/hook",
+    ]);
+  });
+});

--- a/routes-d/tests/webhooks.subscribe.test.ts
+++ b/routes-d/tests/webhooks.subscribe.test.ts
@@ -1,0 +1,98 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import {
+  createInMemoryWebhookSubscriptionStore,
+  type WebhookSubscriptionStore,
+} from "../lib/webhookDispatcher.js";
+import { createWebhooksSubscribeRouter } from "../routes/webhooks.subscribe.js";
+
+const accountId = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function buildApp(store: WebhookSubscriptionStore): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/webhooks/subscribe",
+    createWebhooksSubscribeRouter({
+      store,
+      now: () => new Date("2026-06-01T18:00:00.000Z"),
+      nextId: () => "sub_1",
+      nextSecret: () => "generated-secret-value",
+    }),
+  );
+  return app;
+}
+
+describe("POST /webhooks/subscribe", () => {
+  it("registers a webhook URL for a watched Stellar account", async () => {
+    const store = createInMemoryWebhookSubscriptionStore();
+    const app = buildApp(store);
+
+    const res = await request(app).post("/webhooks/subscribe").send({
+      accountId,
+      url: "https://downstream.example/stellar",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      ok: true,
+      subscription: {
+        id: "sub_1",
+        accountId,
+        url: "https://downstream.example/stellar",
+        createdAt: "2026-06-01T18:00:00.000Z",
+      },
+      secret: "generated-secret-value",
+    });
+
+    const stored = await store.listByAccount(accountId);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      id: "sub_1",
+      accountId,
+      url: "https://downstream.example/stellar",
+      secret: "generated-secret-value",
+    });
+  });
+
+  it("accepts caller-provided secrets without echoing them", async () => {
+    const store = createInMemoryWebhookSubscriptionStore();
+    const app = buildApp(store);
+
+    const res = await request(app).post("/webhooks/subscribe").send({
+      accountId,
+      url: "https://downstream.example/stellar",
+      secret: "caller-provided-secret",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.secret).toBeUndefined();
+
+    const stored = await store.listByAccount(accountId);
+    expect(stored[0]!.secret).toBe("caller-provided-secret");
+  });
+
+  it("rejects malformed Stellar account IDs", async () => {
+    const app = buildApp(createInMemoryWebhookSubscriptionStore());
+
+    const res = await request(app).post("/webhooks/subscribe").send({
+      accountId: "not-an-account",
+      url: "https://downstream.example/stellar",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/accountId/);
+  });
+
+  it("rejects non-HTTPS callback URLs", async () => {
+    const app = buildApp(createInMemoryWebhookSubscriptionStore());
+
+    const res = await request(app).post("/webhooks/subscribe").send({
+      accountId,
+      url: "http://downstream.example/stellar",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/HTTPS URL/);
+  });
+});


### PR DESCRIPTION
Closes #278 

# PR Description

Fixes #278 by adding a production-ready outbound webhook dispatcher for confirmed Stellar transactions in `routes-d`. Downstream services can now subscribe a callback URL for a watched Stellar account, and the dispatcher can deliver a `stellar.transaction.confirmed` event when a successful transaction is confirmed for that account.

The new flow registers webhook subscriptions through the `webhooks.subscribe` route, stores the watched account, callback URL, and signing secret, then uses the dispatcher to fan out confirmed transaction payloads to every subscriber watching the matching account. Each delivery includes HMAC-SHA256 signing over the timestamped raw JSON body so receivers can verify payload integrity and reject tampered requests.

The dispatcher uses bounded exponential backoff with a maximum attempt count. It retries transient delivery failures, network errors, `429` rate-limit responses, and `5xx` server responses, while fast-failing permanent `4xx` responses. This matters for #278 because webhook consumers may have temporary outages, but the service should not retry indefinitely or retry invalid destinations that are unlikely to succeed.

The implementation is isolated to `routes-d/`, follows the existing TypeScript ESM style, and uses injected fetch, sleep, clock, and delivery ID dependencies so tests remain deterministic and offline.

# Changed

- Added `routes-d/lib/webhookDispatcher.ts` for Stellar transaction confirmation payloads, HMAC signing, signature verification, subscription storage, and retrying dispatch.
- Added `routes-d/routes/webhooks.subscribe.ts` to register watched-account webhook callback URLs with validation.
- Added unit tests for dispatch, signature verification, retry behavior, permanent failure handling, and account-specific fan-out.
- Added integration tests for subscription registration, generated secrets, caller-provided secrets, invalid account IDs, and non-HTTPS URL rejection.
