### PR TITLE
feat(routes-d): add DEX cancel, strict-receive, profile update, and p…

### DIFF
--- a/routes-d/routes/account.me.update.ts
+++ b/routes-d/routes/account.me.update.ts
@@ -1,0 +1,149 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type UserProfile = {
+  id: string;
+  email: string;
+  displayName?: string;
+  avatarUrl?: string;
+  createdAt: string;
+};
+
+type AuditEntry = {
+  userId: string;
+  changedFields: string[];
+  before: Partial<UserProfile>;
+  after: Partial<UserProfile>;
+  updatedAt: string;
+};
+
+type ProfileUpdate = {
+  displayName?: string;
+  avatarUrl?: string;
+};
+
+const users = new Map<string, UserProfile>();
+const audit: AuditEntry[] = [];
+
+const EDITABLE_FIELDS: Array<keyof ProfileUpdate> = ["displayName", "avatarUrl"];
+
+/**
+ * PATCH /account/me
+ * Update editable profile fields for the authenticated user.
+ */
+router.patch(
+  "/account/me",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "Authentication required", 401);
+        return;
+      }
+
+      const body = req.body as ProfileUpdate;
+
+      if (body.displayName !== undefined) {
+        if (typeof body.displayName !== "string" || body.displayName.trim() === "") {
+          sendError(res, "INVALID_DISPLAY_NAME", "displayName must be a non-empty string", 400);
+          return;
+        }
+      }
+
+      if (body.avatarUrl !== undefined) {
+        if (typeof body.avatarUrl !== "string" || body.avatarUrl.trim() === "") {
+          sendError(res, "INVALID_AVATAR_URL", "avatarUrl must be a non-empty string", 400);
+          return;
+        }
+      }
+
+      const user = users.get(userId);
+
+      if (!user) {
+        sendError(res, "USER_NOT_FOUND", "Authenticated user profile not found", 404);
+        return;
+      }
+
+      const provided = EDITABLE_FIELDS.filter((k) => body[k] !== undefined);
+
+      if (provided.length === 0) {
+        return res.status(200).json({
+          success: true,
+          data: { updated: false, profile: toSafeProfile(user) },
+        });
+      }
+
+      const noop = provided.every((k) => body[k] === user[k]);
+      if (noop) {
+        return res.status(200).json({
+          success: true,
+          data: { updated: false, profile: toSafeProfile(user) },
+        });
+      }
+
+      const before: Partial<UserProfile> = {};
+      const after: Partial<UserProfile> = {};
+      const changedFields: string[] = [];
+
+      for (const k of provided) {
+        if (body[k] !== user[k]) {
+          before[k] = user[k];
+          user[k] = body[k] as string;
+          after[k] = user[k];
+          changedFields.push(k);
+        }
+      }
+
+      audit.push({
+        userId,
+        changedFields,
+        before,
+        after,
+        updatedAt: new Date().toISOString(),
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: { updated: true, profile: toSafeProfile(user) },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+function toSafeProfile(user: UserProfile): Record<string, unknown> {
+  const profile: Record<string, unknown> = {
+    id: user.id,
+    email: user.email,
+    createdAt: user.createdAt,
+  };
+  if (user.displayName) profile.displayName = user.displayName;
+  if (user.avatarUrl) profile.avatarUrl = user.avatarUrl;
+  return profile;
+}
+
+export function __resetUsers(): void {
+  users.clear();
+}
+
+export function __seedUser(user: UserProfile): void {
+  users.set(user.id, user);
+}
+
+export function __getUsers(): Map<string, UserProfile> {
+  return users;
+}
+
+export function __resetAudit(): void {
+  audit.length = 0;
+}
+
+export function __getAudit(): AuditEntry[] {
+  return audit;
+}
+
+export default router;

--- a/routes-d/routes/account.prefs.get.ts
+++ b/routes-d/routes/account.prefs.get.ts
@@ -1,0 +1,67 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Theme = "light" | "dark" | "system";
+type Currency = "USD" | "EUR" | "XLM";
+type Language = "en" | "fr" | "es" | "de";
+
+type Preferences = {
+  theme: Theme;
+  currency: Currency;
+  language: Language;
+  notificationsEnabled: boolean;
+};
+
+const DEFAULT_PREFS: Preferences = {
+  theme: "system",
+  currency: "USD",
+  language: "en",
+  notificationsEnabled: true,
+};
+
+// Per-user preferences store — isolated from account.prefs.update.ts which is
+// a single-user global store with no auth. This route is per-user with auth.
+const prefsStore = new Map<string, Preferences>();
+
+/**
+ * GET /account/preferences
+ * Return the authenticated user's preferences, applying defaults when none exist.
+ */
+router.get(
+  "/account/preferences",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "Authentication required", 401);
+        return;
+      }
+
+      const userPrefs = prefsStore.get(userId) ?? { ...DEFAULT_PREFS };
+
+      return res.status(200).json({
+        success: true,
+        data: { preferences: { ...userPrefs } },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __resetPrefs(): void {
+  prefsStore.clear();
+}
+
+export function __seedPrefs(userId: string, prefs: Preferences): void {
+  prefsStore.set(userId, prefs);
+}
+
+export function __getPrefs(): Map<string, Preferences> {
+  return prefsStore;
+}
+
+export default router;

--- a/routes-d/routes/stellar.offer.cancel.ts
+++ b/routes-d/routes/stellar.offer.cancel.ts
@@ -1,0 +1,148 @@
+import { Router, Request, Response, NextFunction } from "express";
+import {
+  Networks,
+  TransactionBuilder,
+  Account,
+  Operation,
+  Asset,
+} from "@stellar/stellar-sdk";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type AssetDescriptor = {
+  code: string;
+  issuer?: string;
+};
+
+type StoredOffer = {
+  id: string;
+  accountId: string;
+  sellingAsset: AssetDescriptor;
+  buyingAsset: AssetDescriptor;
+  price: string;
+};
+
+type CancelOfferBody = {
+  offerId: string;
+  accountId: string;
+  networkPassphrase?: string;
+};
+
+const offers = new Map<string, StoredOffer>();
+
+function toStellarAsset(desc: AssetDescriptor): Asset {
+  if (desc.code === "XLM" && !desc.issuer) {
+    return Asset.native();
+  }
+  if (!desc.issuer) {
+    throw new Error(`Issuer is required for non-native asset ${desc.code}`);
+  }
+  return new Asset(desc.code, desc.issuer);
+}
+
+/**
+ * POST /stellar/offer/cancel
+ * Build a zero-amount ManageSellOffer envelope to cancel an existing DEX offer.
+ */
+router.post(
+  "/stellar/offer/cancel",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as CancelOfferBody;
+
+      if (
+        !body.offerId ||
+        typeof body.offerId !== "string" ||
+        !/^\d+$/.test(body.offerId) ||
+        body.offerId === "0"
+      ) {
+        sendError(res, "MISSING_OFFER_ID", "offerId must be a positive integer string", 400);
+        return;
+      }
+
+      if (
+        !body.accountId ||
+        typeof body.accountId !== "string" ||
+        !body.accountId.startsWith("G") ||
+        body.accountId.length !== 56
+      ) {
+        sendError(
+          res,
+          "INVALID_ACCOUNT_ID",
+          "accountId must be a valid Stellar public key (56 chars starting with G)",
+          400,
+        );
+        return;
+      }
+
+      const stored = offers.get(body.offerId);
+
+      if (!stored) {
+        sendError(res, "OFFER_NOT_FOUND", "No offer found with the given offerId", 404);
+        return;
+      }
+
+      if (stored.accountId !== body.accountId) {
+        sendError(res, "OFFER_NOT_OWNED", "The offer does not belong to the calling account", 403);
+        return;
+      }
+
+      let sellingAsset: Asset;
+      let buyingAsset: Asset;
+
+      try {
+        sellingAsset = toStellarAsset(stored.sellingAsset);
+        buyingAsset = toStellarAsset(stored.buyingAsset);
+      } catch {
+        sendError(res, "INVALID_ASSET", "Stored offer has invalid asset descriptors", 400);
+        return;
+      }
+
+      const networkPassphrase = body.networkPassphrase ?? Networks.TESTNET;
+      const source = new Account(body.accountId, "0");
+      const builder = new TransactionBuilder(source, {
+        fee: "100",
+        networkPassphrase,
+      });
+
+      builder.addOperation(
+        Operation.manageSellOffer({
+          selling: sellingAsset,
+          buying: buyingAsset,
+          amount: "0",
+          price: stored.price,
+          offerId: body.offerId,
+        }),
+      );
+
+      builder.setTimeout(300);
+      const tx = builder.build();
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          envelope: tx.toEnvelope().toXDR("base64"),
+          networkPassphrase,
+          offerId: body.offerId,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __resetOffers(): void {
+  offers.clear();
+}
+
+export function __seedOffer(offer: StoredOffer): void {
+  offers.set(offer.id, offer);
+}
+
+export function __getOffers(): Map<string, StoredOffer> {
+  return offers;
+}
+
+export default router;

--- a/routes-d/routes/stellar.payment.strictReceive.ts
+++ b/routes-d/routes/stellar.payment.strictReceive.ts
@@ -1,0 +1,149 @@
+import { Router, Request, Response, NextFunction } from "express";
+import {
+  Networks,
+  TransactionBuilder,
+  Account,
+  Operation,
+  Asset,
+} from "@stellar/stellar-sdk";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type AssetDescriptor = {
+  code: string;
+  issuer?: string;
+};
+
+type StrictReceiveBody = {
+  sourceAccount: string;
+  sendAsset: AssetDescriptor;
+  sourceMax: string;
+  destination: string;
+  destAsset: AssetDescriptor;
+  destAmount: string;
+  path?: AssetDescriptor[];
+  networkPassphrase?: string;
+};
+
+function toStellarAsset(desc: AssetDescriptor): Asset {
+  if (desc.code === "XLM" && !desc.issuer) {
+    return Asset.native();
+  }
+  if (!desc.issuer) {
+    throw new Error(`Issuer is required for non-native asset ${desc.code}`);
+  }
+  return new Asset(desc.code, desc.issuer);
+}
+
+/**
+ * POST /stellar/payment/strict-receive
+ * Build an unsigned strict-receive path payment envelope.
+ */
+router.post(
+  "/stellar/payment/strict-receive",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as StrictReceiveBody;
+
+      if (!body.sourceAccount || typeof body.sourceAccount !== "string") {
+        sendError(res, "INVALID_SOURCE", "sourceAccount is required", 400);
+        return;
+      }
+
+      if (!body.sendAsset || !body.sendAsset.code) {
+        sendError(res, "INVALID_SEND_ASSET", "sendAsset with code is required", 400);
+        return;
+      }
+
+      if (
+        !body.sourceMax ||
+        typeof body.sourceMax !== "string" ||
+        isNaN(Number(body.sourceMax)) ||
+        Number(body.sourceMax) <= 0
+      ) {
+        sendError(res, "INVALID_SOURCE_MAX", "sourceMax must be a positive numeric string", 400);
+        return;
+      }
+
+      if (!body.destination || typeof body.destination !== "string") {
+        sendError(res, "INVALID_DESTINATION", "destination is required", 400);
+        return;
+      }
+
+      if (!body.destAsset || !body.destAsset.code) {
+        sendError(res, "INVALID_DEST_ASSET", "destAsset with code is required", 400);
+        return;
+      }
+
+      if (
+        !body.destAmount ||
+        typeof body.destAmount !== "string" ||
+        isNaN(Number(body.destAmount)) ||
+        Number(body.destAmount) <= 0
+      ) {
+        sendError(res, "INVALID_DEST_AMOUNT", "destAmount must be a positive numeric string", 400);
+        return;
+      }
+
+      // sourceMax is the most the sender will spend; destAmount is the exact receive amount.
+      // If sourceMax exceeds 1000× destAmount it is almost certainly a fat-finger error.
+      if (Number(body.sourceMax) > Number(body.destAmount) * 1000) {
+        sendError(
+          res,
+          "SOURCE_MAX_BREACH",
+          "sourceMax exceeds a reasonable bound relative to destAmount",
+          400,
+        );
+        return;
+      }
+
+      let sendAsset: Asset;
+      let destAsset: Asset;
+      let pathAssets: Asset[];
+
+      try {
+        sendAsset = toStellarAsset(body.sendAsset);
+        destAsset = toStellarAsset(body.destAsset);
+        pathAssets = (body.path ?? []).map(toStellarAsset);
+      } catch {
+        sendError(res, "INVALID_ASSET", "One or more asset descriptors are invalid", 400);
+        return;
+      }
+
+      const networkPassphrase = body.networkPassphrase ?? Networks.TESTNET;
+
+      const source = new Account(body.sourceAccount, "0");
+      const builder = new TransactionBuilder(source, {
+        fee: "100",
+        networkPassphrase,
+      });
+
+      builder.addOperation(
+        Operation.pathPaymentStrictReceive({
+          sendAsset,
+          sendMax: body.sourceMax,
+          destination: body.destination,
+          destAsset,
+          destAmount: body.destAmount,
+          path: pathAssets,
+        }),
+      );
+
+      builder.setTimeout(300);
+      const tx = builder.build();
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          envelope: tx.toEnvelope().toXDR("base64"),
+          networkPassphrase,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/account.me.update.test.ts
+++ b/routes-d/tests/account.me.update.test.ts
@@ -1,0 +1,167 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import accountMeUpdateRouter, {
+  __resetUsers,
+  __seedUser,
+  __getUsers,
+  __resetAudit,
+  __getAudit,
+} from "../routes/account.me.update.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(accountMeUpdateRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("PATCH /account/me", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetUsers();
+    __resetAudit();
+  });
+
+  it("returns 200 updated:true and reflects the new displayName", async () => {
+    __seedUser({
+      id: "user-1",
+      email: "alice@example.com",
+      displayName: "Alice",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-1")
+      .send({ displayName: "Alice Updated" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.updated).toBe(true);
+    expect(res.body.data.profile.displayName).toBe("Alice Updated");
+  });
+
+  it("writes a single audit entry with before/after snapshots on change", async () => {
+    __seedUser({
+      id: "user-1",
+      email: "alice@example.com",
+      displayName: "Alice",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+
+    await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-1")
+      .send({ displayName: "Alice Updated" });
+
+    const entries = __getAudit();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].changedFields).toEqual(["displayName"]);
+    expect(entries[0].before.displayName).toBe("Alice");
+    expect(entries[0].after.displayName).toBe("Alice Updated");
+    expect(entries[0].userId).toBe("user-1");
+  });
+
+  it("returns 200 updated:false when all sent values already match (no-op)", async () => {
+    __seedUser({
+      id: "user-2",
+      email: "bob@example.com",
+      displayName: "Bob",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-2")
+      .send({ displayName: "Bob" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.updated).toBe(false);
+    expect(__getAudit()).toHaveLength(0);
+  });
+
+  it("returns 200 updated:false and current profile when body is empty", async () => {
+    __seedUser({
+      id: "user-3",
+      email: "charlie@example.com",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-3")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.updated).toBe(false);
+    expect(res.body.data.profile.id).toBe("user-3");
+  });
+
+  it("returns 400 INVALID_DISPLAY_NAME when displayName is an empty string", async () => {
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-1")
+      .send({ displayName: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DISPLAY_NAME");
+  });
+
+  it("returns 400 INVALID_DISPLAY_NAME when displayName is not a string", async () => {
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-1")
+      .send({ displayName: 42 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DISPLAY_NAME");
+  });
+
+  it("returns 400 INVALID_AVATAR_URL when avatarUrl is an empty string", async () => {
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-1")
+      .send({ avatarUrl: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AVATAR_URL");
+  });
+
+  it("returns 401 UNAUTHORIZED when no x-user-id header is provided", async () => {
+    const res = await request(app).patch("/account/me").send({ displayName: "Ghost" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 USER_NOT_FOUND when the user is not in the store", async () => {
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "nonexistent")
+      .send({ displayName: "Nobody" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("USER_NOT_FOUND");
+  });
+
+  it("does not include undefined optional fields in the returned profile", async () => {
+    __seedUser({
+      id: "user-4",
+      email: "dave@example.com",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+
+    const res = await request(app)
+      .patch("/account/me")
+      .set("x-user-id", "user-4")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.profile).not.toHaveProperty("displayName");
+    expect(res.body.data.profile).not.toHaveProperty("avatarUrl");
+  });
+});

--- a/routes-d/tests/account.prefs.get.test.ts
+++ b/routes-d/tests/account.prefs.get.test.ts
@@ -1,0 +1,94 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import prefsGetRouter, {
+  __resetPrefs,
+  __seedPrefs,
+  __getPrefs,
+} from "../routes/account.prefs.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(prefsGetRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /account/preferences", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetPrefs();
+  });
+
+  it("returns 401 UNAUTHORIZED when no x-user-id header is provided", async () => {
+    const res = await request(app).get("/account/preferences");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns documented defaults when no preferences exist for the user", async () => {
+    const res = await request(app)
+      .get("/account/preferences")
+      .set("x-user-id", "user-new");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const prefs = res.body.data.preferences;
+    expect(prefs.theme).toBe("system");
+    expect(prefs.currency).toBe("USD");
+    expect(prefs.language).toBe("en");
+    expect(prefs.notificationsEnabled).toBe(true);
+  });
+
+  it("returns persisted preferences when they exist for the user", async () => {
+    __seedPrefs("user-1", {
+      theme: "dark",
+      currency: "EUR",
+      language: "fr",
+      notificationsEnabled: false,
+    });
+
+    const res = await request(app)
+      .get("/account/preferences")
+      .set("x-user-id", "user-1");
+
+    expect(res.status).toBe(200);
+    const prefs = res.body.data.preferences;
+    expect(prefs.theme).toBe("dark");
+    expect(prefs.currency).toBe("EUR");
+    expect(prefs.language).toBe("fr");
+    expect(prefs.notificationsEnabled).toBe(false);
+  });
+
+  it("isolates preferences between users", async () => {
+    __seedPrefs("user-a", {
+      theme: "dark",
+      currency: "EUR",
+      language: "fr",
+      notificationsEnabled: false,
+    });
+
+    const res = await request(app)
+      .get("/account/preferences")
+      .set("x-user-id", "user-b");
+
+    expect(res.status).toBe(200);
+    const prefs = res.body.data.preferences;
+    expect(prefs.theme).toBe("system");
+    expect(prefs.currency).toBe("USD");
+  });
+
+  it("exposes the prefs store via __getPrefs for test assertions", () => {
+    __seedPrefs("user-x", {
+      theme: "light",
+      currency: "XLM",
+      language: "es",
+      notificationsEnabled: true,
+    });
+    expect(__getPrefs().get("user-x")?.theme).toBe("light");
+  });
+});

--- a/routes-d/tests/stellar.offer.cancel.test.ts
+++ b/routes-d/tests/stellar.offer.cancel.test.ts
@@ -1,0 +1,114 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import cancelRouter, {
+  __resetOffers,
+  __seedOffer,
+  __getOffers,
+} from "../routes/stellar.offer.cancel.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cancelRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const ACCOUNT_A = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+const ACCOUNT_B = "GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQQBG5ESBWXHOMGGKJUW7E7JG";
+
+const seedOffer = {
+  id: "12345",
+  accountId: ACCOUNT_A,
+  sellingAsset: { code: "XLM" },
+  buyingAsset: { code: "USDC", issuer: ACCOUNT_A },
+  price: "1.5",
+};
+
+describe("POST /stellar/offer/cancel", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetOffers();
+  });
+
+  it("returns 200 with a valid XDR envelope when the caller owns the offer", async () => {
+    __seedOffer(seedOffer);
+
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ offerId: "12345", accountId: ACCOUNT_A });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.data.envelope).toBe("string");
+    expect(res.body.data.envelope.length).toBeGreaterThan(0);
+    expect(res.body.data.offerId).toBe("12345");
+    expect(res.body.data.networkPassphrase).toBeDefined();
+  });
+
+  it("returns 403 OFFER_NOT_OWNED when the caller does not own the offer", async () => {
+    __seedOffer(seedOffer);
+
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ offerId: "12345", accountId: ACCOUNT_B });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("OFFER_NOT_OWNED");
+  });
+
+  it("returns 404 OFFER_NOT_FOUND for an unknown offerId", async () => {
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ offerId: "99999", accountId: ACCOUNT_A });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("OFFER_NOT_FOUND");
+  });
+
+  it("returns 400 MISSING_OFFER_ID when offerId is absent", async () => {
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ accountId: ACCOUNT_A });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_OFFER_ID");
+  });
+
+  it("returns 400 MISSING_OFFER_ID when offerId is '0'", async () => {
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ offerId: "0", accountId: ACCOUNT_A });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_OFFER_ID");
+  });
+
+  it("returns 400 MISSING_OFFER_ID when offerId is non-numeric", async () => {
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ offerId: "abc", accountId: ACCOUNT_A });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_OFFER_ID");
+  });
+
+  it("returns 400 INVALID_ACCOUNT_ID when accountId is not a valid Stellar key", async () => {
+    __seedOffer(seedOffer);
+
+    const res = await request(app)
+      .post("/stellar/offer/cancel")
+      .send({ offerId: "12345", accountId: "notakey" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_ACCOUNT_ID");
+  });
+
+  it("exposes the offers store via __getOffers for test assertions", () => {
+    __seedOffer(seedOffer);
+    expect(__getOffers().get("12345")).toEqual(seedOffer);
+  });
+});

--- a/routes-d/tests/stellar.payment.strictReceive.test.ts
+++ b/routes-d/tests/stellar.payment.strictReceive.test.ts
@@ -1,0 +1,160 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import strictReceiveRouter from "../routes/stellar.payment.strictReceive.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(strictReceiveRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+
+const validPayload = {
+  sourceAccount: VALID_ACCOUNT,
+  sendAsset: { code: "XLM" },
+  sourceMax: "100",
+  destination: VALID_ACCOUNT,
+  destAsset: { code: "USDC", issuer: VALID_ACCOUNT },
+  destAmount: "10",
+  path: [],
+};
+
+describe("POST /stellar/payment/strict-receive", () => {
+  const app = buildApp();
+
+  it("builds a valid unsigned XDR envelope for a correct strict-receive request", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(validPayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.data.envelope).toBe("string");
+    expect(res.body.data.envelope.length).toBeGreaterThan(0);
+    expect(res.body.data.networkPassphrase).toBeDefined();
+  });
+
+  it("succeeds when the path field is omitted (defaults to empty path)", async () => {
+    const { path: _path, ...payloadWithoutPath } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(payloadWithoutPath);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.envelope).toBeDefined();
+  });
+
+  it("succeeds when sourceMax equals destAmount (no breach)", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send({ ...validPayload, sourceMax: "10", destAmount: "10" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 400 SOURCE_MAX_BREACH when sourceMax exceeds 1000x destAmount", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send({ ...validPayload, sourceMax: "10000", destAmount: "1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("SOURCE_MAX_BREACH");
+  });
+
+  it("returns 400 INVALID_SOURCE when sourceAccount is missing", async () => {
+    const { sourceAccount: _, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SOURCE");
+  });
+
+  it("returns 400 INVALID_SEND_ASSET when sendAsset is missing", async () => {
+    const { sendAsset: _, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SEND_ASSET");
+  });
+
+  it("returns 400 INVALID_SOURCE_MAX when sourceMax is negative", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send({ ...validPayload, sourceMax: "-5" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SOURCE_MAX");
+  });
+
+  it("returns 400 INVALID_SOURCE_MAX when sourceMax is non-numeric", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send({ ...validPayload, sourceMax: "abc" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SOURCE_MAX");
+  });
+
+  it("returns 400 INVALID_DESTINATION when destination is missing", async () => {
+    const { destination: _, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DESTINATION");
+  });
+
+  it("returns 400 INVALID_DEST_ASSET when destAsset is missing", async () => {
+    const { destAsset: _, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DEST_ASSET");
+  });
+
+  it("returns 400 INVALID_DEST_AMOUNT when destAmount is missing", async () => {
+    const { destAmount: _, ...rest } = validPayload;
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send(rest);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DEST_AMOUNT");
+  });
+
+  it("returns 400 INVALID_DEST_AMOUNT when destAmount is not positive", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send({ ...validPayload, destAmount: "0" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DEST_AMOUNT");
+  });
+
+  it("accepts a path with intermediate assets and builds a valid envelope", async () => {
+    const res = await request(app)
+      .post("/stellar/payment/strict-receive")
+      .send({
+        ...validPayload,
+        path: [{ code: "EUR", issuer: VALID_ACCOUNT }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.envelope).toBeDefined();
+  });
+});


### PR DESCRIPTION
 ## What

  Implements four new route handlers inside `routes-d/routes/` as specified in issues #463, #468, #480, and #484.

  ## Changes

  - `routes-d/routes/stellar.offer.cancel.ts` — `POST /stellar/offer/cancel`: validates offer ownership then builds a
  zero-amount `ManageSellOffer` envelope to cancel a DEX offer
  - `routes-d/routes/account.me.update.ts` — `PATCH /account/me`: updates editable profile fields (`displayName`,
  `avatarUrl`) with a single audit log entry per request
  - `routes-d/routes/account.prefs.get.ts` — `GET /account/preferences`: returns per-user preferences with documented
  defaults when none exist; requires authentication
  - `routes-d/routes/stellar.payment.strictReceive.ts` — `POST /stellar/payment/strict-receive`: builds an unsigned
  `pathPaymentStrictReceive` envelope with source-max breach guard

  Each route ships with a full test file under `routes-d/tests/`. No files outside `routes-d/` were modified.

  ## Closes

  Closes #463
  Closes #468
  Closes #480
  Closes #484