### PR TITLE
feat(routes-d): NFT detail, collections list, collection items, and anchor assets routes

### DIFF
--- a/routes-d/routes/anchors.assets.ts
+++ b/routes-d/routes/anchors.assets.ts
@@ -1,0 +1,74 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type AnchorAsset = {
+  code: string;
+  issuer: string;
+  minAmount?: string;
+  maxAmount?: string;
+  depositEnabled: boolean;
+  withdrawEnabled: boolean;
+};
+
+type AnchorAssetResponse = Omit<AnchorAsset, "minAmount" | "maxAmount"> & {
+  minAmount: string | null;
+  maxAmount: string | null;
+};
+
+type AnchorRecord = {
+  id: string;
+  name: string;
+  assets: AnchorAsset[];
+};
+
+const CACHE_TTL_MS = 30_000;
+
+const anchorsStore = new Map<string, AnchorRecord>();
+const assetsCache = new Map<string, { data: AnchorAssetResponse[]; ts: number }>();
+
+export function __seedAnchor(id: string, record: AnchorRecord): void {
+  anchorsStore.set(id, record);
+  assetsCache.delete(id);
+}
+
+export function __resetAnchorsAssets(): void {
+  anchorsStore.clear();
+  assetsCache.clear();
+}
+
+router.get("/anchors/:id/assets", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+
+    const anchor = anchorsStore.get(id);
+    if (!anchor) {
+      sendError(res, "ANCHOR_NOT_FOUND", `Anchor ${id} not found`, 404);
+      return;
+    }
+
+    const now = Date.now();
+    const cached = assetsCache.get(id);
+    if (cached && now - cached.ts < CACHE_TTL_MS) {
+      return res.status(200).json({ success: true, data: cached.data, fromCache: true });
+    }
+
+    const assets: AnchorAssetResponse[] = anchor.assets.map((asset) => ({
+      code:            asset.code,
+      issuer:          asset.issuer,
+      minAmount:       asset.minAmount ?? null,
+      maxAmount:       asset.maxAmount ?? null,
+      depositEnabled:  asset.depositEnabled,
+      withdrawEnabled: asset.withdrawEnabled,
+    }));
+
+    assetsCache.set(id, { data: assets, ts: now });
+
+    return res.status(200).json({ success: true, data: assets, fromCache: false });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/nfts.collection.items.ts
+++ b/routes-d/routes/nfts.collection.items.ts
@@ -1,0 +1,95 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type TraitAttribute = {
+  trait_type: string;
+  value: string;
+};
+
+type DisplayMetadata = {
+  name: string;
+  image?: string;
+  attributes?: TraitAttribute[];
+};
+
+type CollectionItem = {
+  id: string;
+  tokenId: string;
+  collectionId: string;
+  ownerUserId: string;
+  acquiredAt: string;
+};
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const itemsByCollection = new Map<string, CollectionItem[]>();
+const metadataByToken = new Map<string, DisplayMetadata>();
+
+export function __seedCollectionItems(collectionId: string, items: CollectionItem[]): void {
+  itemsByCollection.set(collectionId, items);
+}
+
+export function __seedCollectionItemMetadata(tokenId: string, metadata: DisplayMetadata): void {
+  metadataByToken.set(tokenId, metadata);
+}
+
+export function __resetCollectionItems(): void {
+  itemsByCollection.clear();
+  metadataByToken.clear();
+}
+
+router.get("/collections/:id/items", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+    const page = req.query.page !== undefined ? parseInt(req.query.page as string, 10) : DEFAULT_PAGE;
+    const limit = req.query.limit !== undefined ? parseInt(req.query.limit as string, 10) : DEFAULT_LIMIT;
+
+    if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+      sendError(res, "INVALID_PAGINATION", "page must be >= 1 and limit must be between 1 and 100", 400);
+      return;
+    }
+
+    const traitType = typeof req.query.trait_type === "string" ? req.query.trait_type : null;
+    const traitValue = typeof req.query.trait_value === "string" ? req.query.trait_value : null;
+
+    const allItems = itemsByCollection.get(id) ?? [];
+
+    const filtered =
+      traitType && traitValue
+        ? allItems.filter((item) => {
+            const meta = metadataByToken.get(item.tokenId);
+            return (
+              meta?.attributes?.some(
+                (attr) => attr.trait_type === traitType && attr.value === traitValue,
+              ) ?? false
+            );
+          })
+        : allItems;
+
+    const total = filtered.length;
+    const offset = (page - 1) * limit;
+    const paginated = filtered.slice(offset, offset + limit).map((item) => ({
+      ...item,
+      displayMetadata: metadataByToken.get(item.tokenId) ?? null,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      data: paginated,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 1,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/nfts.collections.list.ts
+++ b/routes-d/routes/nfts.collections.list.ts
@@ -1,0 +1,93 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type NftCollection = {
+  id: string;
+  name: string;
+  category: string;
+  floorPrice: string;
+  volume24h: string;
+  itemCount: number;
+};
+
+const CACHE_TTL_MS = 10_000;
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+let collectionsStore: NftCollection[] = [];
+let cachedCollections: NftCollection[] | null = null;
+let cacheTimestamp = 0;
+
+export function __seedCollectionsList(collections: NftCollection[]): void {
+  collectionsStore = [...collections];
+  cachedCollections = null;
+  cacheTimestamp = 0;
+}
+
+export function __resetCollectionsList(): void {
+  collectionsStore = [];
+  cachedCollections = null;
+  cacheTimestamp = 0;
+}
+
+router.get("/nfts/collections", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const page = req.query.page !== undefined ? parseInt(req.query.page as string, 10) : DEFAULT_PAGE;
+    const limit = req.query.limit !== undefined ? parseInt(req.query.limit as string, 10) : DEFAULT_LIMIT;
+
+    if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+      sendError(res, "INVALID_PAGINATION", "page must be >= 1 and limit must be between 1 and 100", 400);
+      return;
+    }
+
+    const categoryFilter = typeof req.query.category === "string" ? req.query.category.toLowerCase() : null;
+    const sortBy = typeof req.query.sortBy === "string" ? req.query.sortBy : null;
+
+    const now = Date.now();
+    let allCollections: NftCollection[];
+    let fromCache: boolean;
+
+    if (cachedCollections && now - cacheTimestamp < CACHE_TTL_MS) {
+      allCollections = cachedCollections;
+      fromCache = true;
+    } else {
+      allCollections = collectionsStore.map((c) => ({ ...c }));
+      cachedCollections = allCollections;
+      cacheTimestamp = now;
+      fromCache = false;
+    }
+
+    const filtered = categoryFilter
+      ? allCollections.filter((c) => c.category.toLowerCase() === categoryFilter)
+      : allCollections;
+
+    const sorted = [...filtered];
+    if (sortBy === "floorPrice") {
+      sorted.sort((a, b) => parseFloat(b.floorPrice) - parseFloat(a.floorPrice));
+    } else if (sortBy === "volume") {
+      sorted.sort((a, b) => parseFloat(b.volume24h) - parseFloat(a.volume24h));
+    }
+
+    const total = sorted.length;
+    const offset = (page - 1) * limit;
+    const paginated = sorted.slice(offset, offset + limit);
+
+    return res.status(200).json({
+      success: true,
+      data: { collections: paginated, fromCache },
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 1,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/routes/nfts.get.ts
+++ b/routes-d/routes/nfts.get.ts
@@ -1,0 +1,81 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type TraitAttribute = {
+  trait_type: string;
+  value: string;
+};
+
+type DisplayMetadata = {
+  name: string;
+  image?: string;
+  description?: string;
+  attributes?: TraitAttribute[];
+};
+
+type NftRecord = {
+  id: string;
+  tokenId: string;
+  collectionId: string;
+  ownerUserId: string;
+  acquiredAt: string;
+  onChainData?: Record<string, unknown>;
+  displayMetadata?: DisplayMetadata;
+};
+
+type NftResponse = Omit<NftRecord, "displayMetadata"> & {
+  displayMetadata: DisplayMetadata | null;
+};
+
+const CACHE_TTL_MS = 30_000;
+
+const nftStore = new Map<string, NftRecord>();
+const responseCache = new Map<string, { data: NftResponse; ts: number }>();
+
+export function __seedNft(id: string, record: NftRecord): void {
+  nftStore.set(id, record);
+  responseCache.delete(id);
+}
+
+export function __resetNftGet(): void {
+  nftStore.clear();
+  responseCache.clear();
+}
+
+router.get("/nfts/:id", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+
+    const now = Date.now();
+    const cached = responseCache.get(id);
+    if (cached && now - cached.ts < CACHE_TTL_MS) {
+      return res.status(200).json({ success: true, data: cached.data, fromCache: true });
+    }
+
+    const record = nftStore.get(id);
+    if (!record) {
+      sendError(res, "NFT_NOT_FOUND", `NFT ${id} not found`, 404);
+      return;
+    }
+
+    const assembled: NftResponse = {
+      id:            record.id,
+      tokenId:       record.tokenId,
+      collectionId:  record.collectionId,
+      ownerUserId:   record.ownerUserId,
+      acquiredAt:    record.acquiredAt,
+      onChainData:   record.onChainData,
+      displayMetadata: record.displayMetadata ?? null,
+    };
+
+    responseCache.set(id, { data: assembled, ts: now });
+
+    return res.status(200).json({ success: true, data: assembled, fromCache: false });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/routes-d/tests/anchors.assets.test.ts
+++ b/routes-d/tests/anchors.assets.test.ts
@@ -1,0 +1,78 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import anchorsAssetsRouter, {
+  __resetAnchorsAssets,
+  __seedAnchor,
+} from "../routes/anchors.assets.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(anchorsAssetsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /anchors/:id/assets", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetAnchorsAssets();
+  });
+
+  it("returns 404 for an unknown anchor", async () => {
+    const res = await request(app).get("/anchors/unknown-anchor/assets");
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("ANCHOR_NOT_FOUND");
+  });
+
+  it("returns all assets with min and max amounts for a known anchor", async () => {
+    __seedAnchor("anchor-1", {
+      id: "anchor-1",
+      name: "Test Anchor",
+      assets: [
+        {
+          code: "USDC",
+          issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          minAmount: "10.00",
+          maxAmount: "50000.00",
+          depositEnabled: true,
+          withdrawEnabled: true,
+        },
+      ],
+    });
+
+    const res = await request(app).get("/anchors/anchor-1/assets");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].code).toBe("USDC");
+    expect(res.body.data[0].minAmount).toBe("10.00");
+    expect(res.body.data[0].maxAmount).toBe("50000.00");
+    expect(res.body.fromCache).toBe(false);
+  });
+
+  it("returns null for minAmount and maxAmount when the anchor provides partial info", async () => {
+    __seedAnchor("anchor-2", {
+      id: "anchor-2",
+      name: "Partial Anchor",
+      assets: [
+        {
+          code: "XLM",
+          issuer: "native",
+          depositEnabled: true,
+          withdrawEnabled: false,
+        },
+      ],
+    });
+
+    const res = await request(app).get("/anchors/anchor-2/assets");
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].minAmount).toBeNull();
+    expect(res.body.data[0].maxAmount).toBeNull();
+    expect(res.body.data[0].depositEnabled).toBe(true);
+    expect(res.body.data[0].withdrawEnabled).toBe(false);
+  });
+});

