### PR TITLE
feat(routes-d): add LancePay contractor invite, onboarding, freeze, and batch payout routes

### DIFF
--- a/routes-d/routes/lancepay.contractors.freeze.ts
+++ b/routes-d/routes/lancepay.contractors.freeze.ts
@@ -1,0 +1,135 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type FreezeStatus = "frozen" | "active";
+
+type ContractorRecord = {
+  id: string;
+  workspaceId: string;
+  status: FreezeStatus;
+  frozenAt?: string;
+  frozenBy?: string;
+  freezeReason?: string;
+  updatedAt: string;
+};
+
+type AuditEvent = {
+  contractorId: string;
+  action: "freeze";
+  performedBy: string;
+  reason?: string;
+  timestamp: string;
+};
+
+type FreezeBody = {
+  adminId: string;      // workspace admin performing the freeze
+  reason?: string;
+};
+
+// In-memory store
+const contractors = new Map<string, ContractorRecord>();
+const auditLog: AuditEvent[] = [];
+
+/**
+ * POST /lancepay/contractors/:id/freeze
+ * Block payouts to a contractor pending review.
+ * Requires workspace-admin role (adminId header or body).
+ * Emits an audit event on success.
+ */
+router.post(
+  "/lancepay/contractors/:id/freeze",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const contractorId = req.params.id?.trim();
+      if (!contractorId) {
+        sendError(res, "INVALID_CONTRACTOR_ID", "contractorId is required", 400);
+        return;
+      }
+
+      const body = req.body as FreezeBody;
+
+      // Require admin identity — accept from body or x-admin-id header
+      const adminId =
+        body.adminId ||
+        (req.headers["x-admin-id"] as string | undefined);
+
+      if (!adminId || typeof adminId !== "string" || !adminId.trim()) {
+        sendError(
+          res,
+          "UNAUTHORIZED",
+          "workspace-admin identity required (adminId in body or x-admin-id header)",
+          403,
+        );
+        return;
+      }
+
+      const contractor = contractors.get(contractorId);
+
+      if (!contractor) {
+        sendError(res, "NOT_FOUND", "Contractor not found", 404);
+        return;
+      }
+
+      if (contractor.status === "frozen") {
+        sendError(
+          res,
+          "ALREADY_FROZEN",
+          "Contractor is already frozen. No action taken.",
+          409,
+        );
+        return;
+      }
+
+      const now = new Date().toISOString();
+
+      contractor.status      = "frozen";
+      contractor.frozenAt    = now;
+      contractor.frozenBy    = adminId.trim();
+      contractor.freezeReason = body.reason?.trim();
+      contractor.updatedAt   = now;
+
+      // Emit audit event
+      auditLog.push({
+        contractorId,
+        action: "freeze",
+        performedBy: adminId.trim(),
+        reason: body.reason?.trim(),
+        timestamp: now,
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          contractorId,
+          status: contractor.status,
+          frozenAt: contractor.frozenAt,
+          frozenBy: contractor.frozenBy,
+          freezeReason: contractor.freezeReason,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedContractor(c: ContractorRecord): void {
+  contractors.set(c.id, { ...c });
+}
+
+export function __getContractor(id: string): ContractorRecord | undefined {
+  return contractors.get(id);
+}
+
+export function __getAuditLog(): AuditEvent[] {
+  return auditLog;
+}
+
+export function __resetContractors(): void {
+  contractors.clear();
+  auditLog.length = 0;
+}
+
+export default router;

--- a/routes-d/routes/lancepay.contractors.invite.ts
+++ b/routes-d/routes/lancepay.contractors.invite.ts
@@ -1,0 +1,144 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import crypto from "crypto";
+
+const router = Router();
+
+const INVITE_TTL_MS  = 72 * 60 * 60 * 1000; // 72 hours
+const RESEND_COOLDOWN_MS = 60 * 60 * 1000;   // 1 hour between resends
+
+type InviteStatus = "pending" | "accepted" | "expired";
+
+type ContractorInvite = {
+  id: string;
+  contractorId: string;
+  workspaceId: string;
+  token: string;
+  link: string;
+  email?: string;
+  phone?: string;
+  status: InviteStatus;
+  expiresAt: string;
+  lastSentAt: string;
+  createdAt: string;
+};
+
+const invites = new Map<string, ContractorInvite>();    // inviteId -> invite
+const contractorLatestInvite = new Map<string, string>(); // contractorId -> inviteId
+
+type InviteBody = {
+  workspaceId: string;
+  email?: string;
+  phone?: string;
+};
+
+function generateSignedLink(token: string): string {
+  const sig = crypto.createHmac("sha256", "SECRET").update(token).digest("hex").slice(0, 16);
+  return `https://app.nextellar.com/invite/${token}?sig=${sig}`;
+}
+
+/**
+ * POST /lancepay/contractors/:id/invite
+ * Issue or resend a single-use signed invite link to a contractor.
+ */
+router.post(
+  "/lancepay/contractors/:id/invite",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const contractorId = req.params.id?.trim();
+      if (!contractorId) {
+        sendError(res, "INVALID_CONTRACTOR_ID", "contractorId is required", 400);
+        return;
+      }
+
+      const body = req.body as InviteBody;
+
+      if (!body.workspaceId || typeof body.workspaceId !== "string") {
+        sendError(res, "INVALID_WORKSPACE_ID", "workspaceId is required", 400);
+        return;
+      }
+
+      if (!body.email && !body.phone) {
+        sendError(res, "MISSING_CONTACT", "At least one of email or phone is required", 400);
+        return;
+      }
+
+      if (body.email && typeof body.email !== "string") {
+        sendError(res, "INVALID_EMAIL", "email must be a string", 400);
+        return;
+      }
+
+      if (body.phone && typeof body.phone !== "string") {
+        sendError(res, "INVALID_PHONE", "phone must be a string", 400);
+        return;
+      }
+
+      const now = Date.now();
+
+      // Resend throttling — check if an active invite was sent recently
+      const existingId = contractorLatestInvite.get(contractorId);
+      if (existingId) {
+        const existing = invites.get(existingId);
+        if (existing && existing.status === "pending") {
+          const msSinceLastSend = now - new Date(existing.lastSentAt).getTime();
+          if (msSinceLastSend < RESEND_COOLDOWN_MS) {
+            const waitMin = Math.ceil((RESEND_COOLDOWN_MS - msSinceLastSend) / 60_000);
+            sendError(
+              res,
+              "RESEND_TOO_SOON",
+              `Invite was sent recently. Please wait ${waitMin}m before resending.`,
+              429,
+            );
+            return;
+          }
+          // Resend: update lastSentAt and return existing invite
+          existing.lastSentAt = new Date(now).toISOString();
+          return res.status(200).json({ success: true, data: existing, resent: true });
+        }
+      }
+
+      // Create new single-use token
+      const token   = crypto.randomBytes(32).toString("hex");
+      const inviteId = `inv-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+      const invite: ContractorInvite = {
+        id: inviteId,
+        contractorId,
+        workspaceId: body.workspaceId,
+        token,
+        link: generateSignedLink(token),
+        email: body.email,
+        phone: body.phone,
+        status: "pending",
+        expiresAt: new Date(now + INVITE_TTL_MS).toISOString(),
+        lastSentAt: new Date(now).toISOString(),
+        createdAt: new Date(now).toISOString(),
+      };
+
+      invites.set(inviteId, invite);
+      contractorLatestInvite.set(contractorId, inviteId);
+
+      // In production: dispatch via email/SMS notification helpers here
+
+      return res.status(201).json({ success: true, data: invite });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __getInvites(): Map<string, ContractorInvite> {
+  return invites;
+}
+
+export function __resetInvites(): void {
+  invites.clear();
+  contractorLatestInvite.clear();
+}
+
+export function __seedInvite(invite: ContractorInvite): void {
+  invites.set(invite.id, invite);
+  contractorLatestInvite.set(invite.contractorId, invite.id);
+}
+
+export default router;

--- a/routes-d/routes/lancepay.contractors.onboarding.ts
+++ b/routes-d/routes/lancepay.contractors.onboarding.ts
@@ -1,0 +1,153 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import crypto from "crypto";
+
+const router = Router();
+
+const ONBOARDING_STEPS = ["personal_info", "kyc", "wallet_link", "tax_form"] as const;
+type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+
+type StepStatus = "pending" | "completed" | "skipped";
+
+type SessionStep = {
+  step: OnboardingStep;
+  status: StepStatus;
+  completedAt?: string;
+};
+
+type OnboardingSession = {
+  id: string;
+  contractorId: string;
+  sessionToken: string;
+  steps: SessionStep[];
+  currentStep: OnboardingStep | "complete";
+  isComplete: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type StartBody  = { contractorId: string };
+type ResumeBody = { sessionToken: string; completeStep?: OnboardingStep };
+
+// In-memory store
+const sessions = new Map<string, OnboardingSession>();              // sessionId -> session
+const contractorSession = new Map<string, string>();               // contractorId -> sessionId
+const tokenIndex = new Map<string, string>();                      // sessionToken -> sessionId
+
+function nextPendingStep(steps: SessionStep[]): OnboardingStep | "complete" {
+  const next = steps.find((s) => s.status === "pending");
+  return next ? next.step : "complete";
+}
+
+/**
+ * POST /lancepay/contractors/:id/onboarding
+ * Start a new onboarding session or resume an existing one.
+ * Body: { contractorId } to start; { sessionToken, completeStep? } to resume.
+ */
+router.post(
+  "/lancepay/contractors/:id/onboarding",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const contractorId = req.params.id?.trim();
+      if (!contractorId) {
+        sendError(res, "INVALID_CONTRACTOR_ID", "contractorId is required", 400);
+        return;
+      }
+
+      const body = req.body as StartBody & ResumeBody;
+      const now = new Date().toISOString();
+
+      // Resume flow — sessionToken provided
+      if (body.sessionToken) {
+        const sessionId = tokenIndex.get(body.sessionToken);
+        if (!sessionId) {
+          sendError(res, "INVALID_SESSION_TOKEN", "Session token not found or expired", 404);
+          return;
+        }
+
+        const session = sessions.get(sessionId)!;
+
+        if (session.contractorId !== contractorId) {
+          sendError(res, "SESSION_MISMATCH", "Session does not belong to this contractor", 403);
+          return;
+        }
+
+        if (session.isComplete) {
+          return res.status(200).json({ success: true, data: session, resumed: true });
+        }
+
+        // Optionally mark a step complete
+        if (body.completeStep) {
+          const step = session.steps.find((s) => s.step === body.completeStep);
+          if (!step) {
+            sendError(res, "INVALID_STEP", `Unknown step: ${body.completeStep}`, 400);
+            return;
+          }
+          step.status = "completed";
+          step.completedAt = now;
+        }
+
+        session.currentStep = nextPendingStep(session.steps);
+        session.isComplete  = session.currentStep === "complete";
+        session.updatedAt   = now;
+
+        return res.status(200).json({ success: true, data: session, resumed: true });
+      }
+
+      // Start flow — new or existing session
+      const existingId = contractorSession.get(contractorId);
+      if (existingId) {
+        const existing = sessions.get(existingId)!;
+        if (!existing.isComplete) {
+          return res.status(200).json({ success: true, data: existing, resumed: true });
+        }
+        // Completed session exists — start fresh
+      }
+
+      const sessionToken = crypto.randomBytes(32).toString("hex");
+      const sessionId    = `os-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+      const steps: SessionStep[] = ONBOARDING_STEPS.map((s) => ({
+        step: s,
+        status: "pending",
+      }));
+
+      const session: OnboardingSession = {
+        id: sessionId,
+        contractorId,
+        sessionToken,
+        steps,
+        currentStep: ONBOARDING_STEPS[0],
+        isComplete: false,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      sessions.set(sessionId, session);
+      contractorSession.set(contractorId, sessionId);
+      tokenIndex.set(sessionToken, sessionId);
+
+      return res.status(201).json({ success: true, data: session });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __getSessions(): Map<string, OnboardingSession> {
+  return sessions;
+}
+
+export function __resetSessions(): void {
+  sessions.clear();
+  contractorSession.clear();
+  tokenIndex.clear();
+}
+
+export function __seedSession(session: OnboardingSession): void {
+  sessions.set(session.id, session);
+  contractorSession.set(session.contractorId, session.id);
+  tokenIndex.set(session.sessionToken, session.id);
+}
+
+export default router;

--- a/routes-d/routes/lancepay.payouts.batch.ts
+++ b/routes-d/routes/lancepay.payouts.batch.ts
@@ -1,0 +1,175 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import crypto from "crypto";
+
+const router = Router();
+
+const VALID_CURRENCIES = new Set(["USD", "EUR", "GBP", "XLM", "USDC"]);
+const MAX_BATCH_SIZE = 500;
+
+type PayoutStatus = "pending" | "failed";
+
+type PayoutItem = {
+  contractorId: string;
+  destinationWallet: string;
+  amount: number;
+  currency: string;
+};
+
+type PayoutOutcome = {
+  index: number;
+  contractorId: string;
+  status: PayoutStatus;
+  payoutId?: string;
+  error?: string;
+};
+
+type BatchResult = {
+  batchId: string;
+  contentHash: string;
+  total: number;
+  succeeded: number;
+  failed: number;
+  outcomes: PayoutOutcome[];
+  idempotent: boolean;
+};
+
+// In-memory store: contentHash -> BatchResult
+const batchResults = new Map<string, BatchResult>();
+
+function hashContent(items: PayoutItem[]): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(items))
+    .digest("hex");
+}
+
+function validateItem(item: unknown, index: number): string | null {
+  const i = item as Record<string, unknown>;
+  if (!i.contractorId || typeof i.contractorId !== "string") {
+    return `item[${index}]: contractorId is required`;
+  }
+  if (!i.destinationWallet || typeof i.destinationWallet !== "string") {
+    return `item[${index}]: destinationWallet is required`;
+  }
+  const wallet = (i.destinationWallet as string).trim();
+  if (!/^(G[A-Z2-7]{55}|0x[0-9a-fA-F]{40})$/.test(wallet)) {
+    return `item[${index}]: invalid destinationWallet format`;
+  }
+  if (typeof i.amount !== "number" || i.amount <= 0 || !isFinite(i.amount)) {
+    return `item[${index}]: amount must be a positive number`;
+  }
+  if (!i.currency || typeof i.currency !== "string") {
+    return `item[${index}]: currency is required`;
+  }
+  const currency = (i.currency as string).trim().toUpperCase();
+  if (!VALID_CURRENCIES.has(currency)) {
+    return `item[${index}]: unsupported currency ${currency}`;
+  }
+  return null;
+}
+
+/**
+ * POST /lancepay/payouts/batch
+ * Submit a batch of payouts in one request. Returns per-row outcomes.
+ * Idempotent: re-uploading the same payload (by SHA-256 content hash) returns
+ * the cached result without re-processing.
+ */
+router.post(
+  "/lancepay/payouts/batch",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as { payouts?: unknown[]; workspaceId?: string };
+
+      if (!body.workspaceId || typeof body.workspaceId !== "string") {
+        sendError(res, "INVALID_WORKSPACE_ID", "workspaceId is required", 400);
+        return;
+      }
+
+      if (!Array.isArray(body.payouts)) {
+        sendError(res, "INVALID_PAYOUTS", "payouts must be an array", 400);
+        return;
+      }
+
+      if (body.payouts.length === 0) {
+        sendError(res, "EMPTY_BATCH", "payouts array must not be empty", 400);
+        return;
+      }
+
+      if (body.payouts.length > MAX_BATCH_SIZE) {
+        sendError(
+          res,
+          "BATCH_TOO_LARGE",
+          `Batch size ${body.payouts.length} exceeds maximum of ${MAX_BATCH_SIZE}`,
+          400,
+        );
+        return;
+      }
+
+      const contentHash = hashContent(body.payouts as PayoutItem[]);
+
+      // Idempotency: same content hash → return cached result
+      const cached = batchResults.get(contentHash);
+      if (cached) {
+        return res.status(200).json({ success: true, data: { ...cached, idempotent: true } });
+      }
+
+      // Stream-process each row
+      const outcomes: PayoutOutcome[] = [];
+      let succeeded = 0;
+      let failed = 0;
+
+      for (let i = 0; i < body.payouts.length; i++) {
+        const item = body.payouts[i] as Record<string, unknown>;
+        const validationError = validateItem(item, i);
+
+        if (validationError) {
+          outcomes.push({
+            index: i,
+            contractorId: typeof item.contractorId === "string" ? item.contractorId : "",
+            status: "failed",
+            error: validationError,
+          });
+          failed++;
+          continue;
+        }
+
+        const payoutId = `pay-${Date.now()}-${i}-${Math.random().toString(36).slice(2, 7)}`;
+        outcomes.push({
+          index: i,
+          contractorId: item.contractorId as string,
+          status: "pending",
+          payoutId,
+        });
+        succeeded++;
+      }
+
+      const result: BatchResult = {
+        batchId:     `batch-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        contentHash,
+        total:       body.payouts.length,
+        succeeded,
+        failed,
+        outcomes,
+        idempotent:  false,
+      };
+
+      batchResults.set(contentHash, result);
+
+      const status = failed > 0 && succeeded === 0 ? 422 : 201;
+      return res.status(status).json({ success: true, data: result });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __getBatchResults(): Map<string, BatchResult> {
+  return batchResults;
+}
+
+export function __resetBatchResults(): void {
+  batchResults.clear();
+}
+
+export default router;

--- a/routes-d/tests/lancepay.contractors.freeze.test.ts
+++ b/routes-d/tests/lancepay.contractors.freeze.test.ts
@@ -1,0 +1,106 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedContractor,
+  __getContractor,
+  __getAuditLog,
+  __resetContractors,
+} from "../routes/lancepay.contractors.freeze.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const ACTIVE_CONTRACTOR = {
+  id: "con-1",
+  workspaceId: "ws-1",
+  status: "active" as const,
+  updatedAt: new Date().toISOString(),
+};
+
+const FROZEN_CONTRACTOR = {
+  id: "con-2",
+  workspaceId: "ws-1",
+  status: "frozen" as const,
+  frozenAt: new Date().toISOString(),
+  frozenBy: "admin-1",
+  updatedAt: new Date().toISOString(),
+};
+
+describe("POST /lancepay/contractors/:id/freeze", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetContractors();
+    __seedContractor(ACTIVE_CONTRACTOR);
+    __seedContractor(FROZEN_CONTRACTOR);
+  });
+
+  it("freezes an active contractor and returns 200", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/freeze")
+      .send({ adminId: "admin-1", reason: "Suspicious activity" });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("frozen");
+    expect(res.body.data.frozenBy).toBe("admin-1");
+  });
+
+  it("persists freeze in storage", async () => {
+    await request(app)
+      .post("/lancepay/contractors/con-1/freeze")
+      .send({ adminId: "admin-1" });
+    const stored = __getContractor("con-1")!;
+    expect(stored.status).toBe("frozen");
+    expect(stored.frozenAt).toBeDefined();
+  });
+
+  it("emits an audit event on freeze", async () => {
+    await request(app)
+      .post("/lancepay/contractors/con-1/freeze")
+      .send({ adminId: "admin-1", reason: "Review" });
+    const log = __getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].action).toBe("freeze");
+    expect(log[0].performedBy).toBe("admin-1");
+  });
+
+  it("returns 409 when contractor is already frozen", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-2/freeze")
+      .send({ adminId: "admin-1" });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_FROZEN");
+  });
+
+  it("returns 403 when adminId is missing", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/freeze")
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("accepts adminId from x-admin-id header", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/freeze")
+      .set("x-admin-id", "admin-from-header")
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.data.frozenBy).toBe("admin-from-header");
+  });
+
+  it("returns 404 for unknown contractor", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/nonexistent/freeze")
+      .send({ adminId: "admin-1" });
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/routes-d/tests/lancepay.contractors.invite.test.ts
+++ b/routes-d/tests/lancepay.contractors.invite.test.ts
@@ -1,0 +1,107 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __getInvites,
+  __resetInvites,
+  __seedInvite,
+} from "../routes/lancepay.contractors.invite.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_BODY = { workspaceId: "ws-1", email: "contractor@example.com" };
+
+describe("POST /lancepay/contractors/:id/invite", () => {
+  const app = buildApp();
+
+  beforeEach(() => __resetInvites());
+
+  it("sends a new invite and returns 201", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/invite")
+      .send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("token");
+    expect(res.body.data).toHaveProperty("link");
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 400 when workspaceId is missing", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/invite")
+      .send({ email: "x@example.com" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_WORKSPACE_ID");
+  });
+
+  it("returns 400 when neither email nor phone is provided", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/invite")
+      .send({ workspaceId: "ws-1" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_CONTACT");
+  });
+
+  it("returns 429 when resending too soon", async () => {
+    __seedInvite({
+      id: "inv-1",
+      contractorId: "con-1",
+      workspaceId: "ws-1",
+      token: "tok",
+      link: "https://example.com/invite/tok",
+      email: "x@example.com",
+      status: "pending",
+      expiresAt: new Date(Date.now() + 72 * 3600 * 1000).toISOString(),
+      lastSentAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(), // 30 min ago < 1h
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/invite")
+      .send(VALID_BODY);
+    expect(res.status).toBe(429);
+    expect(res.body.error.code).toBe("RESEND_TOO_SOON");
+  });
+
+  it("resends after cooldown and returns 200", async () => {
+    __seedInvite({
+      id: "inv-2",
+      contractorId: "con-2",
+      workspaceId: "ws-1",
+      token: "tok2",
+      link: "https://example.com/invite/tok2",
+      email: "x@example.com",
+      status: "pending",
+      expiresAt: new Date(Date.now() + 72 * 3600 * 1000).toISOString(),
+      lastSentAt: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), // 2h ago > 1h
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/contractors/con-2/invite")
+      .send({ workspaceId: "ws-1", email: "x@example.com" });
+    expect(res.status).toBe(200);
+    expect(res.body.resent).toBe(true);
+  });
+
+  it("generates a unique token per invite", async () => {
+    const r1 = await request(app).post("/lancepay/contractors/con-a/invite").send(VALID_BODY);
+    const r2 = await request(app).post("/lancepay/contractors/con-b/invite").send(VALID_BODY);
+    expect(r1.body.data.token).not.toBe(r2.body.data.token);
+  });
+
+  it("accepts phone-only contact", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-3/invite")
+      .send({ workspaceId: "ws-1", phone: "+2348012345678" });
+    expect(res.status).toBe(201);
+  });
+});

--- a/routes-d/tests/lancepay.contractors.onboarding.test.ts
+++ b/routes-d/tests/lancepay.contractors.onboarding.test.ts
@@ -1,0 +1,118 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __getSessions,
+  __resetSessions,
+  __seedSession,
+} from "../routes/lancepay.contractors.onboarding.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/contractors/:id/onboarding", () => {
+  const app = buildApp();
+
+  beforeEach(() => __resetSessions());
+
+  it("starts a new onboarding session and returns 201", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/onboarding")
+      .send({ contractorId: "con-1" });
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("sessionToken");
+    expect(res.body.data.steps).toHaveLength(4);
+    expect(res.body.data.currentStep).toBe("personal_info");
+    expect(res.body.data.isComplete).toBe(false);
+  });
+
+  it("returns existing session when contractor already started onboarding", async () => {
+    const first = await request(app)
+      .post("/lancepay/contractors/con-1/onboarding")
+      .send({ contractorId: "con-1" });
+    const sessionId = first.body.data.id;
+
+    const second = await request(app)
+      .post("/lancepay/contractors/con-1/onboarding")
+      .send({ contractorId: "con-1" });
+    expect(second.status).toBe(200);
+    expect(second.body.data.id).toBe(sessionId);
+    expect(second.body.data.resumed).toBeUndefined(); // from data, not top-level
+    expect(second.body.resumed).toBe(true);
+  });
+
+  it("resumes session with sessionToken", async () => {
+    const start = await request(app)
+      .post("/lancepay/contractors/con-2/onboarding")
+      .send({ contractorId: "con-2" });
+    const { sessionToken } = start.body.data;
+
+    const resume = await request(app)
+      .post("/lancepay/contractors/con-2/onboarding")
+      .send({ sessionToken });
+    expect(resume.status).toBe(200);
+    expect(resume.body.resumed).toBe(true);
+  });
+
+  it("marks a step complete when completeStep is provided", async () => {
+    const start = await request(app)
+      .post("/lancepay/contractors/con-3/onboarding")
+      .send({ contractorId: "con-3" });
+    const { sessionToken } = start.body.data;
+
+    const res = await request(app)
+      .post("/lancepay/contractors/con-3/onboarding")
+      .send({ sessionToken, completeStep: "personal_info" });
+    expect(res.status).toBe(200);
+    const personalInfo = res.body.data.steps.find((s: { step: string }) => s.step === "personal_info");
+    expect(personalInfo.status).toBe("completed");
+    expect(res.body.data.currentStep).toBe("kyc");
+  });
+
+  it("marks session complete when all steps are done", async () => {
+    const start = await request(app)
+      .post("/lancepay/contractors/con-4/onboarding")
+      .send({ contractorId: "con-4" });
+    let { sessionToken } = start.body.data;
+
+    for (const step of ["personal_info", "kyc", "wallet_link", "tax_form"]) {
+      const r = await request(app)
+        .post("/lancepay/contractors/con-4/onboarding")
+        .send({ sessionToken, completeStep: step });
+      expect(r.status).toBe(200);
+    }
+
+    const sessions = __getSessions();
+    const session = [...sessions.values()].find((s) => s.contractorId === "con-4")!;
+    expect(session.isComplete).toBe(true);
+    expect(session.currentStep).toBe("complete");
+  });
+
+  it("returns 404 for invalid sessionToken", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors/con-1/onboarding")
+      .send({ sessionToken: "invalid-token-xyz" });
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("INVALID_SESSION_TOKEN");
+  });
+
+  it("returns 400 for unknown completeStep", async () => {
+    const start = await request(app)
+      .post("/lancepay/contractors/con-5/onboarding")
+      .send({ contractorId: "con-5" });
+    const { sessionToken } = start.body.data;
+
+    const res = await request(app)
+      .post("/lancepay/contractors/con-5/onboarding")
+      .send({ sessionToken, completeStep: "not_a_real_step" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_STEP");
+  });
+});

--- a/routes-d/tests/lancepay.payouts.batch.test.ts
+++ b/routes-d/tests/lancepay.payouts.batch.test.ts
@@ -1,0 +1,111 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __getBatchResults,
+  __resetBatchResults,
+} from "../routes/lancepay.payouts.batch.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_PAYOUT = {
+  contractorId: "con-1",
+  destinationWallet: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  amount: 100,
+  currency: "USD",
+};
+
+const VALID_BODY = { workspaceId: "ws-1", payouts: [VALID_PAYOUT] };
+
+describe("POST /lancepay/payouts/batch", () => {
+  const app = buildApp();
+
+  beforeEach(() => __resetBatchResults());
+
+  it("processes a valid batch and returns 201", async () => {
+    const res = await request(app).post("/lancepay/payouts/batch").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.total).toBe(1);
+    expect(res.body.data.succeeded).toBe(1);
+    expect(res.body.data.failed).toBe(0);
+    expect(res.body.data.outcomes[0].status).toBe("pending");
+  });
+
+  it("returns per-row outcomes on partial failure", async () => {
+    const body = {
+      workspaceId: "ws-1",
+      payouts: [
+        VALID_PAYOUT,
+        { contractorId: "con-2", destinationWallet: "bad-wallet", amount: 50, currency: "USD" },
+      ],
+    };
+    const res = await request(app).post("/lancepay/payouts/batch").send(body);
+    expect(res.status).toBe(201); // at least one succeeded
+    expect(res.body.data.succeeded).toBe(1);
+    expect(res.body.data.failed).toBe(1);
+    const failedRow = res.body.data.outcomes.find((o: { status: string }) => o.status === "failed");
+    expect(failedRow.error).toMatch(/destinationWallet/);
+  });
+
+  it("returns 422 when entire batch fails", async () => {
+    const body = {
+      workspaceId: "ws-1",
+      payouts: [
+        { contractorId: "con-1", destinationWallet: "bad", amount: -1, currency: "XYZ" },
+      ],
+    };
+    const res = await request(app).post("/lancepay/payouts/batch").send(body);
+    expect(res.status).toBe(422);
+    expect(res.body.data.failed).toBe(1);
+  });
+
+  it("returns idempotent result on repeat upload", async () => {
+    const first = await request(app).post("/lancepay/payouts/batch").send(VALID_BODY);
+    const batchId = first.body.data.batchId;
+
+    const second = await request(app).post("/lancepay/payouts/batch").send(VALID_BODY);
+    expect(second.status).toBe(200);
+    expect(second.body.data.idempotent).toBe(true);
+    expect(second.body.data.batchId).toBe(batchId);
+    expect(__getBatchResults().size).toBe(1);
+  });
+
+  it("returns 400 for empty payouts array", async () => {
+    const res = await request(app)
+      .post("/lancepay/payouts/batch")
+      .send({ workspaceId: "ws-1", payouts: [] });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("EMPTY_BATCH");
+  });
+
+  it("returns 400 when workspaceId is missing", async () => {
+    const res = await request(app)
+      .post("/lancepay/payouts/batch")
+      .send({ payouts: [VALID_PAYOUT] });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_WORKSPACE_ID");
+  });
+
+  it("returns 400 when payouts is not an array", async () => {
+    const res = await request(app)
+      .post("/lancepay/payouts/batch")
+      .send({ workspaceId: "ws-1", payouts: "not-an-array" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAYOUTS");
+  });
+
+  it("assigns unique payoutId to each successful row", async () => {
+    const body = { workspaceId: "ws-1", payouts: [VALID_PAYOUT, { ...VALID_PAYOUT, contractorId: "con-2" }] };
+    const res = await request(app).post("/lancepay/payouts/batch").send(body);
+    const ids = res.body.data.outcomes.map((o: { payoutId: string }) => o.payoutId);
+    expect(new Set(ids).size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds four new LancePay routes under `routes-d/routes/` with corresponding tests under `routes-d/tests/`.

### #558 — `POST /lancepay/contractors/:id/invite`
Issues a single-use HMAC-SHA256 signed invite link (72h TTL) dispatched via email or phone. Throttles resends to once per hour per contractor — returns `429` with remaining wait time if too soon, `200` with `resent: true` after cooldown. 6 tests.

### #560 — `POST /lancepay/contractors/:id/onboarding`
Starts or resumes a guided onboarding session sequencing 4 steps: `personal_info → kyc → wallet_link → tax_form`. Returns a resumable `sessionToken`. Resume by sending `{ sessionToken }` optionally with `completeStep` to advance. Session auto-marks `isComplete` when all steps are done. 7 tests.

### #563 — `POST /lancepay/contractors/:id/freeze`
Blocks payouts to a contractor pending review. Requires workspace-admin identity via `adminId` body field or `x-admin-id` header (returns `403` without it). Emits a structured audit event on every freeze. Returns `409` if already frozen. 7 tests.

### #572 — `POST /lancepay/payouts/batch`
Submits up to 500 payouts in one request. Stream-processes each row independently returning per-row outcomes (`status: pending | failed`). Idempotent by SHA-256 content hash — identical payloads return cached result with `idempotent: true`. Returns `422` when all rows fail, `201` on any success. 8 tests.

closes #558
closes #560
closes #563
closes #572