### PR TITLE
Adds four new route handlers inside routes-d/routes/ with matching test files under routes-d/tests/.

### DIFF
--- a/routes-d/routes/defi.pools.list.ts
+++ b/routes-d/routes/defi.pools.list.ts
@@ -1,0 +1,118 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Asset = {
+  code: string;
+  issuer: string;
+  amount: string;
+};
+
+type PoolSummary = {
+  id: string;
+  assetA: Asset;
+  assetB: Asset;
+  totalShares: string;
+  apyEstimate: string;
+};
+
+const DEFAULT_POOLS: PoolSummary[] = [
+  {
+    id: "pool-usdc-xlm",
+    assetA: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", amount: "1000000.00" },
+    assetB: { code: "XLM", issuer: "native", amount: "50000000.00" },
+    totalShares: "7071067.81",
+    apyEstimate: "5.04",
+  },
+  {
+    id: "pool-btc-xlm",
+    assetA: { code: "BTC", issuer: "GDPJALI4AZKUU2W426U5WKMAT6CN3AJRPIIRYR2YM54TL2GDWO5O2MZM", amount: "10.00" },
+    assetB: { code: "XLM", issuer: "native", amount: "2000000.00" },
+    totalShares: "4472.13",
+    apyEstimate: "7.20",
+  },
+  {
+    id: "pool-usdt-xlm",
+    assetA: { code: "USDT", issuer: "GCQTGZQQ5G4PTM2GL7CDIFKUBIPEC52BROAQIAPW53NMYVOZ3A7EKV68", amount: "500000.00" },
+    assetB: { code: "XLM", issuer: "native", amount: "25000000.00" },
+    totalShares: "3535533.90",
+    apyEstimate: "4.80",
+  },
+];
+
+const CACHE_TTL_MS = 15_000;
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+let poolsStore: PoolSummary[] = [...DEFAULT_POOLS];
+let cachedPools: PoolSummary[] | null = null;
+let cacheTimestamp = 0;
+
+export function __resetPoolsListCache(): void {
+  cachedPools = null;
+  cacheTimestamp = 0;
+  poolsStore = [...DEFAULT_POOLS];
+}
+
+export function __seedPoolsList(pools: PoolSummary[]): void {
+  poolsStore = pools;
+  cachedPools = null;
+  cacheTimestamp = 0;
+}
+
+router.get("/defi/pools", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const page = req.query.page !== undefined ? parseInt(req.query.page as string, 10) : DEFAULT_PAGE;
+    const limit = req.query.limit !== undefined ? parseInt(req.query.limit as string, 10) : DEFAULT_LIMIT;
+
+    if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+      sendError(res, "INVALID_PAGINATION", "page must be >= 1 and limit must be between 1 and 100", 400);
+      return;
+    }
+
+    const assetFilter = typeof req.query.asset === "string" ? req.query.asset.toUpperCase() : null;
+
+    const now = Date.now();
+    let allPools: PoolSummary[];
+    let fromCache: boolean;
+
+    if (cachedPools && now - cacheTimestamp < CACHE_TTL_MS) {
+      allPools = cachedPools;
+      fromCache = true;
+    } else {
+      allPools = poolsStore.map((p) => ({ ...p }));
+      cachedPools = allPools;
+      cacheTimestamp = now;
+      fromCache = false;
+    }
+
+    const filtered = assetFilter
+      ? allPools.filter(
+          (p) =>
+            p.assetA.code.toUpperCase() === assetFilter ||
+            p.assetB.code.toUpperCase() === assetFilter,
+        )
+      : allPools;
+
+    const total = filtered.length;
+    const offset = (page - 1) * limit;
+    const paginated = filtered.slice(offset, offset + limit);
+
+    return res.status(200).json({
+      success: true,
+      data: { pools: paginated, fromCache },
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 1,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/defi.swap.quote.ts
+++ b/routes-d/routes/defi.swap.quote.ts
@@ -1,0 +1,134 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Asset = {
+  code: string;
+  issuer?: string;
+};
+
+type QuoteBody = {
+  fromAsset: Asset;
+  toAsset: Asset;
+  amount: string;
+};
+
+type QuoteResult = {
+  fromAsset: Asset;
+  toAsset: Asset;
+  inputAmount: string;
+  outputAmount: string;
+  fees: { protocol: string; network: string };
+  priceImpact: string;
+  fromCache: boolean;
+};
+
+type PairConfig = {
+  outputRatio: number;
+  priceImpact: string;
+  fees: { protocol: string; network: string };
+};
+
+const knownPairs = new Map<string, PairConfig>([
+  ["USDC:XLM", { outputRatio: 0.997, priceImpact: "0.04", fees: { protocol: "0.30", network: "0.01" } }],
+  ["BTC:XLM", { outputRatio: 0.940, priceImpact: "5.20", fees: { protocol: "0.50", network: "0.10" } }],
+]);
+
+const CACHE_TTL_MS = 5_000;
+const quoteCache = new Map<string, { data: QuoteResult; expires: number }>();
+
+export function __resetQuoteCache(): void {
+  quoteCache.clear();
+}
+
+export function __seedQuoteCache(key: string, data: QuoteResult): void {
+  quoteCache.set(key, { data, expires: Date.now() + CACHE_TTL_MS });
+}
+
+router.post("/defi/swap/quote", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const body = req.body as QuoteBody;
+
+    if (!body.fromAsset || typeof body.fromAsset !== "object") {
+      sendError(res, "INVALID_FROM_ASSET", "fromAsset is required and must be an object", 400);
+      return;
+    }
+
+    if (!body.fromAsset.code || typeof body.fromAsset.code !== "string") {
+      sendError(res, "INVALID_FROM_ASSET_CODE", "fromAsset.code is required and must be a string", 400);
+      return;
+    }
+
+    if (!body.toAsset || typeof body.toAsset !== "object") {
+      sendError(res, "INVALID_TO_ASSET", "toAsset is required and must be an object", 400);
+      return;
+    }
+
+    if (!body.toAsset.code || typeof body.toAsset.code !== "string") {
+      sendError(res, "INVALID_TO_ASSET_CODE", "toAsset.code is required and must be a string", 400);
+      return;
+    }
+
+    if (!body.amount || typeof body.amount !== "string") {
+      sendError(res, "INVALID_AMOUNT", "amount is required and must be a string", 400);
+      return;
+    }
+
+    const amountNum = parseFloat(body.amount);
+    if (isNaN(amountNum) || amountNum <= 0) {
+      sendError(res, "INVALID_AMOUNT", "amount must be a positive number", 400);
+      return;
+    }
+
+    if (
+      body.fromAsset.code === body.toAsset.code &&
+      body.fromAsset.issuer === body.toAsset.issuer
+    ) {
+      sendError(res, "INVALID_ASSET_PAIR", "fromAsset and toAsset cannot be the same", 400);
+      return;
+    }
+
+    const pairKey = `${body.fromAsset.code}:${body.toAsset.code}`;
+    const pairConfig = knownPairs.get(pairKey);
+
+    if (!pairConfig) {
+      sendError(res, "UNKNOWN_PAIR", "No liquidity path found for the requested asset pair", 422);
+      return;
+    }
+
+    const cacheKey = `${pairKey}:${body.amount}`;
+    const now = Date.now();
+    const cached = quoteCache.get(cacheKey);
+
+    if (cached && cached.expires > now) {
+      return res.status(201).json({
+        success: true,
+        data: { ...cached.data, fromCache: true },
+      });
+    }
+
+    const outputAmount = (amountNum * pairConfig.outputRatio).toFixed(7);
+
+    const result: QuoteResult = {
+      fromAsset: body.fromAsset,
+      toAsset: body.toAsset,
+      inputAmount: body.amount,
+      outputAmount,
+      fees: pairConfig.fees,
+      priceImpact: pairConfig.priceImpact,
+      fromCache: false,
+    };
+
+    quoteCache.set(cacheKey, { data: result, expires: now + CACHE_TTL_MS });
+
+    return res.status(201).json({
+      success: true,
+      data: result,
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/defi.yields.get.ts
+++ b/routes-d/routes/defi.yields.get.ts
@@ -1,0 +1,97 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type YieldStrategy = {
+  id: string;
+  name: string;
+  protocol: string;
+  asset: string;
+  grossApy: string;
+  feeRate: string;
+  netApy: string;
+};
+
+const DEFAULT_STRATEGIES: YieldStrategy[] = [
+  { id: "phoenix-btc-xlm", name: "Phoenix BTC/XLM", protocol: "Phoenix", asset: "BTC", grossApy: "12.00", feeRate: "0.50", netApy: "11.50" },
+  { id: "aqua-usdc", name: "Aqua USDC Pool", protocol: "Aqua", asset: "USDC", grossApy: "8.50", feeRate: "0.30", netApy: "8.20" },
+  { id: "aqua-xlm", name: "Aqua XLM Pool", protocol: "Aqua", asset: "XLM", grossApy: "5.20", feeRate: "0.30", netApy: "4.90" },
+];
+
+const CACHE_TTL_MS = 30_000;
+
+let strategies: YieldStrategy[] = [...DEFAULT_STRATEGIES];
+let cachedYields: YieldStrategy[] | null = null;
+let cacheTimestamp = 0;
+let fetchAvailable = true;
+
+export function __resetYieldsCache(): void {
+  cachedYields = null;
+  cacheTimestamp = 0;
+  fetchAvailable = true;
+  strategies = [...DEFAULT_STRATEGIES];
+}
+
+export function __setStrategies(data: YieldStrategy[]): void {
+  strategies = data;
+}
+
+export function __seedYieldsCache(data: YieldStrategy[]): void {
+  cachedYields = [...data];
+  cacheTimestamp = 0;
+}
+
+export function __setFetchAvailable(v: boolean): void {
+  fetchAvailable = v;
+}
+
+function fetchStrategies(): YieldStrategy[] {
+  if (!fetchAvailable) {
+    throw new Error("Yield data source unavailable");
+  }
+  return strategies.map((s) => ({ ...s }));
+}
+
+function rankByNetApy(list: YieldStrategy[]): YieldStrategy[] {
+  return [...list].sort((a, b) => parseFloat(b.netApy) - parseFloat(a.netApy));
+}
+
+router.get("/defi/yields", async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const now = Date.now();
+
+    if (cachedYields && now - cacheTimestamp < CACHE_TTL_MS) {
+      return res.status(200).json({
+        success: true,
+        data: { yields: rankByNetApy(cachedYields), fromCache: true },
+      });
+    }
+
+    let fresh: YieldStrategy[];
+    try {
+      fresh = fetchStrategies();
+    } catch {
+      if (cachedYields) {
+        return res.status(200).json({
+          success: true,
+          data: { yields: rankByNetApy(cachedYields), fromCache: true, stale: true },
+        });
+      }
+      sendError(res, "YIELDS_UNAVAILABLE", "Yield data is currently unavailable", 503);
+      return;
+    }
+
+    cachedYields = fresh;
+    cacheTimestamp = now;
+
+    return res.status(200).json({
+      success: true,
+      data: { yields: rankByNetApy(fresh), fromCache: false },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/wallets.backupHint.ts
+++ b/routes-d/routes/wallets.backupHint.ts
@@ -1,0 +1,67 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+export const MAX_BLOB_BYTES = 4096;
+
+type BackupHintBody = {
+  walletId: string;
+  ciphertext: string;
+};
+
+type HintRecord = {
+  walletId: string;
+  ciphertext: string;
+  storedAt: string;
+};
+
+const hintStore = new Map<string, HintRecord>();
+
+export function __resetHintStore(): void {
+  hintStore.clear();
+}
+
+export function __getHint(walletId: string): HintRecord | undefined {
+  return hintStore.get(walletId);
+}
+
+router.post("/wallets/backup-hint", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.headers["x-user-id"] as string | undefined;
+
+    if (!userId) {
+      sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+      return;
+    }
+
+    const body = req.body as BackupHintBody;
+
+    if (!body.walletId || typeof body.walletId !== "string") {
+      sendError(res, "INVALID_WALLET_ID", "walletId is required", 400);
+      return;
+    }
+
+    if (!body.ciphertext || typeof body.ciphertext !== "string") {
+      sendError(res, "INVALID_CIPHERTEXT", "ciphertext is required", 400);
+      return;
+    }
+
+    if (body.ciphertext.length > MAX_BLOB_BYTES) {
+      sendError(res, "BLOB_TOO_LARGE", `ciphertext must not exceed ${MAX_BLOB_BYTES} bytes`, 400);
+      return;
+    }
+
+    const storedAt = new Date().toISOString();
+    hintStore.set(body.walletId, { walletId: body.walletId, ciphertext: body.ciphertext, storedAt });
+
+    return res.status(201).json({
+      success: true,
+      data: { walletId: body.walletId, storedAt },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/wallets.backupHint.ts
+++ b/routes-d/routes/wallets.backupHint.ts
@@ -12,6 +12,7 @@ type BackupHintBody = {
 
 type HintRecord = {
   walletId: string;
+  ownerUserId: string;
   ciphertext: string;
   storedAt: string;
 };
@@ -52,8 +53,14 @@ router.post("/wallets/backup-hint", async (req: Request, res: Response, next: Ne
       return;
     }
 
+    const existing = hintStore.get(body.walletId);
+    if (existing && existing.ownerUserId !== userId) {
+      sendError(res, "FORBIDDEN", "wallet does not belong to this user", 403);
+      return;
+    }
+
     const storedAt = new Date().toISOString();
-    hintStore.set(body.walletId, { walletId: body.walletId, ciphertext: body.ciphertext, storedAt });
+    hintStore.set(body.walletId, { walletId: body.walletId, ownerUserId: userId, ciphertext: body.ciphertext, storedAt });
 
     return res.status(201).json({
       success: true,

--- a/routes-d/tests/defi.pools.list.test.ts
+++ b/routes-d/tests/defi.pools.list.test.ts
@@ -1,0 +1,163 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import poolsListRouter, {
+  __resetPoolsListCache,
+  __seedPoolsList,
+} from "../routes/defi.pools.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(poolsListRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const samplePools = [
+  {
+    id: "pool-usdc-xlm",
+    assetA: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", amount: "1000000.00" },
+    assetB: { code: "XLM", issuer: "native", amount: "50000000.00" },
+    totalShares: "7071067.81",
+    apyEstimate: "5.04",
+  },
+  {
+    id: "pool-btc-xlm",
+    assetA: { code: "BTC", issuer: "GDPJALI4AZKUU2W426U5WKMAT6CN3AJRPIIRYR2YM54TL2GDWO5O2MZM", amount: "10.00" },
+    assetB: { code: "XLM", issuer: "native", amount: "2000000.00" },
+    totalShares: "4472.13",
+    apyEstimate: "7.20",
+  },
+  {
+    id: "pool-usdt-xlm",
+    assetA: { code: "USDT", issuer: "GCQTGZQQ5G4PTM2GL7CDIFKUBIPEC52BROAQIAPW53NMYVOZ3A7EKV68", amount: "500000.00" },
+    assetB: { code: "XLM", issuer: "native", amount: "25000000.00" },
+    totalShares: "3535533.90",
+    apyEstimate: "4.80",
+  },
+];
+
+describe("GET /defi/pools", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetPoolsListCache();
+  });
+
+  it("returns 200 with all pools when no filter is applied", async () => {
+    const res = await request(app).get("/defi/pools");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.pools.length).toBe(3);
+    expect(res.body.pagination.total).toBe(3);
+  });
+
+  it("filters pools by assetA code (uppercase)", async () => {
+    const res = await request(app).get("/defi/pools?asset=USDC");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pools.length).toBe(1);
+    expect(res.body.data.pools[0].id).toBe("pool-usdc-xlm");
+    expect(res.body.pagination.total).toBe(1);
+  });
+
+  it("filters pools by assetB code (XLM appears in all three pools)", async () => {
+    const res = await request(app).get("/defi/pools?asset=XLM");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pools.length).toBe(3);
+  });
+
+  it("asset filter is case-insensitive", async () => {
+    const upper = await request(app).get("/defi/pools?asset=USDC");
+    const lower = await request(app).get("/defi/pools?asset=usdc");
+
+    expect(upper.status).toBe(200);
+    expect(lower.status).toBe(200);
+    expect(lower.body.data.pools.length).toBe(upper.body.data.pools.length);
+    expect(lower.body.data.pools[0].id).toBe(upper.body.data.pools[0].id);
+  });
+
+  it("returns empty pools array and total 0 when filter matches nothing", async () => {
+    const res = await request(app).get("/defi/pools?asset=UNKNOWN");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pools).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("paginates results correctly", async () => {
+    const res = await request(app).get("/defi/pools?page=2&limit=1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pools.length).toBe(1);
+    expect(res.body.pagination.page).toBe(2);
+    expect(res.body.pagination.limit).toBe(1);
+    expect(res.body.pagination.total).toBe(3);
+    expect(res.body.pagination.totalPages).toBe(3);
+  });
+
+  it("returns fromCache: false on first call", async () => {
+    const res = await request(app).get("/defi/pools");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.fromCache).toBe(false);
+  });
+
+  it("returns fromCache: true on a second call within the TTL window", async () => {
+    await request(app).get("/defi/pools");
+    const res = await request(app).get("/defi/pools");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.fromCache).toBe(true);
+  });
+
+  it("returns 400 INVALID_PAGINATION when page is 0", async () => {
+    const res = await request(app).get("/defi/pools?page=0");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGINATION");
+  });
+
+  it("returns 400 INVALID_PAGINATION when limit is 0", async () => {
+    const res = await request(app).get("/defi/pools?limit=0");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGINATION");
+  });
+
+  it("returns 400 INVALID_PAGINATION when limit exceeds MAX_LIMIT", async () => {
+    const res = await request(app).get("/defi/pools?limit=101");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGINATION");
+  });
+
+  it("response has correct shape with all required fields", async () => {
+    const res = await request(app).get("/defi/pools");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("success", true);
+    expect(res.body).toHaveProperty("data");
+    expect(res.body.data).toHaveProperty("pools");
+    expect(res.body.data).toHaveProperty("fromCache");
+    expect(res.body).toHaveProperty("pagination");
+    expect(res.body.pagination).toHaveProperty("page");
+    expect(res.body.pagination).toHaveProperty("limit");
+    expect(res.body.pagination).toHaveProperty("total");
+    expect(res.body.pagination).toHaveProperty("totalPages");
+  });
+
+  it("reflects seeded pools after __seedPoolsList", async () => {
+    __seedPoolsList(samplePools.slice(0, 1));
+
+    const res = await request(app).get("/defi/pools");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pools.length).toBe(1);
+    expect(res.body.data.pools[0].id).toBe("pool-usdc-xlm");
+  });
+});

--- a/routes-d/tests/defi.swap.quote.test.ts
+++ b/routes-d/tests/defi.swap.quote.test.ts
@@ -1,0 +1,194 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import swapQuoteRouter, {
+  __resetQuoteCache,
+  __seedQuoteCache,
+} from "../routes/defi.swap.quote.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(swapQuoteRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /defi/swap/quote", () => {
+  const app = buildApp();
+
+  const deepLiquidityRequest = {
+    fromAsset: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" },
+    toAsset: { code: "XLM" },
+    amount: "100",
+  };
+
+  const thinLiquidityRequest = {
+    fromAsset: { code: "BTC", issuer: "GDPJALI4AZKUU2W426U5WKMAT6CN3AJRPIIRYR2YM54TL2GDWO5O2MZM" },
+    toAsset: { code: "XLM" },
+    amount: "1",
+  };
+
+  beforeEach(() => {
+    __resetQuoteCache();
+  });
+
+  it("returns 201 with a low priceImpact for a deep liquidity pair", async () => {
+    const res = await request(app).post("/defi/swap/quote").send(deepLiquidityRequest);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(parseFloat(res.body.data.priceImpact)).toBeLessThanOrEqual(0.05);
+    expect(res.body.data.fromCache).toBe(false);
+  });
+
+  it("returns 201 with a high priceImpact for a thin liquidity pair", async () => {
+    const res = await request(app).post("/defi/swap/quote").send(thinLiquidityRequest);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(parseFloat(res.body.data.priceImpact)).toBeGreaterThanOrEqual(5);
+    expect(res.body.data.fromCache).toBe(false);
+  });
+
+  it("returns 422 UNKNOWN_PAIR for an unrecognised asset pair", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { code: "EXOTIC" },
+      toAsset: { code: "RARE" },
+      amount: "10",
+    });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe("UNKNOWN_PAIR");
+  });
+
+  it("returns 400 INVALID_ASSET_PAIR when fromAsset and toAsset are the same", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" },
+      toAsset: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" },
+      amount: "50",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_ASSET_PAIR");
+  });
+
+  it("returns fromCache: true on a second identical request within the TTL window", async () => {
+    await request(app).post("/defi/swap/quote").send(deepLiquidityRequest);
+    const res = await request(app).post("/defi/swap/quote").send(deepLiquidityRequest);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.fromCache).toBe(true);
+  });
+
+  it("returns 400 INVALID_FROM_ASSET when fromAsset is missing", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      toAsset: { code: "XLM" },
+      amount: "10",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_FROM_ASSET");
+  });
+
+  it("returns 400 INVALID_FROM_ASSET_CODE when fromAsset.code is missing", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" },
+      toAsset: { code: "XLM" },
+      amount: "10",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_FROM_ASSET_CODE");
+  });
+
+  it("returns 400 INVALID_TO_ASSET when toAsset is missing", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { code: "USDC" },
+      amount: "10",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_TO_ASSET");
+  });
+
+  it("returns 400 INVALID_TO_ASSET_CODE when toAsset.code is missing", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { code: "USDC" },
+      toAsset: {},
+      amount: "10",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_TO_ASSET_CODE");
+  });
+
+  it("returns 400 INVALID_AMOUNT when amount is zero", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      ...deepLiquidityRequest,
+      amount: "0",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns 400 INVALID_AMOUNT when amount is negative", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      ...deepLiquidityRequest,
+      amount: "-10",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns 400 INVALID_AMOUNT when amount is missing", async () => {
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { code: "USDC" },
+      toAsset: { code: "XLM" },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("response data has the expected shape", async () => {
+    const res = await request(app).post("/defi/swap/quote").send(deepLiquidityRequest);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("fromAsset");
+    expect(res.body.data).toHaveProperty("toAsset");
+    expect(res.body.data).toHaveProperty("inputAmount");
+    expect(res.body.data).toHaveProperty("outputAmount");
+    expect(res.body.data).toHaveProperty("fees");
+    expect(res.body.data.fees).toHaveProperty("protocol");
+    expect(res.body.data.fees).toHaveProperty("network");
+    expect(res.body.data).toHaveProperty("priceImpact");
+    expect(res.body.data).toHaveProperty("fromCache");
+  });
+
+  it("seeded cache entry is returned as a cache hit", async () => {
+    const seedData = {
+      fromAsset: { code: "USDC" },
+      toAsset: { code: "XLM" },
+      inputAmount: "50",
+      outputAmount: "49.850",
+      fees: { protocol: "0.30", network: "0.01" },
+      priceImpact: "0.04",
+      fromCache: false,
+    };
+    __seedQuoteCache("USDC:XLM:50", seedData);
+
+    const res = await request(app).post("/defi/swap/quote").send({
+      fromAsset: { code: "USDC" },
+      toAsset: { code: "XLM" },
+      amount: "50",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.fromCache).toBe(true);
+    expect(res.body.data.outputAmount).toBe("49.850");
+  });
+});