--- a/routes-d/tests/nfts.collection.items.test.ts
+++ b/routes-d/tests/nfts.collection.items.test.ts
@@ -1,0 +1,99 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import nftsCollectionItemsRouter, {
+  __resetCollectionItems,
+  __seedCollectionItems,
+  __seedCollectionItemMetadata,
+} from "../routes/nfts.collection.items.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(nftsCollectionItemsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const COLLECTION_ID = "collection-alpha";
+
+const ITEMS = [
+  {
+    id: "item-1",
+    tokenId: "token-1",
+    collectionId: COLLECTION_ID,
+    ownerUserId: "user-a",
+    acquiredAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "item-2",
+    tokenId: "token-2",
+    collectionId: COLLECTION_ID,
+    ownerUserId: "user-b",
+    acquiredAt: "2026-01-02T00:00:00.000Z",
+  },
+  {
+    id: "item-3",
+    tokenId: "token-3",
+    collectionId: COLLECTION_ID,
+    ownerUserId: "user-c",
+    acquiredAt: "2026-01-03T00:00:00.000Z",
+  },
+];
+
+describe("GET /collections/:id/items", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetCollectionItems();
+  });
+
+  it("returns empty items array for a collection with no items", async () => {
+    const res = await request(app).get(`/collections/${COLLECTION_ID}/items`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("filters items by trait_type and trait_value", async () => {
+    __seedCollectionItems(COLLECTION_ID, ITEMS);
+    __seedCollectionItemMetadata("token-1", {
+      name: "Alpha One",
+      attributes: [{ trait_type: "Background", value: "Blue" }],
+    });
+    __seedCollectionItemMetadata("token-2", {
+      name: "Alpha Two",
+      attributes: [{ trait_type: "Background", value: "Red" }],
+    });
+
+    const res = await request(app).get(
+      `/collections/${COLLECTION_ID}/items?trait_type=Background&trait_value=Blue`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].tokenId).toBe("token-1");
+  });
+
+  it("paginates items correctly", async () => {
+    __seedCollectionItems(COLLECTION_ID, ITEMS);
+
+    const res = await request(app).get(
+      `/collections/${COLLECTION_ID}/items?page=2&limit=2`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].tokenId).toBe("token-3");
+    expect(res.body.pagination).toEqual({ page: 2, limit: 2, total: 3, totalPages: 2 });
+  });
+
+  it("hydrates displayMetadata for items that have it", async () => {
+    __seedCollectionItems(COLLECTION_ID, ITEMS.slice(0, 1));
+    __seedCollectionItemMetadata("token-1", { name: "Hydrated One", image: "ipfs://Qm1" });
+
+    const res = await request(app).get(`/collections/${COLLECTION_ID}/items`);
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].displayMetadata.name).toBe("Hydrated One");
+  });
+});

