### PR TITLE
Add anchor transactions list, card unfreeze, card spending limit, and anchor quote routes

### DIFF
--- a/routes-d/routes/anchors.quote.ts
+++ b/routes-d/routes/anchors.quote.ts
@@ -1,0 +1,162 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Asset = {
+  code: string;
+  issuer?: string;
+};
+
+type QuoteBody = {
+  sourceAsset: Asset;
+  destinationAsset: Asset;
+  amount: string;
+};
+
+type AnchorQuoteResponse = {
+  quoteId: string;
+  anchorQuote: Record<string, unknown>;
+  sourceAsset: Asset;
+  destinationAsset: Asset;
+  amount: string;
+};
+
+type QuoteResult = {
+  quoteId: string;
+  sourceAsset: Asset;
+  destinationAsset: Asset;
+  amount: string;
+  price: string;
+  expiresAt: string;
+};
+
+const knownAnchors = new Map<string, { multiplier: number; fee: string }>();
+knownAnchors.set("anchor-circle", { multiplier: 0.995, fee: "0.50" });
+knownAnchors.set("anchor-stronghold", { multiplier: 1.002, fee: "1.00" });
+
+let quoteCounter = 1;
+let anchorCallSuccess: boolean | undefined = undefined;
+
+export function __resetQuoteState(): void {
+  knownAnchors.clear();
+  knownAnchors.set("anchor-circle", { multiplier: 0.995, fee: "0.50" });
+  knownAnchors.set("anchor-stronghold", { multiplier: 1.002, fee: "1.00" });
+  quoteCounter = 1;
+}
+
+export function __registerAnchor(id: string, config: { multiplier: number; fee: string }): void {
+  knownAnchors.set(id, config);
+}
+
+export function __setAnchorCallSuccess(success: boolean | undefined): void {
+  anchorCallSuccess = success;
+}
+
+function generateQuoteId(): string {
+  return `quote-${String(quoteCounter++)}`;
+}
+
+function fetchAnchorQuote(
+  anchorId: string,
+  body: QuoteBody,
+): { quote: Record<string, unknown>; expiresAt: string } | null {
+  if (anchorCallSuccess === false) {
+    return null;
+  }
+
+  const anchor = knownAnchors.get(anchorId);
+  if (!anchor) {
+    return null;
+  }
+
+  const amount = parseFloat(body.amount);
+  const outputAmount = (amount * anchor.multiplier).toFixed(7);
+
+  return {
+    quote: {
+      price: (amount * anchor.multiplier) / amount,
+      fee: anchor.fee,
+      amountInbound: body.amount,
+      amountOutbound: outputAmount,
+    },
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
+  };
+}
+
+router.post(
+  "/anchors/:id/quote",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const body = req.body as QuoteBody;
+
+      if (!id || typeof id !== "string" || id.trim() === "") {
+        sendError(res, "INVALID_ANCHOR_ID", "anchor id is required", 400);
+        return;
+      }
+
+      const anchorId = id.trim();
+
+      if (!body.sourceAsset || typeof body.sourceAsset !== "object") {
+        sendError(res, "INVALID_SOURCE_ASSET", "sourceAsset is required and must be an object", 400);
+        return;
+      }
+
+      if (!body.sourceAsset.code || typeof body.sourceAsset.code !== "string") {
+        sendError(res, "INVALID_SOURCE_ASSET", "sourceAsset.code is required and must be a string", 400);
+        return;
+      }
+
+      if (!body.destinationAsset || typeof body.destinationAsset !== "object") {
+        sendError(res, "INVALID_DESTINATION_ASSET", "destinationAsset is required and must be an object", 400);
+        return;
+      }
+
+      if (!body.destinationAsset.code || typeof body.destinationAsset.code !== "string") {
+        sendError(res, "INVALID_DESTINATION_ASSET", "destinationAsset.code is required and must be a string", 400);
+        return;
+      }
+
+      if (!body.amount || typeof body.amount !== "string") {
+        sendError(res, "INVALID_AMOUNT", "amount is required and must be a string", 400);
+        return;
+      }
+
+      const amountNum = parseFloat(body.amount);
+      if (isNaN(amountNum) || amountNum <= 0) {
+        sendError(res, "INVALID_AMOUNT", "amount must be a positive number", 400);
+        return;
+      }
+
+      const result = fetchAnchorQuote(anchorId, body);
+
+      if (!result) {
+        sendError(res, "ANCHOR_ERROR", "Failed to fetch quote from anchor", 502);
+        return;
+      }
+
+      const quote: QuoteResult = {
+        quoteId: generateQuoteId(),
+        sourceAsset: body.sourceAsset,
+        destinationAsset: body.destinationAsset,
+        amount: body.amount,
+        price: result.quote.amountOutbound as string,
+        expiresAt: result.expiresAt,
+      };
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          quoteId: quote.quoteId,
+          anchorQuote: result.quote,
+          ...quote,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/anchors.transactions.list.ts
+++ b/routes-d/routes/anchors.transactions.list.ts
@@ -1,0 +1,170 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type AnchorTransactionStatus = "pending" | "completed" | "failed" | "refunded";
+
+type AnchorTransaction = {
+  id: string;
+  userId: string;
+  anchorId: string;
+  status: AnchorTransactionStatus;
+  amount: string;
+  currency: string;
+  type: "deposit" | "withdrawal";
+  startedAt: string;
+  completedAt?: string;
+};
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const transactionStore = new Map<string, AnchorTransaction[]>();
+transactionStore.set("user-001", [
+  {
+    id: "tx-001",
+    userId: "user-001",
+    anchorId: "anchor-circle",
+    status: "completed",
+    amount: "100.00",
+    currency: "USDC",
+    type: "deposit",
+    startedAt: "2024-06-01T10:00:00Z",
+    completedAt: "2024-06-01T10:05:00Z",
+  },
+  {
+    id: "tx-002",
+    userId: "user-001",
+    anchorId: "anchor-stronghold",
+    status: "pending",
+    amount: "250.00",
+    currency: "SHx",
+    type: "withdrawal",
+    startedAt: "2024-06-02T14:30:00Z",
+  },
+]);
+
+transactionStore.set("user-002", [
+  {
+    id: "tx-003",
+    userId: "user-002",
+    anchorId: "anchor-circle",
+    status: "failed",
+    amount: "50.00",
+    currency: "USDC",
+    type: "deposit",
+    startedAt: "2024-06-03T08:00:00Z",
+  },
+]);
+
+export function __resetTransactions(): void {
+  transactionStore.clear();
+  transactionStore.set("user-001", [
+    {
+      id: "tx-001",
+      userId: "user-001",
+      anchorId: "anchor-circle",
+      status: "completed",
+      amount: "100.00",
+      currency: "USDC",
+      type: "deposit",
+      startedAt: "2024-06-01T10:00:00Z",
+      completedAt: "2024-06-01T10:05:00Z",
+    },
+    {
+      id: "tx-002",
+      userId: "user-001",
+      anchorId: "anchor-stronghold",
+      status: "pending",
+      amount: "250.00",
+      currency: "SHx",
+      type: "withdrawal",
+      startedAt: "2024-06-02T14:30:00Z",
+    },
+  ]);
+  transactionStore.set("user-002", [
+    {
+      id: "tx-003",
+      userId: "user-002",
+      anchorId: "anchor-circle",
+      status: "failed",
+      amount: "50.00",
+      currency: "USDC",
+      type: "deposit",
+      startedAt: "2024-06-03T08:00:00Z",
+    },
+  ]);
+}
+
+export function __seedTransactions(userId: string, transactions: AnchorTransaction[]): void {
+  transactionStore.set(userId, transactions);
+}
+
+router.get(
+  "/anchors/transactions",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const page = req.query.page !== undefined ? parseInt(req.query.page as string, 10) : DEFAULT_PAGE;
+      const limit = req.query.limit !== undefined ? parseInt(req.query.limit as string, 10) : DEFAULT_LIMIT;
+      const anchorId = req.query.anchor as string | undefined;
+      const status = req.query.status as string | undefined;
+
+      if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+        sendError(res, "INVALID_PAGINATION", "page must be >= 1 and limit must be between 1 and 100", 400);
+        return;
+      }
+
+      const validStatuses: AnchorTransactionStatus[] = ["pending", "completed", "failed", "refunded"];
+      if (status !== undefined && !validStatuses.includes(status as AnchorTransactionStatus)) {
+        sendError(
+          res,
+          "INVALID_STATUS",
+          `status must be one of: ${validStatuses.join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      const allTransactions = transactionStore.get(userId) ?? [];
+
+      let filtered = [...allTransactions];
+
+      if (anchorId) {
+        filtered = filtered.filter((tx) => tx.anchorId === anchorId);
+      }
+
+      if (status) {
+        filtered = filtered.filter((tx) => tx.status === status);
+      }
+
+      filtered.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+
+      const offset = (page - 1) * limit;
+      const paginated = filtered.slice(offset, offset + limit);
+
+      return res.status(200).json({
+        success: true,
+        data: paginated,
+        pagination: {
+          page,
+          limit,
+          total: filtered.length,
+          totalPages: Math.ceil(filtered.length / limit) || 1,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/cards.limit.set.ts
+++ b/routes-d/routes/cards.limit.set.ts
@@ -1,0 +1,177 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type CardStatus = "active" | "frozen" | "closed";
+
+type CardRecord = {
+  cardId: string;
+  userId: string;
+  status: CardStatus;
+  maskedNumber: string;
+  expiryMonth: string;
+  expiryYear: string;
+  currency: string;
+  spendLimitAmount: string;
+  issuedAt: string;
+};
+
+type ComplianceRecord = {
+  kycPassed: boolean;
+  eligible: boolean;
+  maxSpendLimit?: string;
+};
+
+type AuditEvent = {
+  cardId: string;
+  action: "limit_set";
+  performedBy: string;
+  limit: string;
+  timestamp: string;
+};
+
+type TierLimits = {
+  bronze: number;
+  silver: number;
+  gold: number;
+};
+
+const TIER_LIMITS: TierLimits = {
+  bronze: 1000,
+  silver: 5000,
+  gold: 10000,
+};
+
+const cardStore = new Map<string, CardRecord>();
+const complianceStore = new Map<string, ComplianceRecord>();
+const auditEvents: AuditEvent[] = [];
+const tierStore = new Map<string, keyof TierLimits>();
+
+export function __resetCardStore(): void {
+  cardStore.clear();
+  complianceStore.clear();
+  auditEvents.length = 0;
+  tierStore.clear();
+}
+
+export function __seedCard(card: CardRecord): void {
+  cardStore.set(card.cardId, card);
+}
+
+export function __getCard(cardId: string): CardRecord | undefined {
+  return cardStore.get(cardId);
+}
+
+export function __setCompliance(userId: string, record: ComplianceRecord): void {
+  complianceStore.set(userId, record);
+}
+
+export function __setUserTier(userId: string, tier: keyof TierLimits): void {
+  tierStore.set(userId, tier);
+}
+
+export function __getAuditEvents(): AuditEvent[] {
+  return auditEvents;
+}
+
+function getTierLimit(userId: string): number {
+  const tier = tierStore.get(userId) ?? "bronze";
+  return TIER_LIMITS[tier];
+}
+
+router.post(
+  "/cards/:id/limit",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      const cardId = id?.trim();
+      if (!cardId) {
+        sendError(res, "INVALID_CARD_ID", "cardId is required", 400);
+        return;
+      }
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const card = cardStore.get(cardId);
+
+      if (!card) {
+        sendError(res, "CARD_NOT_FOUND", "Card not found", 404);
+        return;
+      }
+
+      if (card.userId !== userId) {
+        sendError(res, "FORBIDDEN", "You do not have permission to modify this card", 403);
+        return;
+      }
+
+      const body = req.body as { spendLimitAmount?: unknown };
+
+      if (body.spendLimitAmount === undefined || typeof body.spendLimitAmount !== "string") {
+        sendError(res, "INVALID_SPEND_LIMIT", "spendLimitAmount is required and must be a string", 400);
+        return;
+      }
+
+      const spendLimit = parseFloat(body.spendLimitAmount);
+      if (isNaN(spendLimit) || spendLimit <= 0) {
+        sendError(res, "INVALID_SPEND_LIMIT", "spendLimitAmount must be a positive number", 400);
+        return;
+      }
+
+      const compliance = complianceStore.get(userId);
+      if (compliance && compliance.maxSpendLimit) {
+        const maxLimit = parseFloat(compliance.maxSpendLimit);
+        if (!isNaN(maxLimit) && spendLimit > maxLimit) {
+          sendError(
+            res,
+            "LIMIT_EXCEEDED",
+            `Spend limit cannot exceed ${compliance.maxSpendLimit}`,
+            403,
+          );
+          return;
+        }
+      }
+
+      const tierLimit = getTierLimit(userId);
+      if (spendLimit > tierLimit) {
+        sendError(
+          res,
+          "TIER_LIMIT_EXCEEDED",
+          `Spend limit cannot exceed tier limit of ${tierLimit}`,
+          403,
+        );
+        return;
+      }
+
+      const now = new Date().toISOString();
+      card.spendLimitAmount = body.spendLimitAmount;
+
+      const auditEvent: AuditEvent = {
+        cardId,
+        action: "limit_set",
+        performedBy: userId,
+        limit: body.spendLimitAmount,
+        timestamp: now,
+      };
+      auditEvents.push(auditEvent);
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          cardId,
+          spendLimitAmount: body.spendLimitAmount,
+          updatedAt: now,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/cards.unfreeze.ts
+++ b/routes-d/routes/cards.unfreeze.ts
@@ -1,0 +1,128 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type CardStatus = "active" | "frozen" | "closed";
+
+type CardRecord = {
+  cardId: string;
+  userId: string;
+  status: CardStatus;
+  maskedNumber: string;
+  expiryMonth: string;
+  expiryYear: string;
+  currency: string;
+  spendLimitAmount: string;
+  issuedAt: string;
+  frozenAt?: string;
+  unfrozenAt?: string;
+};
+
+type AuditEvent = {
+  cardId: string;
+  action: "unfreeze";
+  performedBy: string;
+  timestamp: string;
+};
+
+const cardStore = new Map<string, CardRecord>();
+const auditEvents: AuditEvent[] = [];
+
+export function __resetCardStore(): void {
+  cardStore.clear();
+  auditEvents.length = 0;
+}
+
+export function __seedCard(card: CardRecord): void {
+  cardStore.set(card.cardId, card);
+}
+
+export function __getCard(cardId: string): CardRecord | undefined {
+  return cardStore.get(cardId);
+}
+
+export function __getAuditEvents(): AuditEvent[] {
+  return auditEvents;
+}
+
+router.post(
+  "/cards/:id/unfreeze",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const userId = req.headers["x-user-id"] as string | undefined;
+      const authTimestamp = req.headers["x-auth-timestamp"] as string | undefined;
+
+      const cardId = id?.trim();
+      if (!cardId) {
+        sendError(res, "INVALID_CARD_ID", "cardId is required", 400);
+        return;
+      }
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const card = cardStore.get(cardId);
+
+      if (!card) {
+        sendError(res, "CARD_NOT_FOUND", "Card not found", 404);
+        return;
+      }
+
+      if (card.userId !== userId) {
+        sendError(res, "FORBIDDEN", "You do not have permission to unfreeze this card", 403);
+        return;
+      }
+
+      const FRESH_AUTH_SECONDS = 300;
+      if (!authTimestamp) {
+        sendError(res, "REAUTH_REQUIRED", "Fresh authentication required", 403);
+        return;
+      }
+
+      const authTime = parseInt(authTimestamp, 10);
+      if (isNaN(authTime) || Date.now() - authTime > FRESH_AUTH_SECONDS * 1000) {
+        sendError(res, "REAUTH_REQUIRED", "Fresh authentication required", 403);
+        return;
+      }
+
+      if (card.status === "active") {
+        sendError(res, "ALREADY_ACTIVE", "Card is already active", 409);
+        return;
+      }
+
+      if (card.status === "closed") {
+        sendError(res, "CARD_CLOSED", "Cannot unfreeze a closed card", 409);
+        return;
+      }
+
+      const now = new Date().toISOString();
+      card.status = "active";
+      card.unfrozenAt = now;
+
+      const auditEvent: AuditEvent = {
+        cardId,
+        action: "unfreeze",
+        performedBy: userId,
+        timestamp: now,
+      };
+      auditEvents.push(auditEvent);
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          cardId,
+          status: "active",
+          unfrozenAt: now,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/anchors.quote.test.ts
+++ b/routes-d/tests/anchors.quote.test.ts
@@ -1,0 +1,193 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __resetQuoteState,
+  __registerAnchor,
+  __setAnchorCallSuccess,
+} from "../routes/anchors.quote.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /anchors/:id/quote", () => {
+  const app = buildApp();
+
+  const validQuoteRequest = {
+    sourceAsset: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" },
+    destinationAsset: { code: "XLM" },
+    amount: "100",
+  };
+
+  beforeEach(() => {
+    __resetQuoteState();
+  });
+
+  it("returns 200 with quote data for a valid request", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send(validQuoteRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.quoteId).toBeDefined();
+    expect(res.body.data.anchorQuote).toBeDefined();
+    expect(res.body.data.sourceAsset.code).toBe("USDC");
+    expect(res.body.data.destinationAsset.code).toBe("XLM");
+    expect(res.body.data.amount).toBe("100");
+  });
+
+  it("returns 502 ANCHOR_ERROR when anchor call fails", async () => {
+    __setAnchorCallSuccess(false);
+
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send(validQuoteRequest);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error.code).toBe("ANCHOR_ERROR");
+    __setAnchorCallSuccess(undefined);
+  });
+
+  it("returns 400 INVALID_ANCHOR_ID for unknown anchor", async () => {
+    const res = await request(app)
+      .post("/anchors/unknown-anchor/quote")
+      .send(validQuoteRequest);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error.code).toBe("ANCHOR_ERROR");
+  });
+
+  it("returns 400 INVALID_SOURCE_ASSET when sourceAsset is missing", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        destinationAsset: { code: "XLM" },
+        amount: "100",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SOURCE_ASSET");
+  });
+
+  it("returns 400 INVALID_SOURCE_ASSET when sourceAsset.code is missing", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        sourceAsset: { issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" },
+        destinationAsset: { code: "XLM" },
+        amount: "100",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SOURCE_ASSET");
+  });
+
+  it("returns 400 INVALID_DESTINATION_ASSET when destinationAsset is missing", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        sourceAsset: { code: "USDC" },
+        amount: "100",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DESTINATION_ASSET");
+  });
+
+  it("returns 400 INVALID_DESTINATION_ASSET when destinationAsset.code is missing", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        sourceAsset: { code: "USDC" },
+        destinationAsset: {},
+        amount: "100",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DESTINATION_ASSET");
+  });
+
+  it("returns 400 INVALID_AMOUNT when amount is missing", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        sourceAsset: { code: "USDC" },
+        destinationAsset: { code: "XLM" },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns 400 INVALID_AMOUNT when amount is zero", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        ...validQuoteRequest,
+        amount: "0",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns 400 INVALID_AMOUNT when amount is negative", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send({
+        ...validQuoteRequest,
+        amount: "-50",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns unique quoteId for successive requests", async () => {
+    const res1 = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send(validQuoteRequest);
+    const res2 = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send(validQuoteRequest);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(res1.body.data.quoteId).not.toBe(res2.body.data.quoteId);
+  });
+
+  it("returns anchorQuote with verbatim payload from anchor", async () => {
+    __registerAnchor("test-anchor", { multiplier: 1, fee: "0.25" });
+
+    const res = await request(app)
+      .post("/anchors/test-anchor/quote")
+      .send(validQuoteRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.anchorQuote).toHaveProperty("price");
+    expect(res.body.data.anchorQuote).toHaveProperty("fee");
+    expect(res.body.data.anchorQuote.fee).toBe("0.25");
+  });
+
+  it("response data has the expected shape", async () => {
+    const res = await request(app)
+      .post("/anchors/anchor-circle/quote")
+      .send(validQuoteRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty("quoteId");
+    expect(res.body.data).toHaveProperty("anchorQuote");
+    expect(res.body.data).toHaveProperty("sourceAsset");
+    expect(res.body.data).toHaveProperty("destinationAsset");
+    expect(res.body.data).toHaveProperty("amount");
+    expect(res.body.data).toHaveProperty("price");
+    expect(res.body.data).toHaveProperty("expiresAt");
+  });
+});

--- a/routes-d/tests/anchors.transactions.list.test.ts
+++ b/routes-d/tests/anchors.transactions.list.test.ts
@@ -1,0 +1,169 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __resetTransactions,
+  __seedTransactions,
+} from "../routes/anchors.transactions.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /anchors/transactions", () => {
+  const app = buildApp();
+  const authHeader = { "x-user-id": "user-001" };
+
+  beforeEach(() => {
+    __resetTransactions();
+  });
+
+  it("returns empty list when no transactions exist", async () => {
+    __seedTransactions("user-empty", []);
+    const res = await request(app)
+      .get("/anchors/transactions")
+      .set("x-user-id", "user-empty");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("returns all transactions for a user", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.length).toBe(2);
+  });
+
+  it("filters by anchor", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions?anchor=anchor-circle")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].anchorId).toBe("anchor-circle");
+  });
+
+  it("filters by status", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions?status=pending")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].status).toBe("pending");
+  });
+
+  it("filters by both anchor and status", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions?anchor=anchor-circle&status=failed")
+      .set("x-user-id", "user-002");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].status).toBe("failed");
+    expect(res.body.data[0].anchorId).toBe("anchor-circle");
+  });
+
+  it("paginates results correctly", async () => {
+    const manyTransactions = Array.from({ length: 25 }, (_, i) => ({
+      id: `tx-${i}`,
+      userId: "user-001",
+      anchorId: "anchor-circle",
+      status: "completed" as const,
+      amount: "100.00",
+      currency: "USDC",
+      type: "deposit" as const,
+      startedAt: new Date(Date.now() - i * 1000).toISOString(),
+    }));
+    __seedTransactions("user-001", manyTransactions);
+
+    const res = await request(app)
+      .get("/anchors/transactions?page=1&limit=10")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(10);
+    expect(res.body.pagination.page).toBe(1);
+    expect(res.body.pagination.limit).toBe(10);
+    expect(res.body.pagination.total).toBe(25);
+    expect(res.body.pagination.totalPages).toBe(3);
+  });
+
+  it("sorts by startedAt descending (newest first)", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].id).toBe("tx-002"); // 2024-06-02
+    expect(res.body.data[1].id).toBe("tx-001"); // 2024-06-01
+  });
+
+  it("returns 401 when x-user-id header is missing", async () => {
+    const res = await request(app).get("/anchors/transactions");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 INVALID_STATUS for unrecognized status", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions?status=unknown")
+      .set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_STATUS");
+  });
+
+  it("returns 400 INVALID_PAGINATION for page 0", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions?page=0")
+      .set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGINATION");
+  });
+
+  it("returns 400 INVALID_PAGINATION for limit over max", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions?limit=200")
+      .set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGINATION");
+  });
+
+  it("response data has the expected shape", async () => {
+    const res = await request(app)
+      .get("/anchors/transactions")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination).toHaveProperty("page");
+    expect(res.body.pagination).toHaveProperty("limit");
+    expect(res.body.pagination).toHaveProperty("total");
+    expect(res.body.pagination).toHaveProperty("totalPages");
+
+    const tx = res.body.data[0];
+    expect(tx).toHaveProperty("id");
+    expect(tx).toHaveProperty("userId");
+    expect(tx).toHaveProperty("anchorId");
+    expect(tx).toHaveProperty("status");
+    expect(tx).toHaveProperty("amount");
+    expect(tx).toHaveProperty("currency");
+    expect(tx).toHaveProperty("type");
+    expect(tx).toHaveProperty("startedAt");
+  });
+});

--- a/routes-d/tests/cards.limit.set.test.ts
+++ b/routes-d/tests/cards.limit.set.test.ts
@@ -1,0 +1,239 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __resetCardStore,
+  __seedCard,
+  __setCompliance,
+  __setUserTier,
+  __getCard,
+  __getAuditEvents,
+} from "../routes/cards.limit.set.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /cards/:id/limit", () => {
+  const app = buildApp();
+  const userId = "user-001";
+  const authHeader = { "x-user-id": userId };
+
+  const ACTIVE_CARD = {
+    cardId: "card-001",
+    userId,
+    status: "active" as const,
+    maskedNumber: "****-****-****-1234",
+    expiryMonth: "12",
+    expiryYear: "2027",
+    currency: "USDC",
+    spendLimitAmount: "500.00",
+    issuedAt: "2024-01-01T00:00:00Z",
+  };
+
+  const OTHER_USER_CARD = {
+    cardId: "card-002",
+    userId: "user-other",
+    status: "active" as const,
+    maskedNumber: "****-****-****-5678",
+    expiryMonth: "06",
+    expiryYear: "2026",
+    currency: "USDC",
+    spendLimitAmount: "300.00",
+    issuedAt: "2024-01-01T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    __resetCardStore();
+    __seedCard(ACTIVE_CARD);
+    __seedCard(OTHER_USER_CARD);
+  });
+
+  it("sets spend limit on a card and returns 200", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "750.00" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.spendLimitAmount).toBe("750.00");
+    expect(res.body.data.cardId).toBe("card-001");
+    expect(res.body.data.updatedAt).toBeDefined();
+  });
+
+  it("persists the limit in storage", async () => {
+    await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "1000.00" });
+    const stored = __getCard("card-001")!;
+    expect(stored.spendLimitAmount).toBe("1000.00");
+  });
+
+  it("emits an audit event on limit change", async () => {
+    await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "2000.00" });
+    const events = __getAuditEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe("limit_set");
+    expect(events[0].cardId).toBe("card-001");
+    expect(events[0].performedBy).toBe(userId);
+    expect(events[0].limit).toBe("2000.00");
+  });
+
+  it("returns 403 FORBIDDEN when user is not card owner", async () => {
+    const res = await request(app)
+      .post("/cards/card-002/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "500.00" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 when x-user-id header is missing", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .send({ spendLimitAmount: "500.00" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 INVALID_SPEND_LIMIT when spendLimitAmount is missing", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SPEND_LIMIT");
+  });
+
+  it("returns 400 INVALID_SPEND_LIMIT when spendLimitAmount is not a string", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: 500 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SPEND_LIMIT");
+  });
+
+  it("returns 400 INVALID_SPEND_LIMIT when spendLimitAmount is zero", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "0" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SPEND_LIMIT");
+  });
+
+  it("returns 400 INVALID_SPEND_LIMIT when spendLimitAmount is negative", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "-100" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SPEND_LIMIT");
+  });
+
+  it("returns 403 TIER_LIMIT_EXCEEDED when exceeding default bronze tier limit", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "2000.00" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("TIER_LIMIT_EXCEEDED");
+  });
+
+  it("allows limit up to silver tier", async () => {
+    __resetCardStore();
+    __setUserTier(userId, "silver");
+    __seedCard(ACTIVE_CARD);
+
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "4500.00" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 403 TIER_LIMIT_EXCEEDED when exceeding silver tier limit", async () => {
+    __resetCardStore();
+    __setUserTier(userId, "silver");
+    __seedCard(ACTIVE_CARD);
+
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "6000.00" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("TIER_LIMIT_EXCEEDED");
+  });
+
+  it("returns 403 LIMIT_EXCEEDED when exceeding compliance limit", async () => {
+    __resetCardStore();
+    __setCompliance(userId, { kycPassed: true, eligible: true, maxSpendLimit: "500.00" });
+    __seedCard(ACTIVE_CARD);
+
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "750.00" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("LIMIT_EXCEEDED");
+  });
+
+  it("compliance limit takes precedence over tier limit", async () => {
+    __resetCardStore();
+    __setUserTier(userId, "gold");
+    __setCompliance(userId, { kycPassed: true, eligible: true, maxSpendLimit: "100.00" });
+    __seedCard(ACTIVE_CARD);
+
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "200.00" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("LIMIT_EXCEEDED");
+  });
+
+  it("returns 404 CARD_NOT_FOUND for unknown card", async () => {
+    const res = await request(app)
+      .post("/cards/nonexistent/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "500.00" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("CARD_NOT_FOUND");
+  });
+
+  it("response data has the expected shape", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/limit")
+      .set(authHeader)
+      .send({ spendLimitAmount: "600.00" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty("cardId");
+    expect(res.body.data).toHaveProperty("spendLimitAmount");
+    expect(res.body.data).toHaveProperty("updatedAt");
+  });
+});

--- a/routes-d/tests/cards.unfreeze.test.ts
+++ b/routes-d/tests/cards.unfreeze.test.ts
@@ -1,0 +1,177 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __resetCardStore,
+  __seedCard,
+  __getCard,
+  __getAuditEvents,
+} from "../routes/cards.unfreeze.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /cards/:id/unfreeze", () => {
+  const app = buildApp();
+  const userId = "user-001";
+  const authHeader = { "x-user-id": userId, "x-auth-timestamp": String(Date.now()) };
+
+  const FROZEN_CARD: CardRecord = {
+    cardId: "card-001",
+    userId,
+    status: "frozen",
+    maskedNumber: "****-****-****-1234",
+    expiryMonth: "12",
+    expiryYear: "2027",
+    currency: "USDC",
+    spendLimitAmount: "500.00",
+    issuedAt: "2024-01-01T00:00:00Z",
+    frozenAt: "2024-06-01T10:00:00Z",
+  };
+
+  const ACTIVE_CARD: CardRecord = {
+    cardId: "card-002",
+    userId,
+    status: "active",
+    maskedNumber: "****-****-****-5678",
+    expiryMonth: "06",
+    expiryYear: "2026",
+    currency: "USDC",
+    spendLimitAmount: "300.00",
+    issuedAt: "2024-01-01T00:00:00Z",
+  };
+
+  const CLOSED_CARD: CardRecord = {
+    cardId: "card-003",
+    userId,
+    status: "closed",
+    maskedNumber: "****-****-****-9999",
+    expiryMonth: "01",
+    expiryYear: "2025",
+    currency: "USDC",
+    spendLimitAmount: "100.00",
+    issuedAt: "2024-01-01T00:00:00Z",
+  };
+
+  type CardRecord = typeof FROZEN_CARD;
+
+  beforeEach(() => {
+    __resetCardStore();
+    __seedCard(FROZEN_CARD);
+    __seedCard(ACTIVE_CARD);
+    __seedCard(CLOSED_CARD);
+  });
+
+  it("unfreezes a frozen card and returns 200", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("active");
+    expect(res.body.data.cardId).toBe("card-001");
+    expect(res.body.data.unfrozenAt).toBeDefined();
+  });
+
+  it("persists unfreeze in storage", async () => {
+    await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set(authHeader);
+    const stored = __getCard("card-001")!;
+    expect(stored.status).toBe("active");
+    expect(stored.unfrozenAt).toBeDefined();
+  });
+
+  it("emits an audit event on unfreeze", async () => {
+    await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set(authHeader);
+    const events = __getAuditEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe("unfreeze");
+    expect(events[0].cardId).toBe("card-001");
+    expect(events[0].performedBy).toBe(userId);
+  });
+
+  it("returns 409 ALREADY_ACTIVE when card is already active", async () => {
+    const res = await request(app)
+      .post("/cards/card-002/unfreeze")
+      .set(authHeader);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_ACTIVE");
+  });
+
+  it("returns 409 CARD_CLOSED when card is closed", async () => {
+    const res = await request(app)
+      .post("/cards/card-003/unfreeze")
+      .set(authHeader);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("CARD_CLOSED");
+  });
+
+  it("returns 401 when x-user-id header is missing", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set("x-auth-timestamp", String(Date.now()));
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 REAUTH_REQUIRED when auth timestamp is missing", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set("x-user-id", userId);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("REAUTH_REQUIRED");
+  });
+
+  it("returns 403 REAUTH_REQUIRED when auth timestamp is stale", async () => {
+    const oldTimestamp = String(Date.now() - 600_000); // 10 minutes ago
+    const res = await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set("x-user-id", userId)
+      .set("x-auth-timestamp", oldTimestamp);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("REAUTH_REQUIRED");
+  });
+
+  it("returns 403 FORBIDDEN when user is not card owner", async () => {
+    const res = await request(app)
+      .post("/cards/card-001/unfreeze")
+      .set("x-user-id", "other-user")
+      .set("x-auth-timestamp", String(Date.now()));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 INVALID_CARD_ID when card id is missing", async () => {
+    const res = await request(app)
+      .post("/cards//unfreeze")
+      .set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CARD_ID");
+  });
+
+  it("returns 404 CARD_NOT_FOUND for unknown card", async () => {
+    const res = await request(app)
+      .post("/cards/nonexistent/unfreeze")
+      .set(authHeader);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("CARD_NOT_FOUND");
+  });
+});


### PR DESCRIPTION
Implements 4 new API routes in routes-d:

## #520 - User Anchor Transactions Route
- GET /anchors/transactions
- Lists calling Nextellar user transactions across known anchors
- Filters by anchor and status query parameters
- Paginates results sorted by start time descending
- Tests cover empty results, filtering, and pagination

## #525 - Card Unfreeze Route
- POST /cards/:id/unfreeze
- Re-enables a frozen virtual card
- Requires fresh authentication (within 5 minutes)
- Rejects when card is already active or closed
- Emits audit event on successful unfreeze
- Tests cover unfreeze, already active, and closed card scenarios

## #527 - Card Spending Limit Route
- POST /cards/:id/limit
- Sets or updates per-card spending limit
- Validates against compliance and user tier limits (bronze/silver/gold)
- Emits audit event on change
- Tests cover set, over-tier rejection, and unauthorized id scenarios

## #519 - Anchor Quote Route
- POST /anchors/:id/quote
- Fetches a quote from an anchor for a deposit or withdrawal
- Validates amount, source asset, and destination asset
- Returns anchor quote payload verbatim plus Nextellar quote id
- Tests cover normal quote, anchor failure, and validation error scenarios

Closes #520
Closes #525
Closes #527
Closes #519