--- a/routes-d/tests/defi.yields.get.test.ts
+++ b/routes-d/tests/defi.yields.get.test.ts
@@ -1,0 +1,113 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import yieldsRouter, {
+  __resetYieldsCache,
+  __setStrategies,
+  __seedYieldsCache,
+  __setFetchAvailable,
+} from "../routes/defi.yields.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(yieldsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /defi/yields", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetYieldsCache();
+  });
+
+  it("returns 200 with an empty yields array when no strategies are registered", async () => {
+    __setStrategies([]);
+
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.yields).toEqual([]);
+    expect(res.body.data.fromCache).toBe(false);
+  });
+
+  it("returns yields ranked by netApy descending", async () => {
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const yields = res.body.data.yields;
+    expect(yields.length).toBeGreaterThan(1);
+
+    for (let i = 0; i < yields.length - 1; i++) {
+      expect(parseFloat(yields[i].netApy)).toBeGreaterThanOrEqual(parseFloat(yields[i + 1].netApy));
+    }
+
+    expect(yields[0].id).toBe("phoenix-btc-xlm");
+  });
+
+  it("returns fromCache: false on the first (fresh) fetch", async () => {
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.fromCache).toBe(false);
+  });
+
+  it("returns fromCache: true on a second call within the TTL window", async () => {
+    await request(app).get("/defi/yields");
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.fromCache).toBe(true);
+  });
+
+  it("returns stale cached data with stale: true when fetch fails but cache exists", async () => {
+    __seedYieldsCache([
+      { id: "stale-strategy", name: "Stale Pool", protocol: "OldPro", asset: "XLM", grossApy: "3.00", feeRate: "0.10", netApy: "2.90" },
+    ]);
+    __setFetchAvailable(false);
+
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.fromCache).toBe(true);
+    expect(res.body.data.stale).toBe(true);
+    expect(res.body.data.yields[0].id).toBe("stale-strategy");
+  });
+
+  it("returns 503 YIELDS_UNAVAILABLE when fetch fails and no cache exists", async () => {
+    __setFetchAvailable(false);
+
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe("YIELDS_UNAVAILABLE");
+  });
+
+  it("each yield strategy has the expected shape", async () => {
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    const strategy = res.body.data.yields[0];
+    expect(strategy).toHaveProperty("id");
+    expect(strategy).toHaveProperty("name");
+    expect(strategy).toHaveProperty("protocol");
+    expect(strategy).toHaveProperty("asset");
+    expect(strategy).toHaveProperty("grossApy");
+    expect(strategy).toHaveProperty("feeRate");
+    expect(strategy).toHaveProperty("netApy");
+  });
+
+  it("does not include stale field on a successful fresh fetch", async () => {
+    const res = await request(app).get("/defi/yields");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).not.toHaveProperty("stale");
+  });
+});