--- a/routes-d/tests/nfts.collections.list.test.ts
+++ b/routes-d/tests/nfts.collections.list.test.ts
@@ -59,4 +59,27 @@ describe("GET /nfts/collections", () => {
       expect(prices[i]).toBeGreaterThanOrEqual(prices[i + 1]);
     }
   });
+
+  it("sorts collections by volume24h descending", async () => {
+    __seedCollectionsList(COLLECTIONS);
+
+    const res = await request(app).get("/nfts/collections?sortBy=volume");
+    expect(res.status).toBe(200);
+    const volumes = res.body.data.collections.map(
+      (c: { volume24h: string }) => parseFloat(c.volume24h),
+    );
+    for (let i = 0; i < volumes.length - 1; i++) {
+      expect(volumes[i]).toBeGreaterThanOrEqual(volumes[i + 1]);
+    }
+  });
+
+  it("returns fromCache: false on first request and fromCache: true on repeated request", async () => {
+    __seedCollectionsList(COLLECTIONS);
+
+    const first = await request(app).get("/nfts/collections");
+    expect(first.body.data.fromCache).toBe(false);
+
+    const second = await request(app).get("/nfts/collections");
+    expect(second.body.data.fromCache).toBe(true);
+  });
 });

--- a/routes-d/tests/nfts.collections.list.test.ts
+++ b/routes-d/tests/nfts.collections.list.test.ts
@@ -1,0 +1,62 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import nftsCollectionsListRouter, {
+  __resetCollectionsList,
+  __seedCollectionsList,
+} from "../routes/nfts.collections.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(nftsCollectionsListRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const COLLECTIONS = [
+  { id: "c1", name: "Alpha Art", category: "art", floorPrice: "50.00", volume24h: "5000.00", itemCount: 100 },
+  { id: "c2", name: "Beta Gaming", category: "gaming", floorPrice: "20.00", volume24h: "15000.00", itemCount: 250 },
+  { id: "c3", name: "Gamma Art", category: "art", floorPrice: "75.00", volume24h: "3000.00", itemCount: 50 },
+];
+
+describe("GET /nfts/collections", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetCollectionsList();
+  });
+
+  it("returns an empty list when no collections are seeded", async () => {
+    const res = await request(app).get("/nfts/collections");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.collections).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("filters collections by category", async () => {
+    __seedCollectionsList(COLLECTIONS);
+
+    const res = await request(app).get("/nfts/collections?category=art");
+    expect(res.status).toBe(200);
+    expect(res.body.data.collections.length).toBe(2);
+    expect(
+      res.body.data.collections.every((c: { category: string }) => c.category === "art"),
+    ).toBe(true);
+  });
+
+  it("sorts collections by floor price descending with stable order", async () => {
+    __seedCollectionsList(COLLECTIONS);
+
+    const res = await request(app).get("/nfts/collections?sortBy=floorPrice");
+    expect(res.status).toBe(200);
+    const prices = res.body.data.collections.map(
+      (c: { floorPrice: string }) => parseFloat(c.floorPrice),
+    );
+    for (let i = 0; i < prices.length - 1; i++) {
+      expect(prices[i]).toBeGreaterThanOrEqual(prices[i + 1]);
+    }
+  });
+});

