### PR TITLE
feat: add account profile, operations-by-tx, strict-send, and offers list routes

### DIFF
--- a/routes-d/routes/account.me.get.ts
+++ b/routes-d/routes/account.me.get.ts
@@ -1,0 +1,67 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type UserProfile = {
+  id: string;
+  email: string;
+  displayName?: string;
+  avatarUrl?: string;
+  createdAt: string;
+};
+
+// In-memory user store (mock database)
+const users = new Map<string, UserProfile>();
+
+/**
+ * GET /account/me
+ * Return the authenticated user's profile.
+ */
+router.get(
+  "/account/me",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId =
+        req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "Authentication required", 401);
+        return;
+      }
+
+      const user = users.get(userId);
+
+      if (!user) {
+        sendError(res, "USER_NOT_FOUND", "Authenticated user profile not found", 404);
+        return;
+      }
+
+      const safeProfile: Record<string, unknown> = {
+        id: user.id,
+        email: user.email,
+        createdAt: user.createdAt,
+      };
+      if (user.displayName) safeProfile.displayName = user.displayName;
+      if (user.avatarUrl) safeProfile.avatarUrl = user.avatarUrl;
+
+      return res.status(200).json({ success: true, data: safeProfile });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __getUsers(): Map<string, UserProfile> {
+  return users;
+}
+
+export function __resetUsers(): void {
+  users.clear();
+}
+
+export function __seedUser(user: UserProfile): void {
+  users.set(user.id, user);
+}
+
+export default router;