--- a/routes-d/tests/wallets.backupHint.test.ts
+++ b/routes-d/tests/wallets.backupHint.test.ts
@@ -1,0 +1,153 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import backupHintRouter, {
+  __resetHintStore,
+  __getHint,
+  MAX_BLOB_BYTES,
+} from "../routes/wallets.backupHint.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(backupHintRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /wallets/backup-hint", () => {
+  const app = buildApp();
+
+  const validRequest = {
+    walletId: "wallet-abc",
+    ciphertext: "U2FsdGVkX1+encryptedpayloadhere==",
+  };
+
+  const authHeader = { "x-user-id": "user-xyz" };
+
+  beforeEach(() => {
+    __resetHintStore();
+  });
+
+  it("returns 201 with walletId and storedAt on a valid request", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send(validRequest);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.walletId).toBe(validRequest.walletId);
+    expect(typeof res.body.data.storedAt).toBe("string");
+    expect(new Date(res.body.data.storedAt).getTime()).not.toBeNaN();
+  });
+
+  it("does not echo the ciphertext back in the response body", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send(validRequest);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).not.toHaveProperty("ciphertext");
+    expect(JSON.stringify(res.body)).not.toContain(validRequest.ciphertext);
+  });
+
+  it("accepts a ciphertext exactly at MAX_BLOB_BYTES length", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ...validRequest, ciphertext: "a".repeat(MAX_BLOB_BYTES) });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 400 BLOB_TOO_LARGE when ciphertext exceeds MAX_BLOB_BYTES", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ...validRequest, ciphertext: "a".repeat(MAX_BLOB_BYTES + 1) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("BLOB_TOO_LARGE");
+  });
+
+  it("returns 401 UNAUTHORIZED when x-user-id header is missing", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .send(validRequest);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 INVALID_WALLET_ID when walletId is empty", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ...validRequest, walletId: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_WALLET_ID");
+  });
+
+  it("returns 400 INVALID_WALLET_ID when walletId is missing", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ciphertext: validRequest.ciphertext });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_WALLET_ID");
+  });
+
+  it("returns 400 INVALID_CIPHERTEXT when ciphertext is empty", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ...validRequest, ciphertext: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CIPHERTEXT");
+  });
+
+  it("returns 400 INVALID_CIPHERTEXT when ciphertext is missing", async () => {
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ walletId: validRequest.walletId });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CIPHERTEXT");
+  });
+
+  it("overwrites an existing hint for the same walletId (upsert)", async () => {
+    await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ...validRequest, ciphertext: "first-ciphertext" });
+
+    await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send({ ...validRequest, ciphertext: "second-ciphertext" });
+
+    const stored = __getHint(validRequest.walletId);
+    expect(stored?.ciphertext).toBe("second-ciphertext");
+  });
+
+  it("__getHint returns the stored record including ciphertext", async () => {
+    await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send(validRequest);
+
+    const stored = __getHint(validRequest.walletId);
+
+    expect(stored).toBeDefined();
+    expect(stored?.walletId).toBe(validRequest.walletId);
+    expect(stored?.ciphertext).toBe(validRequest.ciphertext);
+    expect(typeof stored?.storedAt).toBe("string");
+  });
+});