--- a/routes-d/tests/nfts.get.test.ts
+++ b/routes-d/tests/nfts.get.test.ts
@@ -79,4 +79,21 @@ describe("GET /nfts/:id", () => {
     expect(res.body.data.displayMetadata.name).toBe("Cool NFT #3");
     expect(res.body.data.displayMetadata.attributes[0].trait_type).toBe("Background");
   });
+
+  it("returns fromCache: true on second request for the same NFT within TTL", async () => {
+    __seedNft("nft-4", {
+      id: "nft-4",
+      tokenId: "token-4",
+      collectionId: "collection-alpha",
+      ownerUserId: "user-abc",
+      acquiredAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    const first = await request(app).get("/nfts/nft-4");
+    expect(first.body.fromCache).toBe(false);
+
+    const second = await request(app).get("/nfts/nft-4");
+    expect(second.body.fromCache).toBe(true);
+    expect(second.body.data.id).toBe("nft-4");
+  });
 });

--- a/routes-d/tests/nfts.get.test.ts
+++ b/routes-d/tests/nfts.get.test.ts
@@ -1,0 +1,82 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import nftsGetRouter, {
+  __resetNftGet,
+  __seedNft,
+} from "../routes/nfts.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(nftsGetRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /nfts/:id", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetNftGet();
+  });
+
+  it("returns 404 for an unknown NFT id", async () => {
+    const res = await request(app).get("/nfts/unknown-id");
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NFT_NOT_FOUND");
+  });
+
+  it("returns the NFT with on-chain data for a known id", async () => {
+    __seedNft("nft-1", {
+      id: "nft-1",
+      tokenId: "token-1",
+      collectionId: "collection-alpha",
+      ownerUserId: "user-abc",
+      acquiredAt: "2026-01-01T00:00:00.000Z",
+      onChainData: { contractId: "CABC123", mintLedger: 1000 },
+    });
+
+    const res = await request(app).get("/nfts/nft-1");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe("nft-1");
+    expect(res.body.data.onChainData.contractId).toBe("CABC123");
+    expect(res.body.fromCache).toBe(false);
+  });
+
+  it("returns null displayMetadata when no off-chain metadata is seeded", async () => {
+    __seedNft("nft-2", {
+      id: "nft-2",
+      tokenId: "token-2",
+      collectionId: "collection-beta",
+      ownerUserId: "user-xyz",
+      acquiredAt: "2026-02-01T00:00:00.000Z",
+    });
+
+    const res = await request(app).get("/nfts/nft-2");
+    expect(res.status).toBe(200);
+    expect(res.body.data.displayMetadata).toBeNull();
+  });
+
+  it("hydrates displayMetadata when off-chain metadata is present", async () => {
+    __seedNft("nft-3", {
+      id: "nft-3",
+      tokenId: "token-3",
+      collectionId: "collection-alpha",
+      ownerUserId: "user-abc",
+      acquiredAt: "2026-03-01T00:00:00.000Z",
+      displayMetadata: {
+        name: "Cool NFT #3",
+        image: "ipfs://Qm123",
+        attributes: [{ trait_type: "Background", value: "Blue" }],
+      },
+    });
+
+    const res = await request(app).get("/nfts/nft-3");
+    expect(res.status).toBe(200);
+    expect(res.body.data.displayMetadata.name).toBe("Cool NFT #3");
+    expect(res.body.data.displayMetadata.attributes[0].trait_type).toBe("Background");
+  });
+});


