### PR TITLE
feat: add ErrorBoundary component to template

### DIFF
--- a/src/templates/default/src/app/layout.tsx
+++ b/src/templates/default/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { WalletProvider } from "@/contexts";
 
 const geistSans = Geist({
@@ -28,9 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/templates/default/src/components/ErrorBoundary.tsx
+++ b/src/templates/default/src/components/ErrorBoundary.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  showDetails: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  public state: ErrorBoundaryState = {
+    error: null,
+    errorInfo: null,
+    showDetails: false,
+  };
+
+  public static getDerivedStateFromError(
+    error: Error,
+  ): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught a rendering error:", {
+      error,
+      componentStack: errorInfo.componentStack,
+    });
+
+    this.setState({ errorInfo });
+  }
+
+  private reset = () => {
+    this.setState({
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+  };
+
+  private toggleDetails = () => {
+    this.setState((state) => ({ showDetails: !state.showDetails }));
+  };
+
+  public render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[var(--background)] px-6 py-12 text-[var(--foreground)]">
+        <section className="w-full max-w-2xl rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/15 dark:bg-zinc-950 sm:p-8">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-blue-600 dark:text-blue-300">
+            Render error
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold sm:text-3xl">
+            Something went wrong
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-300 sm:text-base">
+            The app hit an unexpected rendering error. Try again to re-render
+            the current page, or show the technical details for debugging.
+          </p>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={this.reset}
+              className="rounded-full bg-zinc-950 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-zinc-800 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200"
+            >
+              Try Again
+            </button>
+            <button
+              type="button"
+              onClick={this.toggleDetails}
+              className="rounded-full border border-zinc-300 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-zinc-100 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
+            >
+              {this.state.showDetails ? "Hide Details" : "Show Details"}
+            </button>
+          </div>
+
+          {this.state.showDetails ? (
+            <pre className="mt-6 max-h-80 overflow-auto rounded-xl border border-red-200 bg-red-50 p-4 text-xs leading-5 text-red-900 dark:border-red-400/25 dark:bg-red-950/35 dark:text-red-100">
+              {this.state.error.toString()}
+              {this.state.errorInfo?.componentStack
+                ? `\n\nComponent stack:${this.state.errorInfo.componentStack}`
+                : ""}
+            </pre>
+          ) : null}
+        </section>
+      </main>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/src/templates/default/src/hooks/useStellarWallet.ts
+++ b/src/templates/default/src/hooks/useStellarWallet.ts
@@ -93,12 +93,14 @@ export function useStellarWallet(
    */
   const connect = useCallback(async () => {
     try {
-      await kit.openModal({
+      const walletKit = kit();
+
+      await walletKit.openModal({
         modalTitle: "Connect to your favorite wallet",
         onWalletSelected: async (option: ISupportedWallet) => {
-          kit.setWallet(option.id);
+          walletKit.setWallet(option.id);
 
-          const { address } = await kit.getAddress();
+          const { address } = await walletKit.getAddress();
           const { name } = option;
 
           setPublicKey(address);
@@ -136,7 +138,7 @@ export function useStellarWallet(
    */
   const disconnect = useCallback(async () => {
     try {
-      await kit.disconnect();
+      await kit().disconnect();
       setConnected(false);
       setPublicKey(undefined);
       setWalletName(undefined);
@@ -221,7 +223,7 @@ export function useStellarWallet(
       const transaction = txBuilder.build();
 
       // Sign transaction using stellar-wallets-kit
-      const { signedTxXdr } = await kit.signTransaction(transaction.toXDR(), {
+      const { signedTxXdr } = await kit().signTransaction(transaction.toXDR(), {
         address: publicKey,
         networkPassphrase: network,
       });
@@ -248,8 +250,10 @@ export function useStellarWallet(
       
       if (wasConnected === 'true' && savedWalletId && savedAddress) {
         try {
-          kit.setWallet(savedWalletId);
-          const { address } = await kit.getAddress();
+          const walletKit = kit();
+
+          walletKit.setWallet(savedWalletId);
+          const { address } = await walletKit.getAddress();
           
           if (address === savedAddress) {
             setPublicKey(address);


### PR DESCRIPTION
Closes #101

## Summary
- add a client-side `ErrorBoundary` class component to the default TypeScript template
- wrap the default template root content so wallet/API render failures show a graceful fallback instead of a blank page
- include a Try Again reset action, Show Details toggle, console error logging, and light/dark-compatible fallback styling
- fix the default template wallet hook to call the lazy `kit()` accessor before using wallet-kit instance methods, allowing the template build to type-check

## Validation
- `npm install --package-lock=false --omit=optional --ignore-scripts --prefer-offline --no-audit --no-fund`
- `npm install lightningcss-win32-x64-msvc --package-lock=false --ignore-scripts --prefer-offline --no-audit --no-fund`
- `npm run build` passed in `src/templates/default`

Note: the build emits a Next.js workspace-root warning because this source checkout contains both the repository lockfile and the template lockfile; the production build itself completes successfully.
## Screenshots

Light mode fallback with details expanded:

![Light mode ErrorBoundary fallback](https://raw.githubusercontent.com/Errordog2/nextellar/codex/nextellar-error-boundary-screenshots/docs/qa/nextellar-error-boundary-light.png)

Dark mode fallback with details expanded:

![Dark mode ErrorBoundary fallback](https://raw.githubusercontent.com/Errordog2/nextellar/codex/nextellar-error-boundary-screenshots/docs/qa/nextellar-error-boundary-dark.png)
## Rendered QA
- Production preview: `next build` then `next start --hostname 127.0.0.1 --port 3158`
- Playwright opened `/error-boundary-preview`, verified the `Something went wrong` heading, `Try Again` button, and `Show Details` interaction in both light and dark color schemes.
- Console errors in the screenshot run are the intentionally thrown preview render error plus the ErrorBoundary catch log.