--- a/routes-d/routes/stellar.offers.list.ts
+++ b/routes-d/routes/stellar.offers.list.ts
@@ -1,0 +1,117 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type AssetDescriptor = {
+  code: string;
+  issuer?: string;
+};
+
+type Offer = {
+  id: string;
+  account: string;
+  selling: AssetDescriptor;
+  buying: AssetDescriptor;
+  amount: string;
+  price: string;
+  createdAt: string;
+};
+
+type OffersPage = {
+  offers: Offer[];
+  cursor: string | null;
+  hasMore: boolean;
+};
+
+// In-memory storage keyed by account id
+const offersByAccount = new Map<string, Offer[]>();
+
+const STELLAR_ACCOUNT_REGEX = /^G[A-Z2-7]{55}$/;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+function assetMatches(offer: AssetDescriptor, filter: string): boolean {
+  return offer.code === filter;
+}
+
+/**
+ * GET /stellar/offers/:account
+ * List open DEX offers for a Stellar account.
+ */
+router.get(
+  "/stellar/offers/:account",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { account } = req.params;
+
+      if (!account || !STELLAR_ACCOUNT_REGEX.test(account)) {
+        sendError(
+          res,
+          "INVALID_ACCOUNT",
+          "A valid Stellar account ID (G…) is required",
+          400,
+        );
+        return;
+      }
+
+      const allOffers = offersByAccount.get(account) ?? [];
+
+      // Optional asset filters
+      const sellingFilter = typeof req.query.selling === "string" ? req.query.selling : null;
+      const buyingFilter = typeof req.query.buying === "string" ? req.query.buying : null;
+
+      let filtered = allOffers;
+      if (sellingFilter) {
+        filtered = filtered.filter((o) => assetMatches(o.selling, sellingFilter));
+      }
+      if (buyingFilter) {
+        filtered = filtered.filter((o) => assetMatches(o.buying, buyingFilter));
+      }
+
+      // Pagination
+      const cursor = typeof req.query.cursor === "string" ? req.query.cursor : null;
+      const limitParam = typeof req.query.limit === "string" ? parseInt(req.query.limit, 10) : DEFAULT_LIMIT;
+      const limit = Number.isFinite(limitParam) && limitParam > 0
+        ? Math.min(limitParam, MAX_LIMIT)
+        : DEFAULT_LIMIT;
+
+      let startIndex = 0;
+      if (cursor) {
+        const cursorIndex = filtered.findIndex((o) => o.id === cursor);
+        if (cursorIndex === -1) {
+          sendError(res, "INVALID_CURSOR", "Cursor does not match any offer", 400);
+          return;
+        }
+        startIndex = cursorIndex + 1;
+      }
+
+      const page = filtered.slice(startIndex, startIndex + limit);
+      const hasMore = startIndex + limit < filtered.length;
+
+      const result: OffersPage = {
+        offers: page,
+        cursor: hasMore ? page[page.length - 1].id : null,
+        hasMore,
+      };
+
+      return res.status(200).json({ success: true, data: result });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __getOffersByAccount(): Map<string, Offer[]> {
+  return offersByAccount;
+}
+
+export function __resetOffers(): void {
+  offersByAccount.clear();
+}
+
+export function __seedOffers(account: string, offers: Offer[]): void {
+  offersByAccount.set(account, offers);
+}
+
+export default router;

--- a/routes-d/routes/stellar.operations.get.ts
+++ b/routes-d/routes/stellar.operations.get.ts
@@ -1,0 +1,98 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Operation = {
+  id: string;
+  type: string;
+  sourceAccount: string;
+  transactionHash: string;
+  createdAt: string;
+  details: Record<string, unknown>;
+};
+
+type OperationsPage = {
+  operations: Operation[];
+  cursor: string | null;
+  hasMore: boolean;
+};
+
+// In-memory storage for operations keyed by transaction hash
+const operationsByTx = new Map<string, Operation[]>();
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+/**
+ * GET /stellar/operations/:txHash
+ * List operations belonging to a Stellar transaction.
+ */
+router.get(
+  "/stellar/operations/:txHash",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { txHash } = req.params;
+
+      if (!txHash || typeof txHash !== "string") {
+        sendError(res, "INVALID_TX_HASH", "Transaction hash is required", 400);
+        return;
+      }
+
+      const ops = operationsByTx.get(txHash);
+
+      if (!ops) {
+        sendError(
+          res,
+          "TRANSACTION_NOT_FOUND",
+          "No transaction found for the given hash",
+          404,
+        );
+        return;
+      }
+
+      const cursor = typeof req.query.cursor === "string" ? req.query.cursor : null;
+      const limitParam = typeof req.query.limit === "string" ? parseInt(req.query.limit, 10) : DEFAULT_LIMIT;
+      const limit = Number.isFinite(limitParam) && limitParam > 0
+        ? Math.min(limitParam, MAX_LIMIT)
+        : DEFAULT_LIMIT;
+
+      let startIndex = 0;
+      if (cursor) {
+        const cursorIndex = ops.findIndex((op) => op.id === cursor);
+        if (cursorIndex === -1) {
+          sendError(res, "INVALID_CURSOR", "Cursor does not match any operation", 400);
+          return;
+        }
+        startIndex = cursorIndex + 1;
+      }
+
+      const page = ops.slice(startIndex, startIndex + limit);
+      const hasMore = startIndex + limit < ops.length;
+
+      const result: OperationsPage = {
+        operations: page,
+        cursor: hasMore ? page[page.length - 1].id : null,
+        hasMore,
+      };
+
+      return res.status(200).json({ success: true, data: result });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __getOperationsByTx(): Map<string, Operation[]> {
+  return operationsByTx;
+}
+
+export function __resetOperations(): void {
+  operationsByTx.clear();
+}
+
+export function __seedOperations(txHash: string, ops: Operation[]): void {
+  operationsByTx.set(txHash, ops);
+}
+
+export default router;

--- a/routes-d/routes/stellar.payment.strictSend.ts
+++ b/routes-d/routes/stellar.payment.strictSend.ts
@@ -1,0 +1,148 @@
+import { Router, Request, Response, NextFunction } from "express";
+import {
+  Networks,
+  TransactionBuilder,
+  Account,
+  Operation,
+  Asset,
+  Memo,
+} from "@stellar/stellar-sdk";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type AssetDescriptor = {
+  code: string;
+  issuer?: string;
+};
+
+type StrictSendBody = {
+  sourceAccount: string;
+  sendAsset: AssetDescriptor;
+  sendAmount: string;
+  destination: string;
+  destAsset: AssetDescriptor;
+  destMin: string;
+  path?: AssetDescriptor[];
+  networkPassphrase?: string;
+};
+
+function toStellarAsset(desc: AssetDescriptor): Asset {
+  if (desc.code === "XLM" && !desc.issuer) {
+    return Asset.native();
+  }
+  if (!desc.issuer) {
+    throw new Error(`Issuer is required for non-native asset ${desc.code}`);
+  }
+  return new Asset(desc.code, desc.issuer);
+}
+
+/**
+ * POST /stellar/payment/strict-send
+ * Build an unsigned strict-send path payment envelope.
+ */
+router.post(
+  "/stellar/payment/strict-send",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as StrictSendBody;
+
+      if (!body.sourceAccount || typeof body.sourceAccount !== "string") {
+        sendError(res, "INVALID_SOURCE", "sourceAccount is required", 400);
+        return;
+      }
+
+      if (!body.sendAsset || !body.sendAsset.code) {
+        sendError(res, "INVALID_SEND_ASSET", "sendAsset with code is required", 400);
+        return;
+      }
+
+      if (
+        !body.sendAmount ||
+        typeof body.sendAmount !== "string" ||
+        isNaN(Number(body.sendAmount)) ||
+        Number(body.sendAmount) <= 0
+      ) {
+        sendError(res, "INVALID_SEND_AMOUNT", "sendAmount must be a positive numeric string", 400);
+        return;
+      }
+
+      if (!body.destination || typeof body.destination !== "string") {
+        sendError(res, "INVALID_DESTINATION", "destination is required", 400);
+        return;
+      }
+
+      if (!body.destAsset || !body.destAsset.code) {
+        sendError(res, "INVALID_DEST_ASSET", "destAsset with code is required", 400);
+        return;
+      }
+
+      if (
+        !body.destMin ||
+        typeof body.destMin !== "string" ||
+        isNaN(Number(body.destMin)) ||
+        Number(body.destMin) <= 0
+      ) {
+        sendError(res, "INVALID_DEST_MIN", "destMin must be a positive numeric string", 400);
+        return;
+      }
+
+      if (Number(body.destMin) > Number(body.sendAmount) * 1000) {
+        sendError(
+          res,
+          "SLIPPAGE_BREACH",
+          "destMin exceeds a reasonable bound relative to sendAmount",
+          400,
+        );
+        return;
+      }
+
+      let sendAsset: Asset;
+      let destAsset: Asset;
+      let pathAssets: Asset[];
+
+      try {
+        sendAsset = toStellarAsset(body.sendAsset);
+        destAsset = toStellarAsset(body.destAsset);
+        pathAssets = (body.path ?? []).map(toStellarAsset);
+      } catch {
+        sendError(res, "INVALID_ASSET", "One or more asset descriptors are invalid", 400);
+        return;
+      }
+
+      const networkPassphrase = body.networkPassphrase ?? Networks.TESTNET;
+
+      const source = new Account(body.sourceAccount, "0");
+      const builder = new TransactionBuilder(source, {
+        fee: "100",
+        networkPassphrase,
+      });
+
+      builder.addOperation(
+        Operation.pathPaymentStrictSend({
+          sendAsset,
+          sendAmount: body.sendAmount,
+          destination: body.destination,
+          destAsset,
+          destMin: body.destMin,
+          path: pathAssets,
+        }),
+      );
+
+      builder.setTimeout(300);
+      const tx = builder.build();
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          envelope: tx.toEnvelope().toXDR("base64"),
+          networkPassphrase,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/account.me.get.test.ts
+++ b/routes-d/tests/account.me.get.test.ts
@@ -1,0 +1,102 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import accountMeRouter, {
+  __resetUsers,
+  __seedUser,
+} from "../routes/account.me.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(accountMeRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /account/me", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetUsers();
+  });
+
+  it("returns the authenticated user profile", async () => {
+    __seedUser({
+      id: "user-1",
+      email: "alice@example.com",
+      displayName: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .get("/account/me")
+      .set("x-user-id", "user-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe("user-1");
+    expect(res.body.data.email).toBe("alice@example.com");
+    expect(res.body.data.displayName).toBe("Alice");
+    expect(res.body.data.avatarUrl).toBe("https://example.com/alice.png");
+    expect(res.body.data.createdAt).toBe("2024-01-01T00:00:00Z");
+  });
+
+  it("returns 401 when no authentication header is provided", async () => {
+    const res = await request(app).get("/account/me");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when user profile does not exist", async () => {
+    const res = await request(app)
+      .get("/account/me")
+      .set("x-user-id", "nonexistent");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("USER_NOT_FOUND");
+  });
+
+  it("omits optional fields when they are not set (partial profile)", async () => {
+    __seedUser({
+      id: "user-2",
+      email: "bob@example.com",
+      createdAt: "2024-06-01T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .get("/account/me")
+      .set("x-user-id", "user-2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe("user-2");
+    expect(res.body.data.email).toBe("bob@example.com");
+    expect(res.body.data).not.toHaveProperty("displayName");
+    expect(res.body.data).not.toHaveProperty("avatarUrl");
+  });
+
+  it("does not expose internal fields beyond the safe set", async () => {
+    __seedUser({
+      id: "user-3",
+      email: "charlie@example.com",
+      displayName: "Charlie",
+      createdAt: "2024-03-15T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .get("/account/me")
+      .set("x-user-id", "user-3");
+
+    expect(res.status).toBe(200);
+    const keys = Object.keys(res.body.data);
+    expect(keys).toEqual(
+      expect.arrayContaining(["id", "email", "createdAt"]),
+    );
+    expect(keys.every((k) =>
+      ["id", "email", "displayName", "avatarUrl", "createdAt"].includes(k),
+    )).toBe(true);
+  });
+});

--- a/routes-d/tests/stellar.offers.list.test.ts
+++ b/routes-d/tests/stellar.offers.list.test.ts
@@ -1,0 +1,140 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import stellarOffersRouter, {
+  __resetOffers,
+  __seedOffers,
+} from "../routes/stellar.offers.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(stellarOffersRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+
+function makeOffer(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    account: VALID_ACCOUNT,
+    selling: { code: "XLM" },
+    buying: { code: "USDC", issuer: VALID_ACCOUNT },
+    amount: "500",
+    price: "0.10",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("GET /stellar/offers/:account", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetOffers();
+  });
+
+  it("returns an empty list for an account with no offers", async () => {
+    const res = await request(app).get(`/stellar/offers/${VALID_ACCOUNT}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.offers).toHaveLength(0);
+    expect(res.body.data.hasMore).toBe(false);
+    expect(res.body.data.cursor).toBeNull();
+  });
+
+  it("returns offers for a known account", async () => {
+    __seedOffers(VALID_ACCOUNT, [makeOffer("offer-1"), makeOffer("offer-2")]);
+
+    const res = await request(app).get(`/stellar/offers/${VALID_ACCOUNT}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.offers).toHaveLength(2);
+  });
+
+  it("filters by selling asset", async () => {
+    __seedOffers(VALID_ACCOUNT, [
+      makeOffer("offer-1", { selling: { code: "XLM" } }),
+      makeOffer("offer-2", { selling: { code: "EUR", issuer: VALID_ACCOUNT } }),
+    ]);
+
+    const res = await request(app)
+      .get(`/stellar/offers/${VALID_ACCOUNT}`)
+      .query({ selling: "EUR" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.offers).toHaveLength(1);
+    expect(res.body.data.offers[0].id).toBe("offer-2");
+  });
+
+  it("filters by buying asset", async () => {
+    __seedOffers(VALID_ACCOUNT, [
+      makeOffer("offer-1", { buying: { code: "USDC", issuer: VALID_ACCOUNT } }),
+      makeOffer("offer-2", { buying: { code: "BTC", issuer: VALID_ACCOUNT } }),
+    ]);
+
+    const res = await request(app)
+      .get(`/stellar/offers/${VALID_ACCOUNT}`)
+      .query({ buying: "BTC" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.offers).toHaveLength(1);
+    expect(res.body.data.offers[0].id).toBe("offer-2");
+  });
+
+  it("paginates when there are many offers", async () => {
+    const offers = Array.from({ length: 15 }, (_, i) =>
+      makeOffer(`offer-${i}`),
+    );
+    __seedOffers(VALID_ACCOUNT, offers);
+
+    const first = await request(app)
+      .get(`/stellar/offers/${VALID_ACCOUNT}`)
+      .query({ limit: "5" });
+
+    expect(first.status).toBe(200);
+    expect(first.body.data.offers).toHaveLength(5);
+    expect(first.body.data.hasMore).toBe(true);
+    expect(first.body.data.cursor).toBe("offer-4");
+
+    const second = await request(app)
+      .get(`/stellar/offers/${VALID_ACCOUNT}`)
+      .query({ limit: "5", cursor: "offer-4" });
+
+    expect(second.status).toBe(200);
+    expect(second.body.data.offers).toHaveLength(5);
+    expect(second.body.data.offers[0].id).toBe("offer-5");
+    expect(second.body.data.hasMore).toBe(true);
+
+    const third = await request(app)
+      .get(`/stellar/offers/${VALID_ACCOUNT}`)
+      .query({ limit: "5", cursor: "offer-9" });
+
+    expect(third.status).toBe(200);
+    expect(third.body.data.offers).toHaveLength(5);
+    expect(third.body.data.hasMore).toBe(false);
+    expect(third.body.data.cursor).toBeNull();
+  });
+
+  it("returns 400 for an invalid account ID", async () => {
+    const res = await request(app).get("/stellar/offers/not-a-valid-account");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_ACCOUNT");
+  });
+
+  it("returns 400 for an invalid cursor", async () => {
+    __seedOffers(VALID_ACCOUNT, [makeOffer("offer-1")]);
+
+    const res = await request(app)
+      .get(`/stellar/offers/${VALID_ACCOUNT}`)
+      .query({ cursor: "nonexistent" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CURSOR");
+  });
+});

--- a/routes-d/tests/stellar.operations.get.test.ts
+++ b/routes-d/tests/stellar.operations.get.test.ts
@@ -1,0 +1,114 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import stellarOperationsRouter, {
+  __resetOperations,
+  __seedOperations,
+} from "../routes/stellar.operations.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(stellarOperationsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+function makeOp(id: string, txHash: string) {
+  return {
+    id,
+    type: "payment",
+    sourceAccount: "GABCDEF",
+    transactionHash: txHash,
+    createdAt: "2024-01-01T00:00:00Z",
+    details: { amount: "100" },
+  };
+}
+
+describe("GET /stellar/operations/:txHash", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetOperations();
+  });
+
+  it("returns a single operation for a known transaction", async () => {
+    const op = makeOp("op-1", "txhash-abc");
+    __seedOperations("txhash-abc", [op]);
+
+    const res = await request(app).get("/stellar/operations/txhash-abc");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.operations).toHaveLength(1);
+    expect(res.body.data.operations[0].id).toBe("op-1");
+    expect(res.body.data.hasMore).toBe(false);
+    expect(res.body.data.cursor).toBeNull();
+  });
+
+  it("paginates when there are many operations", async () => {
+    const ops = Array.from({ length: 15 }, (_, i) =>
+      makeOp(`op-${i}`, "txhash-many"),
+    );
+    __seedOperations("txhash-many", ops);
+
+    const first = await request(app)
+      .get("/stellar/operations/txhash-many")
+      .query({ limit: "5" });
+
+    expect(first.status).toBe(200);
+    expect(first.body.data.operations).toHaveLength(5);
+    expect(first.body.data.hasMore).toBe(true);
+    expect(first.body.data.cursor).toBe("op-4");
+
+    const second = await request(app)
+      .get("/stellar/operations/txhash-many")
+      .query({ limit: "5", cursor: "op-4" });
+
+    expect(second.status).toBe(200);
+    expect(second.body.data.operations).toHaveLength(5);
+    expect(second.body.data.operations[0].id).toBe("op-5");
+    expect(second.body.data.hasMore).toBe(true);
+
+    const third = await request(app)
+      .get("/stellar/operations/txhash-many")
+      .query({ limit: "5", cursor: "op-9" });
+
+    expect(third.status).toBe(200);
+    expect(third.body.data.operations).toHaveLength(5);
+    expect(third.body.data.hasMore).toBe(false);
+    expect(third.body.data.cursor).toBeNull();
+  });
+
+  it("returns 404 for an unknown transaction hash", async () => {
+    const res = await request(app).get("/stellar/operations/unknown-hash");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("TRANSACTION_NOT_FOUND");
+  });
+
+  it("returns 400 for an invalid cursor", async () => {
+    __seedOperations("txhash-abc", [makeOp("op-1", "txhash-abc")]);
+
+    const res = await request(app)
+      .get("/stellar/operations/txhash-abc")
+      .query({ cursor: "nonexistent" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CURSOR");
+  });
+
+  it("uses default limit when none is provided", async () => {
+    const ops = Array.from({ length: 12 }, (_, i) =>
+      makeOp(`op-${i}`, "txhash-default"),
+    );
+    __seedOperations("txhash-default", ops);
+
+    const res = await request(app).get("/stellar/operations/txhash-default");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.operations).toHaveLength(10);
+    expect(res.body.data.hasMore).toBe(true);
+  });
+});

--- a/routes-d/tests/stellar.payment.strictSend.test.ts
+++ b/routes-d/tests/stellar.payment.strictSend.test.ts
@@ -1,0 +1,121 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import strictSendRouter from "../routes/stellar.payment.strictSend.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(strictSendRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+
+const validPayload = {
+  sourceAccount: VALID_ACCOUNT,
+  sendAsset: { code: "XLM" },
+  sendAmount: "100",
+  destination: VALID_ACCOUNT,
+  destAsset: { code: "USDC", issuer: VALID_ACCOUNT },
+  destMin: "10",
+  path: [],
+};
+
+describe("POST /stellar/payment/strict-send", () => {
+  const app = buildApp();
+
+  it("builds an unsigned envelope for a valid strict-send request", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send(validPayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.envelope).toBeDefined();
+    expect(typeof res.body.data.envelope).toBe("string");
+    expect(res.body.data.networkPassphrase).toBeDefined();
+  });
+
+  it("returns 400 when sourceAccount is missing", async () => {
+    const { sourceAccount, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SOURCE");
+  });
+
+  it("returns 400 when sendAmount is not a positive number", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send({ ...validPayload, sendAmount: "-5" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SEND_AMOUNT");
+  });
+
+  it("returns 400 when sendAmount is not numeric", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send({ ...validPayload, sendAmount: "abc" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SEND_AMOUNT");
+  });
+
+  it("returns 400 when destMin is missing", async () => {
+    const { destMin, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DEST_MIN");
+  });
+
+  it("returns 400 on slippage breach", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send({ ...validPayload, sendAmount: "1", destMin: "100000" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("SLIPPAGE_BREACH");
+  });
+
+  it("returns 400 when sendAsset is missing", async () => {
+    const { sendAsset, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SEND_ASSET");
+  });
+
+  it("returns 400 when destination is missing", async () => {
+    const { destination, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DESTINATION");
+  });
+
+  it("accepts a path with intermediate assets", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-send")
+      .send({
+        ...validPayload,
+        path: [{ code: "EUR", issuer: VALID_ACCOUNT }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.envelope).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- **#456** — Add `GET /stellar/operations/:txHash` route with cursor-based pagination, stable operation shape mapping, and tests for one-op, many-op, and unknown-tx cases
- **#464** — Add `GET /stellar/offers/:account` route listing open DEX offers with selling/buying asset filters, account ID validation, and cursor-based pagination. Tests cover empty, filtered, paginated, and invalid-account cases
- **#467** — Add `POST /stellar/payment/strict-send` route that validates source amount, destination min, and path, then returns an unsigned Stellar envelope for client signing. Tests cover happy path, slippage breach, and missing fields
- **#479** — Add `GET /account/me` route that returns the authenticated user profile (safe fields only), rejects unauthenticated callers with 401. Tests cover authed, unauthed, and partial-profile cases

All routes live under `routes-d/routes/`, tests under `routes-d/tests/`. No changes outside `routes-d/`.

Closes #456
Closes #464
Closes #467
Closes #479

## Test plan
- [x] 26 new tests across 4 test suites — all passing
- [x] No regressions in existing routes-d tests
- [x] Files compile under the project's strict TypeScript config