### PR TITLE
Add NFT and wallet recovery routes in routes-d

### DIFF
--- a/routes-d/routes/nfts.list.ts
+++ b/routes-d/routes/nfts.list.ts
@@ -1,0 +1,90 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type DisplayMetadata = {
+  name: string;
+  image?: string;
+  description?: string;
+};
+
+type NftHolding = {
+  id: string;
+  tokenId: string;
+  collectionId: string;
+  ownerUserId: string;
+  acquiredAt: string;
+};
+
+const holdingsByUser = new Map<string, NftHolding[]>();
+const metadataByToken = new Map<string, DisplayMetadata>();
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function parsePositiveInteger(value: unknown, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (typeof value !== "string") return NaN;
+  return parseInt(value, 10);
+}
+
+router.get("/nfts", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.headers["x-user-id"] as string | undefined;
+
+    if (!userId) {
+      sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+      return;
+    }
+
+    const page = parsePositiveInteger(req.query.page, DEFAULT_PAGE);
+    const limit = parsePositiveInteger(req.query.limit, DEFAULT_LIMIT);
+
+    if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+      sendError(res, "INVALID_PAGINATION", "page must be >= 1 and limit must be between 1 and 100", 400);
+      return;
+    }
+
+    const collection = req.query.collection as string | undefined;
+    const allHoldings = holdingsByUser.get(userId) ?? [];
+    const filtered = collection
+      ? allHoldings.filter((holding) => holding.collectionId === collection)
+      : allHoldings;
+
+    const offset = (page - 1) * limit;
+    const data = filtered.slice(offset, offset + limit).map((holding) => ({
+      ...holding,
+      displayMetadata: metadataByToken.get(holding.tokenId) ?? null,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      data,
+      pagination: {
+        page,
+        limit,
+        total: filtered.length,
+        totalPages: Math.ceil(filtered.length / limit) || 1,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __seedNftHoldings(userId: string, holdings: NftHolding[]): void {
+  holdingsByUser.set(userId, holdings);
+}
+
+export function __seedNftMetadata(tokenId: string, metadata: DisplayMetadata): void {
+  metadataByToken.set(tokenId, metadata);
+}
+
+export function __resetNftList(): void {
+  holdingsByUser.clear();
+  metadataByToken.clear();
+}
+
+export default router;

--- a/routes-d/routes/nfts.metadata.refresh.ts
+++ b/routes-d/routes/nfts.metadata.refresh.ts
@@ -1,0 +1,115 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type MetadataRefreshBody = {
+  tokenId: string;
+};
+
+type TokenRecord = {
+  tokenId: string;
+  collectionId: string;
+  metadataUri: string;
+  metadata: {
+    name: string;
+    image?: string;
+    description?: string;
+  };
+  refreshedAt?: string;
+};
+
+const tokens = new Map<string, TokenRecord>();
+const metadataCache = new Map<string, TokenRecord["metadata"]>();
+const refreshRateLimits = new Map<string, { count: number; windowStart: number }>();
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const MAX_REFRESHES_PER_WINDOW = 1;
+
+function getRateEntry(tokenId: string): { count: number; windowStart: number } {
+  const now = Date.now();
+  const current = refreshRateLimits.get(tokenId);
+
+  if (!current || now - current.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    const freshEntry = { count: 0, windowStart: now };
+    refreshRateLimits.set(tokenId, freshEntry);
+    return freshEntry;
+  }
+
+  return current;
+}
+
+function fetchPinnedMetadata(token: TokenRecord): TokenRecord["metadata"] {
+  return {
+    ...token.metadata,
+    name: token.metadata.name.trim(),
+  };
+}
+
+router.post("/nfts/metadata/refresh", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const body = req.body as MetadataRefreshBody;
+
+    if (!body.tokenId || typeof body.tokenId !== "string") {
+      sendError(res, "MISSING_TOKEN", "tokenId is required", 400);
+      return;
+    }
+
+    const token = tokens.get(body.tokenId);
+    if (!token) {
+      sendError(res, "TOKEN_NOT_FOUND", "NFT token was not found", 404);
+      return;
+    }
+
+    const rateEntry = getRateEntry(body.tokenId);
+    rateEntry.count += 1;
+
+    if (rateEntry.count > MAX_REFRESHES_PER_WINDOW) {
+      sendError(res, "RATE_LIMITED", "metadata refresh is temporarily throttled for this token", 429);
+      return;
+    }
+
+    const metadata = fetchPinnedMetadata(token);
+    const refreshedAt = new Date().toISOString();
+
+    metadataCache.delete(body.tokenId);
+    tokens.set(body.tokenId, {
+      ...token,
+      metadata,
+      refreshedAt,
+    });
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        tokenId: body.tokenId,
+        collectionId: token.collectionId,
+        metadata,
+        refreshedAt,
+        cacheInvalidated: true,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __seedNftToken(token: TokenRecord): void {
+  tokens.set(token.tokenId, token);
+}
+
+export function __seedMetadataCache(tokenId: string, metadata: TokenRecord["metadata"]): void {
+  metadataCache.set(tokenId, metadata);
+}
+
+export function __hasMetadataCache(tokenId: string): boolean {
+  return metadataCache.has(tokenId);
+}
+
+export function __resetMetadataRefresh(): void {
+  tokens.clear();
+  metadataCache.clear();
+  refreshRateLimits.clear();
+}
+
+export default router;

--- a/routes-d/routes/nfts.mint.ts
+++ b/routes-d/routes/nfts.mint.ts
@@ -53,6 +53,7 @@ function validateMetadata(metadata: NftMetadata | undefined): string | null {
     }
 
     const invalidAttribute = metadata.attributes.some((attribute) => (
+      attribute === null ||
       typeof attribute !== "object" ||
       typeof attribute.traitType !== "string" ||
       attribute.traitType.trim().length === 0 ||

--- a/routes-d/routes/nfts.mint.ts
+++ b/routes-d/routes/nfts.mint.ts
@@ -1,0 +1,157 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type NftMetadata = {
+  name: string;
+  description?: string;
+  image: string;
+  attributes?: Array<{ traitType: string; value: string | number | boolean }>;
+};
+
+type MintBody = {
+  collectionId: string;
+  recipient: string;
+  metadata: NftMetadata;
+  submit?: boolean;
+};
+
+type Collection = {
+  id: string;
+  contractId: string;
+  authorizedMinters: Set<string>;
+};
+
+const collections = new Map<string, Collection>();
+const mintedTransactions: Array<{ collectionId: string; recipient: string; tokenId: string }> = [];
+
+function isValidStellarAddress(address: string): boolean {
+  return typeof address === "string" && /^[GM][A-Z2-7]{55}$/.test(address);
+}
+
+function validateMetadata(metadata: NftMetadata | undefined): string | null {
+  if (!metadata || typeof metadata !== "object") {
+    return "metadata is required";
+  }
+
+  if (typeof metadata.name !== "string" || metadata.name.trim().length === 0 || metadata.name.length > 120) {
+    return "metadata.name must be a non-empty string of at most 120 characters";
+  }
+
+  if (typeof metadata.image !== "string" || metadata.image.trim().length === 0) {
+    return "metadata.image is required";
+  }
+
+  if (metadata.description !== undefined && typeof metadata.description !== "string") {
+    return "metadata.description must be a string";
+  }
+
+  if (metadata.attributes !== undefined) {
+    if (!Array.isArray(metadata.attributes)) {
+      return "metadata.attributes must be an array";
+    }
+
+    const invalidAttribute = metadata.attributes.some((attribute) => (
+      typeof attribute !== "object" ||
+      typeof attribute.traitType !== "string" ||
+      attribute.traitType.trim().length === 0 ||
+      !["string", "number", "boolean"].includes(typeof attribute.value)
+    ));
+
+    if (invalidAttribute) {
+      return "metadata.attributes must contain traitType and primitive value entries";
+    }
+  }
+
+  return null;
+}
+
+function createUnsignedEnvelope(collection: Collection, recipient: string, metadata: NftMetadata): string {
+  const payload = `${collection.contractId}:${recipient}:${metadata.name}:${Date.now()}`;
+  return Buffer.from(payload).toString("base64");
+}
+
+router.post("/nfts/mint", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const minterId = req.headers["x-minter-id"] as string | undefined;
+
+    if (!minterId) {
+      sendError(res, "UNAUTHORIZED", "x-minter-id header is required", 401);
+      return;
+    }
+
+    const body = req.body as MintBody;
+
+    if (!body.collectionId || typeof body.collectionId !== "string") {
+      sendError(res, "MISSING_COLLECTION", "collectionId is required", 400);
+      return;
+    }
+
+    const collection = collections.get(body.collectionId);
+    if (!collection) {
+      sendError(res, "COLLECTION_NOT_FOUND", "NFT collection was not found", 404);
+      return;
+    }
+
+    if (!collection.authorizedMinters.has(minterId)) {
+      sendError(res, "UNAUTHORIZED_MINTER", "Minter is not authorized for this collection", 403);
+      return;
+    }
+
+    if (!isValidStellarAddress(body.recipient)) {
+      sendError(res, "INVALID_RECIPIENT", "recipient must be a valid Stellar account or muxed address", 400);
+      return;
+    }
+
+    const metadataError = validateMetadata(body.metadata);
+    if (metadataError) {
+      sendError(res, "INVALID_METADATA", metadataError, 400);
+      return;
+    }
+
+    if (body.submit === true) {
+      const tokenId = `nft_${body.collectionId}_${mintedTransactions.length + 1}`;
+      const transactionId = `tx_${Buffer.from(`${tokenId}:${body.recipient}`).toString("hex").slice(0, 24)}`;
+      mintedTransactions.push({ collectionId: body.collectionId, recipient: body.recipient, tokenId });
+
+      return res.status(201).json({
+        success: true,
+        data: {
+          transactionId,
+          tokenId,
+          submitted: true,
+        },
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        unsignedEnvelope: createUnsignedEnvelope(collection, body.recipient, body.metadata),
+        submitted: false,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __seedNftCollection(collection: { id: string; contractId: string; authorizedMinters: string[] }): void {
+  collections.set(collection.id, {
+    id: collection.id,
+    contractId: collection.contractId,
+    authorizedMinters: new Set(collection.authorizedMinters),
+  });
+}
+
+export function __getMintedTransactions(): Array<{ collectionId: string; recipient: string; tokenId: string }> {
+  return mintedTransactions;
+}
+
+export function __resetNftMint(): void {
+  collections.clear();
+  mintedTransactions.length = 0;
+}
+
+export default router;

--- a/routes-d/routes/wallets.recovery.init.ts
+++ b/routes-d/routes/wallets.recovery.init.ts
@@ -1,0 +1,150 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type RecoveryInitBody = {
+  walletId: string;
+  guardians: string[];
+  threshold: number;
+};
+
+type RecoveryFlow = {
+  id: string;
+  userId: string;
+  walletId: string;
+  guardians: string[];
+  threshold: number;
+  createdAt: string;
+};
+
+type Notification = {
+  guardian: string;
+  recoveryId: string;
+  walletId: string;
+};
+
+const recoveryFlows = new Map<string, RecoveryFlow>();
+const guardianReachability = new Map<string, boolean>();
+const sentNotifications: Notification[] = [];
+
+function validateGuardians(guardians: unknown): string | null {
+  if (!Array.isArray(guardians) || guardians.length === 0) {
+    return "guardians must be a non-empty array";
+  }
+
+  const normalized = guardians.map((guardian) => (
+    typeof guardian === "string" ? guardian.trim().toLowerCase() : ""
+  ));
+
+  if (normalized.some((guardian) => guardian.length === 0)) {
+    return "guardians must contain non-empty identifiers";
+  }
+
+  if (new Set(normalized).size !== normalized.length) {
+    return "guardians must be unique";
+  }
+
+  return null;
+}
+
+function validateThreshold(threshold: unknown, guardianCount: number): string | null {
+  if (typeof threshold !== "number" || !Number.isInteger(threshold)) {
+    return "threshold must be an integer";
+  }
+
+  if (threshold < 1 || threshold > guardianCount) {
+    return "threshold must be between 1 and the number of guardians";
+  }
+
+  return null;
+}
+
+function dispatchGuardianNotification(guardian: string, recoveryId: string, walletId: string): void {
+  if (guardianReachability.get(guardian) === false) {
+    throw new Error(`guardian ${guardian} is unreachable`);
+  }
+
+  sentNotifications.push({ guardian, recoveryId, walletId });
+}
+
+router.post("/wallets/recovery/init", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.headers["x-user-id"] as string | undefined;
+
+    if (!userId) {
+      sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+      return;
+    }
+
+    const body = req.body as RecoveryInitBody;
+
+    if (!body.walletId || typeof body.walletId !== "string") {
+      sendError(res, "MISSING_WALLET", "walletId is required", 400);
+      return;
+    }
+
+    const guardiansError = validateGuardians(body.guardians);
+    if (guardiansError) {
+      sendError(res, "INVALID_GUARDIANS", guardiansError, 400);
+      return;
+    }
+
+    const thresholdError = validateThreshold(body.threshold, body.guardians.length);
+    if (thresholdError) {
+      sendError(res, "INVALID_THRESHOLD", thresholdError, 400);
+      return;
+    }
+
+    const recoveryId = `recovery_${Date.now()}_${recoveryFlows.size + 1}`;
+
+    try {
+      body.guardians.forEach((guardian) => {
+        dispatchGuardianNotification(guardian, recoveryId, body.walletId);
+      });
+    } catch (err) {
+      const error = err as Error;
+      sendError(res, "GUARDIAN_UNREACHABLE", error.message, 424);
+      return;
+    }
+
+    const flow: RecoveryFlow = {
+      id: recoveryId,
+      userId,
+      walletId: body.walletId,
+      guardians: body.guardians,
+      threshold: body.threshold,
+      createdAt: new Date().toISOString(),
+    };
+
+    recoveryFlows.set(recoveryId, flow);
+
+    return res.status(201).json({
+      success: true,
+      data: {
+        recoveryId,
+        walletId: flow.walletId,
+        guardiansNotified: sentNotifications.filter((notification) => notification.recoveryId === recoveryId).length,
+        threshold: flow.threshold,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __setGuardianReachable(guardian: string, reachable: boolean): void {
+  guardianReachability.set(guardian, reachable);
+}
+
+export function __getRecoveryNotifications(): Notification[] {
+  return sentNotifications;
+}
+
+export function __resetRecoveryInit(): void {
+  recoveryFlows.clear();
+  guardianReachability.clear();
+  sentNotifications.length = 0;
+}
+
+export default router;

--- a/routes-d/tests/nfts.list.test.ts
+++ b/routes-d/tests/nfts.list.test.ts
@@ -1,0 +1,98 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import nftsListRouter, {
+  __resetNftList,
+  __seedNftHoldings,
+  __seedNftMetadata,
+} from "../routes/nfts.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(nftsListRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER_ID = "user-abc123";
+
+const holdings = [
+  {
+    id: "holding-1",
+    tokenId: "token-1",
+    collectionId: "collection-alpha",
+    ownerUserId: USER_ID,
+    acquiredAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "holding-2",
+    tokenId: "token-2",
+    collectionId: "collection-beta",
+    ownerUserId: USER_ID,
+    acquiredAt: "2026-01-02T00:00:00.000Z",
+  },
+  {
+    id: "holding-3",
+    tokenId: "token-3",
+    collectionId: "collection-alpha",
+    ownerUserId: USER_ID,
+    acquiredAt: "2026-01-03T00:00:00.000Z",
+  },
+];
+
+describe("GET /nfts", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetNftList();
+  });
+
+  it("returns an empty NFT list for a user with no holdings", async () => {
+    const res = await request(app)
+      .get("/nfts")
+      .set("x-user-id", USER_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("filters NFTs by collection and hydrates display metadata", async () => {
+    __seedNftHoldings(USER_ID, holdings);
+    __seedNftMetadata("token-1", {
+      name: "Alpha One",
+      image: "ipfs://alpha-one",
+    });
+
+    const res = await request(app)
+      .get("/nfts?collection=collection-alpha")
+      .set("x-user-id", USER_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.data.every((nft: { collectionId: string }) => nft.collectionId === "collection-alpha")).toBe(true);
+    expect(res.body.data[0].displayMetadata.name).toBe("Alpha One");
+    expect(res.body.data[1].displayMetadata).toBeNull();
+  });
+
+  it("paginates NFT holdings", async () => {
+    __seedNftHoldings(USER_ID, holdings);
+
+    const res = await request(app)
+      .get("/nfts?page=2&limit=2")
+      .set("x-user-id", USER_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].tokenId).toBe("token-3");
+    expect(res.body.pagination).toEqual({
+      page: 2,
+      limit: 2,
+      total: 3,
+      totalPages: 2,
+    });
+  });
+});

--- a/routes-d/tests/nfts.metadata.refresh.test.ts
+++ b/routes-d/tests/nfts.metadata.refresh.test.ts
@@ -1,0 +1,74 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import metadataRefreshRouter, {
+  __hasMetadataCache,
+  __resetMetadataRefresh,
+  __seedMetadataCache,
+  __seedNftToken,
+} from "../routes/nfts.metadata.refresh.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(metadataRefreshRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const token = {
+  tokenId: "token-1",
+  collectionId: "collection-alpha",
+  metadataUri: "ipfs://token-1",
+  metadata: {
+    name: " Alpha One ",
+    image: "ipfs://alpha-one",
+  },
+};
+
+describe("POST /nfts/metadata/refresh", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetMetadataRefresh();
+    __seedNftToken(token);
+  });
+
+  it("refreshes metadata and invalidates cached entries", async () => {
+    __seedMetadataCache("token-1", { name: "Stale Alpha One" });
+
+    const res = await request(app)
+      .post("/nfts/metadata/refresh")
+      .send({ tokenId: "token-1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.metadata.name).toBe("Alpha One");
+    expect(res.body.data.cacheInvalidated).toBe(true);
+    expect(__hasMetadataCache("token-1")).toBe(false);
+  });
+
+  it("throttles repeated refreshes per token", async () => {
+    const first = await request(app)
+      .post("/nfts/metadata/refresh")
+      .send({ tokenId: "token-1" });
+    expect(first.status).toBe(200);
+
+    const second = await request(app)
+      .post("/nfts/metadata/refresh")
+      .send({ tokenId: "token-1" });
+
+    expect(second.status).toBe(429);
+    expect(second.body.error.code).toBe("RATE_LIMITED");
+  });
+
+  it("returns unknown token errors without consuming another token rate limit", async () => {
+    const res = await request(app)
+      .post("/nfts/metadata/refresh")
+      .send({ tokenId: "missing-token" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("TOKEN_NOT_FOUND");
+  });
+});

--- a/routes-d/tests/nfts.mint.test.ts
+++ b/routes-d/tests/nfts.mint.test.ts
@@ -1,0 +1,90 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import nftsMintRouter, {
+  __getMintedTransactions,
+  __resetNftMint,
+  __seedNftCollection,
+} from "../routes/nfts.mint.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(nftsMintRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const MINTER_ID = "minter-1";
+const RECIPIENT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const validMint = {
+  collectionId: "collection-alpha",
+  recipient: RECIPIENT,
+  metadata: {
+    name: "Founders Badge",
+    image: "ipfs://founders-badge",
+    description: "Early Nextellar supporter badge",
+  },
+};
+
+describe("POST /nfts/mint", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetNftMint();
+    __seedNftCollection({
+      id: "collection-alpha",
+      contractId: "contract-alpha",
+      authorizedMinters: [MINTER_ID],
+    });
+  });
+
+  it("returns an unsigned envelope for an authorized mint request", async () => {
+    const res = await request(app)
+      .post("/nfts/mint")
+      .set("x-minter-id", MINTER_ID)
+      .send(validMint);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.unsignedEnvelope).toBeDefined();
+    expect(res.body.data.submitted).toBe(false);
+  });
+
+  it("submits a mint and returns a transaction id when requested", async () => {
+    const res = await request(app)
+      .post("/nfts/mint")
+      .set("x-minter-id", MINTER_ID)
+      .send({ ...validMint, submit: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.transactionId).toMatch(/^tx_/);
+    expect(res.body.data.tokenId).toMatch(/^nft_collection-alpha_/);
+    expect(__getMintedTransactions()).toHaveLength(1);
+  });
+
+  it("rejects invalid metadata", async () => {
+    const res = await request(app)
+      .post("/nfts/mint")
+      .set("x-minter-id", MINTER_ID)
+      .send({
+        ...validMint,
+        metadata: { name: "", image: "ipfs://missing-name" },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_METADATA");
+  });
+
+  it("rejects unauthorized minters", async () => {
+    const res = await request(app)
+      .post("/nfts/mint")
+      .set("x-minter-id", "minter-2")
+      .send(validMint);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("UNAUTHORIZED_MINTER");
+  });
+});

--- a/routes-d/tests/wallets.recovery.init.test.ts
+++ b/routes-d/tests/wallets.recovery.init.test.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import recoveryInitRouter, {
+  __getRecoveryNotifications,
+  __resetRecoveryInit,
+  __setGuardianReachable,
+} from "../routes/wallets.recovery.init.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(recoveryInitRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER_ID = "user-abc123";
+
+const validRecovery = {
+  walletId: "wallet-1",
+  guardians: ["guardian-a@example.com", "guardian-b@example.com", "guardian-c@example.com"],
+  threshold: 2,
+};
+
+describe("POST /wallets/recovery/init", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetRecoveryInit();
+  });
+
+  it("starts a recovery flow and notifies every guardian", async () => {
+    const res = await request(app)
+      .post("/wallets/recovery/init")
+      .set("x-user-id", USER_ID)
+      .send(validRecovery);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.recoveryId).toMatch(/^recovery_/);
+    expect(res.body.data.guardiansNotified).toBe(3);
+    expect(__getRecoveryNotifications()).toHaveLength(3);
+  });
+
+  it("rejects threshold values above the guardian count", async () => {
+    const res = await request(app)
+      .post("/wallets/recovery/init")
+      .set("x-user-id", USER_ID)
+      .send({ ...validRecovery, threshold: 4 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_THRESHOLD");
+    expect(__getRecoveryNotifications()).toHaveLength(0);
+  });
+
+  it("returns guardian unreachable when notification dispatch fails", async () => {
+    __setGuardianReachable("guardian-b@example.com", false);
+
+    const res = await request(app)
+      .post("/wallets/recovery/init")
+      .set("x-user-id", USER_ID)
+      .send(validRecovery);
+
+    expect(res.status).toBe(424);
+    expect(res.body.error.code).toBe("GUARDIAN_UNREACHABLE");
+    expect(__getRecoveryNotifications()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

closes #507
closes #496
closes #509
closes #513


- Add `GET /nfts` route with collection filtering, pagination, and metadata hydration
- Add `POST /nfts/mint` route with recipient validation, metadata validation, and authorized minter checks
- Add `POST /wallets/recovery/init` route with guardian/threshold validation and guardian notification dispatch handling
- Add `POST /nfts/metadata/refresh` route with per-token rate limiting and cache invalidation

## Tests
- Added route-level tests for NFT listing: empty state, collection filtering, and pagination
- Added route-level tests for NFT minting: mint success, metadata rejection, and unauthorized minter
- Added route-level tests for wallet recovery init: init success, threshold violation, and guardian unreachable
- Added route-level tests for metadata refresh: refresh success, throttling, and unknown token

## Notes
- Changes are scoped to `routes-d/`
- Build, lint, install, and tests were not run per instruction