### PR TITLE
feat(routes-d): invoice create, cards list, anchor dispute, and farm unstake routes

### DIFF
--- a/routes-d/routes/anchors.dispute.ts
+++ b/routes-d/routes/anchors.dispute.ts
@@ -1,0 +1,153 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type DisputeReasonCode =
+  | "TRANSACTION_NOT_RECEIVED"
+  | "INCORRECT_AMOUNT"
+  | "DUPLICATE_TRANSACTION"
+  | "UNAUTHORIZED_TRANSACTION"
+  | "ANCHOR_TIMEOUT";
+
+interface Dispute {
+  id: string;
+  anchorTransactionId: string;
+  userId: string;
+  reasonCode: DisputeReasonCode;
+  status: "open" | "resolved" | "rejected";
+  openedAt: string;
+}
+
+const VALID_REASON_CODES = new Set<DisputeReasonCode>([
+  "TRANSACTION_NOT_RECEIVED",
+  "INCORRECT_AMOUNT",
+  "DUPLICATE_TRANSACTION",
+  "UNAUTHORIZED_TRANSACTION",
+  "ANCHOR_TIMEOUT",
+]);
+
+const disputeStore = new Map<string, Dispute>();
+// Key: `${userId}:${anchorTransactionId}` -> dispute id (for duplicate detection)
+const disputeIndex = new Map<string, string>();
+
+let disputeCounter = 0;
+
+function generateDisputeId(): string {
+  disputeCounter += 1;
+  return `dispute-${String(disputeCounter).padStart(6, "0")}`;
+}
+
+export function __resetDisputeStore(): void {
+  disputeStore.clear();
+  disputeIndex.clear();
+  disputeCounter = 0;
+}
+
+export function __seedDispute(dispute: Dispute): void {
+  disputeStore.set(dispute.id, dispute);
+  const key = `${dispute.userId}:${dispute.anchorTransactionId}`;
+  disputeIndex.set(key, dispute.id);
+}
+
+const alertOperators = (dispute: Dispute): void => {
+  // Alerting hook: in production this would notify operators
+  if (process.env.NODE_ENV !== "test") {
+    console.log(`[ALERT] New anchor dispute opened: ${dispute.id}`, {
+      disputeId: dispute.id,
+      anchorTransactionId: dispute.anchorTransactionId,
+      reasonCode: dispute.reasonCode,
+    });
+  }
+};
+
+router.post(
+  "/anchors/dispute",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+      const freshAuth = req.headers["x-fresh-auth"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      if (!freshAuth || freshAuth !== "true") {
+        sendError(
+          res,
+          "FRESH_AUTH_REQUIRED",
+          "x-fresh-auth: true header is required to open a dispute",
+          401,
+        );
+        return;
+      }
+
+      const { anchorTransactionId, reasonCode } = req.body as {
+        anchorTransactionId?: unknown;
+        reasonCode?: unknown;
+      };
+
+      if (!anchorTransactionId || typeof anchorTransactionId !== "string") {
+        sendError(
+          res,
+          "INVALID_TRANSACTION_ID",
+          "anchorTransactionId is required and must be a string",
+          400,
+        );
+        return;
+      }
+
+      if (!reasonCode || typeof reasonCode !== "string") {
+        sendError(res, "INVALID_REASON_CODE", "reasonCode is required", 400);
+        return;
+      }
+
+      if (!VALID_REASON_CODES.has(reasonCode as DisputeReasonCode)) {
+        sendError(
+          res,
+          "INVALID_REASON_CODE",
+          `reasonCode must be one of: ${[...VALID_REASON_CODES].join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      const indexKey = `${userId}:${anchorTransactionId}`;
+      const existingId = disputeIndex.get(indexKey);
+      if (existingId) {
+        sendError(
+          res,
+          "DUPLICATE_DISPUTE",
+          "A dispute for this transaction is already open",
+          409,
+        );
+        return;
+      }
+
+      const id = generateDisputeId();
+      const dispute: Dispute = {
+        id,
+        anchorTransactionId,
+        userId,
+        reasonCode: reasonCode as DisputeReasonCode,
+        status: "open",
+        openedAt: new Date().toISOString(),
+      };
+
+      disputeStore.set(id, dispute);
+      disputeIndex.set(indexKey, id);
+
+      alertOperators(dispute);
+
+      res.status(201).json({
+        success: true,
+        data: dispute,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/cards.list.ts
+++ b/routes-d/routes/cards.list.ts
@@ -1,0 +1,62 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type CardStatus = "active" | "closed" | "suspended";
+
+interface Card {
+  id: string;
+  userId: string;
+  maskedNumber: string;
+  status: CardStatus;
+  label?: string;
+  createdAt: string;
+}
+
+const cardStore = new Map<string, Card[]>();
+
+export function __seedCards(userId: string, cards: Card[]): void {
+  cardStore.set(userId, cards);
+}
+
+export function __resetCardStore(): void {
+  cardStore.clear();
+}
+
+router.get(
+  "/cards",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const userCards = cardStore.get(userId) ?? [];
+
+      // Active cards first, then closed/suspended
+      const sorted = [...userCards].sort((a, b) => {
+        const aActive = a.status === "active" ? 0 : 1;
+        const bActive = b.status === "active" ? 0 : 1;
+        return aActive - bActive;
+      });
+
+      res.status(200).json({
+        success: true,
+        data: sorted.map((card) => ({
+          id: card.id,
+          maskedNumber: card.maskedNumber,
+          status: card.status,
+          label: card.label ?? null,
+          createdAt: card.createdAt,
+        })),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/defi.farm.unstake.ts
+++ b/routes-d/routes/defi.farm.unstake.ts
@@ -1,0 +1,98 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+interface FarmPosition {
+  userId: string;
+  farmId: string;
+  stakedAmount: number;
+  asset: string;
+}
+
+const farmPositions = new Map<string, FarmPosition>();
+
+function positionKey(userId: string, farmId: string): string {
+  return `${userId}:${farmId}`;
+}
+
+export function __seedFarmPosition(position: FarmPosition): void {
+  farmPositions.set(positionKey(position.userId, position.farmId), position);
+}
+
+export function __resetFarmPositions(): void {
+  farmPositions.clear();
+}
+
+router.post(
+  "/defi/farm/unstake",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const { farmId, amount } = req.body as {
+        farmId?: unknown;
+        amount?: unknown;
+      };
+
+      if (!farmId || typeof farmId !== "string") {
+        sendError(res, "INVALID_FARM_ID", "farmId is required and must be a string", 400);
+        return;
+      }
+
+      const parsedAmount = Number(amount);
+      if (!amount || !Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+        sendError(res, "INVALID_AMOUNT", "amount must be a positive number", 400);
+        return;
+      }
+
+      const key = positionKey(userId, farmId);
+      const position = farmPositions.get(key);
+
+      if (!position) {
+        sendError(res, "NO_POSITION", "No staked position found for this farm", 404);
+        return;
+      }
+
+      if (parsedAmount > position.stakedAmount) {
+        sendError(
+          res,
+          "INSUFFICIENT_STAKE",
+          `Cannot unstake ${parsedAmount}; only ${position.stakedAmount} is staked`,
+          422,
+        );
+        return;
+      }
+
+      const remainingAmount = position.stakedAmount - parsedAmount;
+
+      // Update position
+      if (remainingAmount === 0) {
+        farmPositions.delete(key);
+      } else {
+        farmPositions.set(key, { ...position, stakedAmount: remainingAmount });
+      }
+
+      const envelope = `Unsigned unstake envelope: ${parsedAmount} ${position.asset} from farm ${farmId}`;
+
+      res.status(200).json({
+        success: true,
+        data: {
+          farmId,
+          unstakedAmount: parsedAmount,
+          remainingStake: remainingAmount,
+          asset: position.asset,
+          envelope,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/invoices.create.ts
+++ b/routes-d/routes/invoices.create.ts
@@ -1,0 +1,184 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type InvoiceStatus = "draft" | "pending" | "paid" | "voided";
+
+interface InvoiceLineItem {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  amount: number;
+}
+
+interface Invoice {
+  id: string;
+  issuerId: string;
+  recipientId: string;
+  status: InvoiceStatus;
+  currency: string;
+  lineItems: InvoiceLineItem[];
+  totalAmount: number;
+  payableLink: string;
+  createdAt: string;
+  idempotencyKey?: string;
+}
+
+const invoiceStore = new Map<string, Invoice>();
+const idempotencyIndex = new Map<string, string>();
+
+let invoiceCounter = 0;
+
+function generateInvoiceId(): string {
+  invoiceCounter += 1;
+  return `inv-${String(invoiceCounter).padStart(6, "0")}`;
+}
+
+export function __resetInvoiceStore(): void {
+  invoiceStore.clear();
+  idempotencyIndex.clear();
+  invoiceCounter = 0;
+}
+
+export function __seedInvoice(invoice: Invoice): void {
+  invoiceStore.set(invoice.id, invoice);
+  if (invoice.idempotencyKey) {
+    idempotencyIndex.set(invoice.idempotencyKey, invoice.id);
+  }
+}
+
+const VALID_CURRENCIES = new Set(["USD", "EUR", "XLM", "USDC"]);
+
+router.post(
+  "/invoices",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { lineItems, currency, recipientId, idempotencyKey } = req.body as {
+        lineItems?: unknown;
+        currency?: unknown;
+        recipientId?: unknown;
+        idempotencyKey?: unknown;
+      };
+
+      const issuerId = req.headers["x-user-id"] as string | undefined;
+      if (!issuerId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      if (!currency || typeof currency !== "string") {
+        sendError(res, "INVALID_CURRENCY", "currency is required and must be a string", 400);
+        return;
+      }
+
+      if (!VALID_CURRENCIES.has(currency)) {
+        sendError(
+          res,
+          "INVALID_CURRENCY",
+          `currency must be one of: ${[...VALID_CURRENCIES].join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      if (!recipientId || typeof recipientId !== "string") {
+        sendError(res, "INVALID_RECIPIENT", "recipientId is required and must be a string", 400);
+        return;
+      }
+
+      if (recipientId === issuerId) {
+        sendError(res, "INVALID_RECIPIENT", "recipientId cannot be the same as the issuer", 400);
+        return;
+      }
+
+      if (!Array.isArray(lineItems) || lineItems.length === 0) {
+        sendError(res, "INVALID_LINE_ITEMS", "lineItems must be a non-empty array", 400);
+        return;
+      }
+
+      const parsedItems: InvoiceLineItem[] = [];
+      for (let i = 0; i < lineItems.length; i++) {
+        const item = lineItems[i] as Record<string, unknown>;
+
+        if (!item.description || typeof item.description !== "string") {
+          sendError(res, "INVALID_LINE_ITEM", `lineItems[${i}].description is required`, 400);
+          return;
+        }
+
+        const quantity = Number(item.quantity);
+        if (!Number.isFinite(quantity) || quantity <= 0) {
+          sendError(
+            res,
+            "INVALID_LINE_ITEM",
+            `lineItems[${i}].quantity must be a positive number`,
+            400,
+          );
+          return;
+        }
+
+        const unitPrice = Number(item.unitPrice);
+        if (!Number.isFinite(unitPrice) || unitPrice < 0) {
+          sendError(
+            res,
+            "INVALID_LINE_ITEM",
+            `lineItems[${i}].unitPrice must be a non-negative number`,
+            400,
+          );
+          return;
+        }
+
+        parsedItems.push({
+          description: item.description,
+          quantity,
+          unitPrice,
+          amount: quantity * unitPrice,
+        });
+      }
+
+      // Idempotency: return existing invoice for duplicate keys
+      if (idempotencyKey && typeof idempotencyKey === "string") {
+        const existingId = idempotencyIndex.get(idempotencyKey);
+        if (existingId) {
+          const existing = invoiceStore.get(existingId)!;
+          res.status(200).json({
+            success: true,
+            data: existing,
+          });
+          return;
+        }
+      }
+
+      const totalAmount = parsedItems.reduce((sum, item) => sum + item.amount, 0);
+      const id = generateInvoiceId();
+      const payableLink = `https://pay.nextellar.app/invoices/${id}`;
+
+      const invoice: Invoice = {
+        id,
+        issuerId,
+        recipientId,
+        status: "pending",
+        currency,
+        lineItems: parsedItems,
+        totalAmount,
+        payableLink,
+        createdAt: new Date().toISOString(),
+        ...(idempotencyKey && typeof idempotencyKey === "string" ? { idempotencyKey } : {}),
+      };
+
+      invoiceStore.set(id, invoice);
+      if (idempotencyKey && typeof idempotencyKey === "string") {
+        idempotencyIndex.set(idempotencyKey, id);
+      }
+
+      res.status(201).json({
+        success: true,
+        data: invoice,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/anchors.dispute.test.ts
+++ b/routes-d/tests/anchors.dispute.test.ts
@@ -1,0 +1,151 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import anchorsDisputeRouter, {
+  __resetDisputeStore,
+} from "../routes/anchors.dispute.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(anchorsDisputeRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const app = buildApp();
+
+const VALID_BODY = {
+  anchorTransactionId: "anchor-tx-001",
+  reasonCode: "TRANSACTION_NOT_RECEIVED",
+};
+
+const AUTH_HEADERS = {
+  "x-user-id": "user-abc",
+  "x-fresh-auth": "true",
+};
+
+beforeEach(() => {
+  __resetDisputeStore();
+});
+
+describe("POST /anchors/dispute – open dispute", () => {
+  it("opens a dispute and returns the dispute record", async () => {
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set(AUTH_HEADERS)
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toMatch(/^dispute-/);
+    expect(res.body.data.status).toBe("open");
+    expect(res.body.data.reasonCode).toBe("TRANSACTION_NOT_RECEIVED");
+    expect(res.body.data.anchorTransactionId).toBe("anchor-tx-001");
+    expect(res.body.data.userId).toBe("user-abc");
+    expect(res.body.data.openedAt).toBeDefined();
+  });
+
+  it("accepts all valid reason codes", async () => {
+    const codes = [
+      "TRANSACTION_NOT_RECEIVED",
+      "INCORRECT_AMOUNT",
+      "DUPLICATE_TRANSACTION",
+      "UNAUTHORIZED_TRANSACTION",
+      "ANCHOR_TIMEOUT",
+    ];
+
+    for (const reasonCode of codes) {
+      __resetDisputeStore();
+      const res = await request(app)
+        .post("/anchors/dispute")
+        .set(AUTH_HEADERS)
+        .send({ ...VALID_BODY, reasonCode });
+      expect(res.status).toBe(201);
+    }
+  });
+});
+
+describe("POST /anchors/dispute – duplicate", () => {
+  it("rejects a second dispute for the same transaction", async () => {
+    await request(app)
+      .post("/anchors/dispute")
+      .set(AUTH_HEADERS)
+      .send(VALID_BODY);
+
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set(AUTH_HEADERS)
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("DUPLICATE_DISPUTE");
+  });
+
+  it("allows different users to dispute the same transaction id", async () => {
+    await request(app)
+      .post("/anchors/dispute")
+      .set({ "x-user-id": "user-1", "x-fresh-auth": "true" })
+      .send(VALID_BODY);
+
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set({ "x-user-id": "user-2", "x-fresh-auth": "true" })
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("POST /anchors/dispute – invalid reason", () => {
+  it("rejects unknown reason code", async () => {
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set(AUTH_HEADERS)
+      .send({ ...VALID_BODY, reasonCode: "WRONG_CODE" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_REASON_CODE");
+  });
+
+  it("rejects missing reason code", async () => {
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set(AUTH_HEADERS)
+      .send({ anchorTransactionId: "tx-001" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_REASON_CODE");
+  });
+
+  it("rejects missing x-user-id", async () => {
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set("x-fresh-auth", "true")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects missing fresh auth header", async () => {
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set("x-user-id", "user-abc")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("FRESH_AUTH_REQUIRED");
+  });
+
+  it("rejects missing anchorTransactionId", async () => {
+    const res = await request(app)
+      .post("/anchors/dispute")
+      .set(AUTH_HEADERS)
+      .send({ reasonCode: "ANCHOR_TIMEOUT" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_TRANSACTION_ID");
+  });
+});

--- a/routes-d/tests/cards.list.test.ts
+++ b/routes-d/tests/cards.list.test.ts
@@ -1,0 +1,122 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import cardsListRouter, {
+  __seedCards,
+  __resetCardStore,
+} from "../routes/cards.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cardsListRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const app = buildApp();
+
+beforeEach(() => {
+  __resetCardStore();
+});
+
+describe("GET /cards – no cards", () => {
+  it("returns empty array when user has no cards", async () => {
+    const res = await request(app)
+      .get("/cards")
+      .set("x-user-id", "user-empty");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe("GET /cards – active cards only", () => {
+  it("returns all active cards sorted first", async () => {
+    __seedCards("user-1", [
+      {
+        id: "card-a",
+        userId: "user-1",
+        maskedNumber: "****1234",
+        status: "active",
+        createdAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "card-b",
+        userId: "user-1",
+        maskedNumber: "****5678",
+        status: "active",
+        createdAt: "2024-02-01T00:00:00Z",
+      },
+    ]);
+
+    const res = await request(app).get("/cards").set("x-user-id", "user-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].status).toBe("active");
+    expect(res.body.data[1].status).toBe("active");
+  });
+});
+
+describe("GET /cards – mixed status", () => {
+  it("sorts active cards before closed ones", async () => {
+    __seedCards("user-2", [
+      {
+        id: "card-closed",
+        userId: "user-2",
+        maskedNumber: "****0001",
+        status: "closed",
+        createdAt: "2023-01-01T00:00:00Z",
+      },
+      {
+        id: "card-active",
+        userId: "user-2",
+        maskedNumber: "****0002",
+        status: "active",
+        createdAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "card-suspended",
+        userId: "user-2",
+        maskedNumber: "****0003",
+        status: "suspended",
+        createdAt: "2024-03-01T00:00:00Z",
+      },
+    ]);
+
+    const res = await request(app).get("/cards").set("x-user-id", "user-2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data[0].id).toBe("card-active");
+    expect(["closed", "suspended"]).toContain(res.body.data[1].status);
+    expect(["closed", "suspended"]).toContain(res.body.data[2].status);
+  });
+
+  it("masks card numbers in response", async () => {
+    __seedCards("user-3", [
+      {
+        id: "card-x",
+        userId: "user-3",
+        maskedNumber: "****9999",
+        status: "active",
+        createdAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    const res = await request(app).get("/cards").set("x-user-id", "user-3");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].maskedNumber).toBe("****9999");
+  });
+
+  it("returns 401 when x-user-id header is missing", async () => {
+    const res = await request(app).get("/cards");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/routes-d/tests/defi.farm.unstake.test.ts
+++ b/routes-d/tests/defi.farm.unstake.test.ts
@@ -1,0 +1,122 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import defiFarmUnstakeRouter, {
+  __seedFarmPosition,
+  __resetFarmPositions,
+} from "../routes/defi.farm.unstake.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(defiFarmUnstakeRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const app = buildApp();
+
+const USER_ID = "user-defi-001";
+const FARM_ID = "farm-xlm-usdc";
+
+beforeEach(() => {
+  __resetFarmPositions();
+  __seedFarmPosition({
+    userId: USER_ID,
+    farmId: FARM_ID,
+    stakedAmount: 1000,
+    asset: "XLM",
+  });
+});
+
+describe("POST /defi/farm/unstake – full unstake", () => {
+  it("unstakes the full staked amount and clears the position", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", USER_ID)
+      .send({ farmId: FARM_ID, amount: 1000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.unstakedAmount).toBe(1000);
+    expect(res.body.data.remainingStake).toBe(0);
+    expect(res.body.data.envelope).toContain("1000");
+    expect(res.body.data.envelope).toContain(FARM_ID);
+  });
+});
+
+describe("POST /defi/farm/unstake – partial unstake", () => {
+  it("unstakes partial amount and returns remaining stake", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", USER_ID)
+      .send({ farmId: FARM_ID, amount: 400 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.unstakedAmount).toBe(400);
+    expect(res.body.data.remainingStake).toBe(600);
+    expect(res.body.data.asset).toBe("XLM");
+  });
+});
+
+describe("POST /defi/farm/unstake – over-amount rejection", () => {
+  it("rejects unstake amount greater than staked balance", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", USER_ID)
+      .send({ farmId: FARM_ID, amount: 1500 });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe("INSUFFICIENT_STAKE");
+  });
+
+  it("rejects when user has no position in the farm", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", "user-no-stake")
+      .send({ farmId: FARM_ID, amount: 100 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NO_POSITION");
+  });
+
+  it("rejects missing x-user-id", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .send({ farmId: FARM_ID, amount: 100 });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects missing farmId", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", USER_ID)
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_FARM_ID");
+  });
+
+  it("rejects zero amount", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", USER_ID)
+      .send({ farmId: FARM_ID, amount: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("rejects negative amount", async () => {
+    const res = await request(app)
+      .post("/defi/farm/unstake")
+      .set("x-user-id", USER_ID)
+      .send({ farmId: FARM_ID, amount: -50 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+});

--- a/routes-d/tests/invoices.create.test.ts
+++ b/routes-d/tests/invoices.create.test.ts
@@ -1,0 +1,195 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import invoiceCreateRouter, {
+  __resetInvoiceStore,
+  __seedInvoice,
+} from "../routes/invoices.create.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(invoiceCreateRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const app = buildApp();
+
+const BASE_BODY = {
+  currency: "USD",
+  recipientId: "recipient-001",
+  lineItems: [
+    { description: "Web design", quantity: 1, unitPrice: 500 },
+    { description: "Hosting", quantity: 12, unitPrice: 20 },
+  ],
+};
+
+beforeEach(() => {
+  __resetInvoiceStore();
+});
+
+describe("POST /invoices – create", () => {
+  it("creates an invoice and returns payable link", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send(BASE_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toMatch(/^inv-/);
+    expect(res.body.data.status).toBe("pending");
+    expect(res.body.data.currency).toBe("USD");
+    expect(res.body.data.recipientId).toBe("recipient-001");
+    expect(res.body.data.payableLink).toContain(res.body.data.id);
+    expect(res.body.data.totalAmount).toBe(740); // 500 + 12*20
+    expect(res.body.data.lineItems).toHaveLength(2);
+  });
+
+  it("computes totalAmount correctly for each line item", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({
+        ...BASE_BODY,
+        lineItems: [
+          { description: "Item A", quantity: 3, unitPrice: 100 },
+          { description: "Item B", quantity: 2, unitPrice: 50 },
+        ],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.totalAmount).toBe(400); // 300 + 100
+    expect(res.body.data.lineItems[0].amount).toBe(300);
+    expect(res.body.data.lineItems[1].amount).toBe(100);
+  });
+});
+
+describe("POST /invoices – validation failures", () => {
+  it("rejects missing x-user-id", async () => {
+    const res = await request(app).post("/invoices").send(BASE_BODY);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects missing currency", async () => {
+    const { currency: _, ...body } = BASE_BODY;
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CURRENCY");
+  });
+
+  it("rejects invalid currency", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({ ...BASE_BODY, currency: "GBP" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CURRENCY");
+  });
+
+  it("rejects missing recipientId", async () => {
+    const { recipientId: _, ...body } = BASE_BODY;
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_RECIPIENT");
+  });
+
+  it("rejects recipientId equal to issuerId", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "user-same")
+      .send({ ...BASE_BODY, recipientId: "user-same" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_RECIPIENT");
+  });
+
+  it("rejects empty lineItems array", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({ ...BASE_BODY, lineItems: [] });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LINE_ITEMS");
+  });
+
+  it("rejects lineItems with missing description", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({
+        ...BASE_BODY,
+        lineItems: [{ quantity: 1, unitPrice: 100 }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LINE_ITEM");
+  });
+
+  it("rejects lineItems with non-positive quantity", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({
+        ...BASE_BODY,
+        lineItems: [{ description: "X", quantity: 0, unitPrice: 10 }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LINE_ITEM");
+  });
+
+  it("rejects lineItems with negative unitPrice", async () => {
+    const res = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({
+        ...BASE_BODY,
+        lineItems: [{ description: "X", quantity: 1, unitPrice: -5 }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LINE_ITEM");
+  });
+});
+
+describe("POST /invoices – idempotency", () => {
+  it("returns same invoice for duplicate idempotency key", async () => {
+    const body = { ...BASE_BODY, idempotencyKey: "idem-key-abc" };
+
+    const first = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send(body);
+
+    expect(first.status).toBe(201);
+    const firstId = first.body.data.id;
+
+    const second = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send(body);
+
+    expect(second.status).toBe(200);
+    expect(second.body.data.id).toBe(firstId);
+  });
+
+  it("creates distinct invoices for different idempotency keys", async () => {
+    const first = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({ ...BASE_BODY, idempotencyKey: "key-1" });
+
+    const second = await request(app)
+      .post("/invoices")
+      .set("x-user-id", "issuer-1")
+      .send({ ...BASE_BODY, idempotencyKey: "key-2" });
+
+    expect(first.body.data.id).not.toBe(second.body.data.id);
+  });
+});


### PR DESCRIPTION
## Summary

Four new route handlers with matching test files covering all required scenarios.

### #530 — Invoice creation route
- `routes-d/routes/invoices.create.ts`: POST /invoices
- Validates line items, currency (USD/EUR/XLM/USDC), and recipient
- Returns payable link with invoice id
- Idempotency key support — duplicate key returns existing invoice (200)
- Tests: create, validation failures, duplicate idempotency

### #523 — User cards list route
- `routes-d/routes/cards.list.ts`: GET /cards
- Returns masked card numbers and per-card status
- Sorts active cards before closed/suspended ones
- Tests: none, active-only, mixed status

### #521 — Anchor dispute route
- `routes-d/routes/anchors.dispute.ts`: POST /anchors/dispute
- Requires fresh authentication (`x-fresh-auth: true` header)
- Validates reason code against allowed values
- Prevents duplicate disputes for the same transaction+user pair (409)
- Notifies operators via alerting hook
- Tests: open, duplicate, invalid reason, missing auth

### #506 — Yield farm unstake route
- `routes-d/routes/defi.farm.unstake.ts`: POST /defi/farm/unstake
- Validates unstake amount against staked balance
- Returns unsigned envelope for client signing
- Tests: full unstake, partial unstake, over-amount rejection

## Issues closed

closes #530
closes #523
closes #521
closes #506

## Test plan

- [x] 35 tests across 4 suites — all pass locally
- [ ] Files compile with TypeScript
- [ ] No regressions in existing routes-d tests