### PR DESCRIPTION
Closes #518

---

Closes #512

---

Closes #511

---

Closes #508

---

## Summary

- **Issue #508**: Add `routes-d/routes/nfts.get.ts` — `GET /nfts/:id` resolves on-chain and off-chain metadata, assembles the response, caches it for 30 seconds, and returns `null` for `displayMetadata` when no off-chain data is available.
- **Issue #511**: Add `routes-d/routes/nfts.collections.list.ts` — `GET /nfts/collections` lists known NFT collections with optional `category` filter, `sortBy=floorPrice|volume` sorting, pagination, and a 10-second in-memory cache.
- **Issue #512**: Add `routes-d/routes/nfts.collection.items.ts` — `GET /collections/:id/items` lists items within a collection, supports `trait_type`/`trait_value` attribute filter, paginates results, and hydrates `displayMetadata` for each item where available.
- **Issue #518**: Add `routes-d/routes/anchors.assets.ts` — `GET /anchors/:id/assets` returns the assets an anchor supports, annotates each asset with `minAmount`/`maxAmount` (null when not provided), caches per-anchor for 30 seconds, and returns 404 for unknown anchors.

All four routes follow the existing `routes-d` codebase conventions: Express Router, `sendError` from `lib/response.js`, in-memory seed/reset helpers for testing, and ESM imports.

