### PR TITLE
Add LancePay contracts list route

### DIFF
--- a/routes-d/routes/lancepay.contracts.list.ts
+++ b/routes-d/routes/lancepay.contracts.list.ts
@@ -1,0 +1,115 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type ContractRecord = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  status: string;
+  currency: string;
+  rate: number;
+  scope: string;
+  startDate: string;
+  endDate?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const contracts = new Map<string, ContractRecord>();
+
+function requestedWorkspaceId(req: Request): string | undefined {
+  const header = req.header("x-lancepay-workspace-id") ?? req.header("x-workspace-id");
+  if (header?.trim()) return header.trim();
+
+  const queryWorkspaceId = req.query.workspaceId;
+  if (typeof queryWorkspaceId === "string" && queryWorkspaceId.trim()) {
+    return queryWorkspaceId.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * GET /lancepay/contracts
+ * List contracts for the calling LancePay workspace.
+ * Query params: contractor, status, currency, page, limit
+ */
+router.get(
+  "/lancepay/contracts",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { contractor, status, currency, page = "1", limit = "20" } = req.query;
+
+      const pageNum = parseInt(String(page), 10);
+      const limitNum = parseInt(String(limit), 10);
+
+      if (isNaN(pageNum) || pageNum < 1) {
+        sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+        return;
+      }
+
+      if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+        sendError(res, "INVALID_LIMIT", "limit must be between 1 and 100", 400);
+        return;
+      }
+
+      const workspaceId = requestedWorkspaceId(req);
+      let filtered = Array.from(contracts.values());
+
+      if (workspaceId) {
+        filtered = filtered.filter((contract) => contract.workspaceId === workspaceId);
+      }
+
+      if (contractor && typeof contractor === "string") {
+        filtered = filtered.filter((contract) => contract.contractorId === contractor.trim());
+      }
+
+      if (status && typeof status === "string") {
+        filtered = filtered.filter((contract) => contract.status === status.trim());
+      }
+
+      if (currency && typeof currency === "string") {
+        const normalizedCurrency = currency.trim().toUpperCase();
+        filtered = filtered.filter((contract) => contract.currency.toUpperCase() === normalizedCurrency);
+      }
+
+      filtered.sort((a, b) => {
+        const aTime = new Date(a.startDate).getTime();
+        const bTime = new Date(b.startDate).getTime();
+        return bTime - aTime;
+      });
+
+      const offset = (pageNum - 1) * limitNum;
+      const paged = filtered.slice(offset, offset + limitNum);
+
+      return res.status(200).json({
+        success: true,
+        data: paged,
+        pagination: {
+          page: pageNum,
+          limit: limitNum,
+          total: filtered.length,
+          hasNext: offset + limitNum < filtered.length,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedContract(contract: ContractRecord): void {
+  contracts.set(contract.id, { ...contract });
+}
+
+export function __resetContracts(): void {
+  contracts.clear();
+}
+
+export function __getContracts(): Map<string, ContractRecord> {
+  return contracts;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.contracts.list.test.ts
+++ b/routes-d/tests/lancepay.contracts.list.test.ts
@@ -1,0 +1,97 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedContract,
+  __resetContracts,
+  __getContracts,
+} from "../routes/lancepay.contracts.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+function seedContract(overrides: Partial<Parameters<typeof __seedContract>[0]> = {}) {
+  __seedContract({
+    id: overrides.id ?? "contract-1",
+    workspaceId: overrides.workspaceId ?? "ws-1",
+    contractorId: overrides.contractorId ?? "con-1",
+    status: overrides.status ?? "active",
+    currency: overrides.currency ?? "USD",
+    rate: overrides.rate ?? 100,
+    scope: overrides.scope ?? "Frontend work",
+    startDate: overrides.startDate ?? "2026-01-01T00:00:00Z",
+    endDate: overrides.endDate,
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00Z",
+    updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00Z",
+  });
+}
+
+describe("GET /lancepay/contracts", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetContracts();
+  });
+
+  it("returns an empty list when no contracts exist", async () => {
+    const res = await request(app).get("/lancepay/contracts");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("filters contracts by workspace, contractor, status, and currency", async () => {
+    seedContract({ id: "contract-1", workspaceId: "ws-1", contractorId: "con-1", status: "active", currency: "USD" });
+    seedContract({ id: "contract-2", workspaceId: "ws-1", contractorId: "con-2", status: "active", currency: "USD" });
+    seedContract({ id: "contract-3", workspaceId: "ws-1", contractorId: "con-1", status: "draft", currency: "USD" });
+    seedContract({ id: "contract-4", workspaceId: "ws-2", contractorId: "con-1", status: "active", currency: "USD" });
+    seedContract({ id: "contract-5", workspaceId: "ws-1", contractorId: "con-1", status: "active", currency: "EUR" });
+
+    const res = await request(app)
+      .get("/lancepay/contracts?contractor=con-1&status=active&currency=usd")
+      .set("x-lancepay-workspace-id", "ws-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("contract-1");
+  });
+
+  it("paginates contracts sorted by start date descending", async () => {
+    seedContract({ id: "old", startDate: "2026-01-01T00:00:00Z" });
+    seedContract({ id: "middle", startDate: "2026-02-01T00:00:00Z" });
+    seedContract({ id: "new", startDate: "2026-03-01T00:00:00Z" });
+
+    const page1 = await request(app).get("/lancepay/contracts?page=1&limit=2");
+    expect(page1.status).toBe(200);
+    expect(page1.body.data.map((contract: { id: string }) => contract.id)).toEqual(["new", "middle"]);
+    expect(page1.body.pagination).toMatchObject({ page: 1, limit: 2, total: 3, hasNext: true });
+
+    const page2 = await request(app).get("/lancepay/contracts?page=2&limit=2");
+    expect(page2.status).toBe(200);
+    expect(page2.body.data.map((contract: { id: string }) => contract.id)).toEqual(["old"]);
+    expect(page2.body.pagination.hasNext).toBe(false);
+  });
+
+  it("returns validation errors for invalid pagination", async () => {
+    const invalidPage = await request(app).get("/lancepay/contracts?page=0");
+    expect(invalidPage.status).toBe(400);
+    expect(invalidPage.body.error.code).toBe("INVALID_PAGE");
+
+    const invalidLimit = await request(app).get("/lancepay/contracts?limit=101");
+    expect(invalidLimit.status).toBe(400);
+    expect(invalidLimit.body.error.code).toBe("INVALID_LIMIT");
+  });
+
+  it("exposes the seeded contracts store for tests", () => {
+    seedContract({ id: "contract-1" });
+    expect(__getContracts().has("contract-1")).toBe(true);
+  });
+});


### PR DESCRIPTION

## Summary

This PR adds a new LancePay contracts list route under `routes-d/routes`, following the existing route naming and test patterns already used by the LancePay routes.

The new endpoint exposes `GET /lancepay/contracts` and allows a calling workspace to retrieve its contracts with useful filtering and pagination controls. It is intentionally scoped to the `routes-d/` folder, as required by the issue.

## Changes

- Added `routes-d/routes/lancepay.contracts.list.ts`.
- Added `GET /lancepay/contracts`.
- Added workspace scoping using `x-lancepay-workspace-id`, `x-workspace-id`, or `workspaceId`.
- Added filters for:
  - `contractor`
  - `status`
  - `currency`
- Added pagination with `page` and `limit`.
- Sorted results by `startDate` descending so newer contracts appear first.
- Added validation for invalid page and limit values.
- Added test helpers:
  - `__seedContract`
  - `__resetContracts`
  - `__getContracts`
- Added route tests under `routes-d/tests/lancepay.contracts.list.test.ts`.

## Test Coverage Added

The new tests cover:

- Empty contract list response.
- Filtering by workspace, contractor, status, and currency.
- Pagination behavior.
- Start-date sorting.
- Invalid pagination inputs.
- Test store helper behavior.

## Notes

This PR only touches files inside `routes-d/`, matching the issue scope. It does not modify shared app code, unrelated routes, or existing LancePay mutation flows.

## Testing

Closes #566
Closes #561
Closes #569 
Closes #577