--- a/routes-d/tests/wallets.backupHint.test.ts
+++ b/routes-d/tests/wallets.backupHint.test.ts
@@ -122,7 +122,7 @@ describe("POST /wallets/backup-hint", () => {
     expect(res.body.error.code).toBe("INVALID_CIPHERTEXT");
   });
 
-  it("overwrites an existing hint for the same walletId (upsert)", async () => {
+  it("overwrites an existing hint for the same walletId when the owner matches (upsert)", async () => {
     await request(app)
       .post("/wallets/backup-hint")
       .set(authHeader)
@@ -135,6 +135,21 @@ describe("POST /wallets/backup-hint", () => {
 
     const stored = __getHint(validRequest.walletId);
     expect(stored?.ciphertext).toBe("second-ciphertext");
+  });
+
+  it("returns 403 FORBIDDEN when a different user tries to overwrite another user's hint", async () => {
+    await request(app)
+      .post("/wallets/backup-hint")
+      .set(authHeader)
+      .send(validRequest);
+
+    const res = await request(app)
+      .post("/wallets/backup-hint")
+      .set({ "x-user-id": "different-user" })
+      .send(validRequest);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
   });
 
   it("__getHint returns the stored record including ciphertext", async () => {


### PR DESCRIPTION
  ## Summary

  Adds four new route handlers inside `routes-d/routes/` with matching test files under `routes-d/tests/`.

  | Issue | Route file | HTTP route |
  |-------|-----------|------------|
  | #502 | `routes-d/routes/defi.yields.get.ts` | `GET /defi/yields` |
  | #495 | `routes-d/routes/wallets.backupHint.ts` | `POST /wallets/backup-hint` |
  | #497 | `routes-d/routes/defi.pools.list.ts` | `GET /defi/pools` |
  | #504 | `routes-d/routes/defi.swap.quote.ts` | `POST /defi/swap/quote` |

  ## What Changed

  - **`defi.yields.get.ts`** — Aggregates yield strategies ranked by net APY after fees; 30s TTL cache with stale-data
  fallback when fresh fetch is unavailable.
  - **`defi.pools.list.ts`** — Lists Stellar liquidity pools with case-insensitive asset filtering and offset pagination; 15s
  TTL cache.
  - **`defi.swap.quote.ts`** — Returns price-impact-aware swap quote (output amount, fees, price impact) for known pairs; 5s
  quote cache keyed by pair + amount.
  - **`wallets.backupHint.ts`** — Stores encrypted backup hint blobs (zero-knowledge: server never sees plaintext); enforces
  `MAX_BLOB_BYTES = 4096` cap; ownership check prevents IDOR overwrites.

  ## Test Coverage

  | Route | Scenarios |
  |-------|-----------|
  | `/defi/yields` | empty list, ranked order, fromCache false → true, stale fallback, 503 when no cache |
  | `/defi/pools` | no filter, asset filter (case-insensitive, assetA and assetB), zero match, pagination, invalid
  pagination, cache hit |
  | `/defi/swap/quote` | deep liquidity, thin liquidity, unknown pair, same-asset guard, cache hit, missing field validation
  |
  | `/wallets/backup-hint` | save success, ciphertext not echoed, boundary blob size, oversize → 400, auth guard, ownership
  guard → 403, upsert semantics |

  ## Closes

  Closes #502
  Closes #495
  Closes #497
  Closes #504