## Test plan

- [ ] `GET /nfts/unknown` returns 404 with `error.code: "NFT_NOT_FOUND"`
- [ ] `GET /nfts/:id` returns the NFT with `displayMetadata: null` when no off-chain metadata is seeded
- [ ] `GET /nfts/:id` hydrates `displayMetadata` when it is present
- [ ] `GET /nfts/:id` returns `fromCache: true` on a second request within the TTL
- [ ] `GET /nfts/collections` returns an empty array when no collections are seeded
- [ ] `GET /nfts/collections?category=art` returns only art collections
- [ ] `GET /nfts/collections?sortBy=floorPrice` returns collections sorted highest-to-lowest
- [ ] `GET /nfts/collections?sortBy=volume` returns collections sorted by volume24h descending
- [ ] `GET /nfts/collections` returns `fromCache: false` then `fromCache: true` on repeat
- [ ] `GET /collections/:id/items` returns empty array for a collection with no items
- [ ] `GET /collections/:id/items?trait_type=X&trait_value=Y` returns only matching items
- [ ] `GET /collections/:id/items?page=2&limit=2` paginates correctly
- [ ] `GET /collections/:id/items` hydrates `displayMetadata` for items that have it
- [ ] `GET /anchors/unknown/assets` returns 404 with `error.code: "ANCHOR_NOT_FOUND"`
- [ ] `GET /anchors/:id/assets` returns assets with correct `minAmount`/`maxAmount` values
- [ ] `GET /anchors/:id/assets` returns `null` for `minAmount`/`maxAmount` when partial info
- [ ] All new test files pass: `nfts.get.test.ts`, `nfts.collections.list.test.ts`, `nfts.collection.items.test.ts`, `anchors.assets.test.ts`