### PR TITLE
feat(invoices): add GET /invoices list route with filtering and pagination

### DIFF
--- a/routes-d/routes/invoices.list.ts
+++ b/routes-d/routes/invoices.list.ts
@@ -1,0 +1,127 @@
+import { Router, Response, NextFunction } from "express";
+import { authenticate, AuthenticatedRequest } from "../../backend/middleware/auth.js";
+import { sendError } from "../../backend/utils/response.js";
+
+const router = Router();
+
+type InvoiceStatus = "draft" | "pending" | "paid" | "voided";
+
+interface InvoiceLineItem {
+  id: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  amount: number;
+}
+
+interface Invoice {
+  id: string;
+  issuerId: string;
+  payerId: string;
+  status: InvoiceStatus;
+  amount: number;
+  currency: string;
+  lineItems: InvoiceLineItem[];
+  createdAt: Date;
+  dueDate: Date;
+  paidAt?: Date;
+  stellarTxHash?: string;
+}
+
+// Mock storage for invoices
+const invoices = new Map<string, Invoice>();
+
+/**
+ * GET /invoices
+ * List invoices visible to the calling user (as issuer or payer).
+ * Query params: status, from, to, page, limit
+ * Results are sorted by createdAt descending (newest first).
+ */
+router.get(
+  "/invoices",
+  authenticate,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.sub;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "User not authenticated", 401);
+        return;
+      }
+
+      const { status, from, to, page = "1", limit = "20" } = req.query;
+
+      const pageNum = parseInt(String(page), 10);
+      const limitNum = parseInt(String(limit), 10);
+
+      if (isNaN(pageNum) || pageNum < 1) {
+        sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+        return;
+      }
+
+      if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+        sendError(res, "INVALID_LIMIT", "limit must be between 1 and 100", 400);
+        return;
+      }
+
+      let fromDate: Date | undefined;
+      let toDate: Date | undefined;
+
+      if (from) {
+        fromDate = new Date(String(from));
+        if (isNaN(fromDate.getTime())) {
+          sendError(res, "INVALID_DATE", "from must be a valid ISO date", 400);
+          return;
+        }
+      }
+
+      if (to) {
+        toDate = new Date(String(to));
+        if (isNaN(toDate.getTime())) {
+          sendError(res, "INVALID_DATE", "to must be a valid ISO date", 400);
+          return;
+        }
+      }
+
+      // Only return invoices where the caller is the issuer or payer
+      let filtered = Array.from(invoices.values()).filter(
+        (inv) => inv.issuerId === userId || inv.payerId === userId,
+      );
+
+      if (status && typeof status === "string") {
+        filtered = filtered.filter((inv) => inv.status === status.trim());
+      }
+
+      if (fromDate) {
+        filtered = filtered.filter((inv) => inv.createdAt >= fromDate!);
+      }
+
+      if (toDate) {
+        filtered = filtered.filter((inv) => inv.createdAt <= toDate!);
+      }
+
+      // Sort newest first
+      filtered.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+      const total = filtered.length;
+      const offset = (pageNum - 1) * limitNum;
+      const paged = filtered.slice(offset, offset + limitNum);
+
+      res.status(200).json({
+        success: true,
+        data: paged,
+        pagination: {
+          page: pageNum,
+          limit: limitNum,
+          total,
+          hasNext: offset + limitNum < total,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;
+export { invoices };

--- a/routes-d/tests/invoices.list.test.ts
+++ b/routes-d/tests/invoices.list.test.ts
@@ -1,0 +1,344 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import invoiceListRouter, { invoices } from "../routes/invoices.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(invoiceListRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+function createMockToken(userId: string): string {
+  const payload = JSON.stringify({ sub: userId, role: "user" });
+  return Buffer.from(payload).toString("base64");
+}
+
+const ISSUER = "user-issuer";
+const PAYER = "user-payer";
+const OTHER = "user-other";
+
+const BASE = {
+  issuerId: ISSUER,
+  payerId: PAYER,
+  amount: 100,
+  currency: "USD",
+  lineItems: [],
+  dueDate: new Date("2024-02-01"),
+};
+
+describe("GET /invoices", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    invoices.clear();
+  });
+
+  // --- empty list ---
+
+  it("returns empty list when caller has no invoices", async () => {
+    invoices.set("inv-other", {
+      ...BASE,
+      id: "inv-other",
+      issuerId: "someone-else",
+      payerId: "another-person",
+      status: "pending",
+      createdAt: new Date("2024-01-10"),
+    });
+
+    const res = await request(app)
+      .get("/invoices")
+      .set("Authorization", `Bearer ${createMockToken(OTHER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  // --- visibility ---
+
+  it("returns invoices where caller is the issuer", async () => {
+    invoices.set("inv-1", {
+      ...BASE,
+      id: "inv-1",
+      status: "pending",
+      createdAt: new Date("2024-01-05"),
+    });
+
+    const res = await request(app)
+      .get("/invoices")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("inv-1");
+  });
+
+  it("returns invoices where caller is the payer", async () => {
+    invoices.set("inv-1", {
+      ...BASE,
+      id: "inv-1",
+      status: "pending",
+      createdAt: new Date("2024-01-05"),
+    });
+
+    const res = await request(app)
+      .get("/invoices")
+      .set("Authorization", `Bearer ${createMockToken(PAYER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("inv-1");
+  });
+
+  it("does not return invoices where caller is neither issuer nor payer", async () => {
+    invoices.set("inv-1", {
+      ...BASE,
+      id: "inv-1",
+      status: "pending",
+      createdAt: new Date("2024-01-05"),
+    });
+
+    const res = await request(app)
+      .get("/invoices")
+      .set("Authorization", `Bearer ${createMockToken(OTHER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  // --- status filter ---
+
+  it("filters by status=paid", async () => {
+    invoices.set("inv-paid", {
+      ...BASE,
+      id: "inv-paid",
+      status: "paid",
+      createdAt: new Date("2024-01-01"),
+      paidAt: new Date("2024-01-10"),
+      stellarTxHash: "tx-abc",
+    });
+    invoices.set("inv-pending", {
+      ...BASE,
+      id: "inv-pending",
+      status: "pending",
+      createdAt: new Date("2024-01-02"),
+    });
+
+    const res = await request(app)
+      .get("/invoices?status=paid")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("inv-paid");
+  });
+
+  it("returns all statuses when no status filter is given", async () => {
+    for (const status of ["draft", "pending", "paid", "voided"] as const) {
+      invoices.set(`inv-${status}`, {
+        ...BASE,
+        id: `inv-${status}`,
+        status,
+        createdAt: new Date("2024-01-01"),
+      });
+    }
+
+    const res = await request(app)
+      .get("/invoices")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(4);
+  });
+
+  // --- date range filter ---
+
+  it("filters by from date", async () => {
+    invoices.set("inv-old", {
+      ...BASE,
+      id: "inv-old",
+      status: "pending",
+      createdAt: new Date("2024-01-01"),
+    });
+    invoices.set("inv-new", {
+      ...BASE,
+      id: "inv-new",
+      status: "pending",
+      createdAt: new Date("2024-02-01"),
+    });
+
+    const res = await request(app)
+      .get("/invoices?from=2024-01-15")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("inv-new");
+  });
+
+  it("filters by to date", async () => {
+    invoices.set("inv-old", {
+      ...BASE,
+      id: "inv-old",
+      status: "pending",
+      createdAt: new Date("2024-01-01"),
+    });
+    invoices.set("inv-new", {
+      ...BASE,
+      id: "inv-new",
+      status: "pending",
+      createdAt: new Date("2024-03-01"),
+    });
+
+    const res = await request(app)
+      .get("/invoices?to=2024-02-01")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("inv-old");
+  });
+
+  it("filters by combined status and date range", async () => {
+    invoices.set("inv-a", {
+      ...BASE,
+      id: "inv-a",
+      status: "pending",
+      createdAt: new Date("2024-01-10"),
+    });
+    invoices.set("inv-b", {
+      ...BASE,
+      id: "inv-b",
+      status: "paid",
+      createdAt: new Date("2024-01-15"),
+    });
+    invoices.set("inv-c", {
+      ...BASE,
+      id: "inv-c",
+      status: "pending",
+      createdAt: new Date("2024-02-01"),
+    });
+
+    const res = await request(app)
+      .get("/invoices?status=pending&from=2024-01-01&to=2024-01-31")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("inv-a");
+  });
+
+  // --- sort order ---
+
+  it("returns results sorted by createdAt descending", async () => {
+    invoices.set("inv-jan", {
+      ...BASE,
+      id: "inv-jan",
+      status: "pending",
+      createdAt: new Date("2024-01-01"),
+    });
+    invoices.set("inv-mar", {
+      ...BASE,
+      id: "inv-mar",
+      status: "pending",
+      createdAt: new Date("2024-03-01"),
+    });
+    invoices.set("inv-feb", {
+      ...BASE,
+      id: "inv-feb",
+      status: "pending",
+      createdAt: new Date("2024-02-01"),
+    });
+
+    const res = await request(app)
+      .get("/invoices")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((i: { id: string }) => i.id);
+    expect(ids).toEqual(["inv-mar", "inv-feb", "inv-jan"]);
+  });
+
+  // --- pagination ---
+
+  it("paginates correctly with page and limit", async () => {
+    for (let i = 1; i <= 5; i++) {
+      invoices.set(`inv-${i}`, {
+        ...BASE,
+        id: `inv-${i}`,
+        status: "pending",
+        createdAt: new Date(`2024-01-0${i}`),
+      });
+    }
+
+    const res = await request(app)
+      .get("/invoices?page=2&limit=2")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.pagination.page).toBe(2);
+    expect(res.body.pagination.limit).toBe(2);
+    expect(res.body.pagination.total).toBe(5);
+    expect(res.body.pagination.hasNext).toBe(true);
+  });
+
+  it("returns hasNext=false on the last page", async () => {
+    for (let i = 1; i <= 3; i++) {
+      invoices.set(`inv-${i}`, {
+        ...BASE,
+        id: `inv-${i}`,
+        status: "pending",
+        createdAt: new Date(`2024-01-0${i}`),
+      });
+    }
+
+    const res = await request(app)
+      .get("/invoices?page=2&limit=2")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.pagination.hasNext).toBe(false);
+  });
+
+  // --- validation ---
+
+  it("rejects invalid page param", async () => {
+    const res = await request(app)
+      .get("/invoices?page=0")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGE");
+  });
+
+  it("rejects invalid limit param", async () => {
+    const res = await request(app)
+      .get("/invoices?limit=200")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LIMIT");
+  });
+
+  it("rejects invalid from date", async () => {
+    const res = await request(app)
+      .get("/invoices?from=not-a-date")
+      .set("Authorization", `Bearer ${createMockToken(ISSUER)}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DATE");
+  });
+
+  it("rejects unauthenticated request", async () => {
+    const res = await request(app).get("/invoices");
+
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Closes #531
Closes #524
Closes #526
Closes #528

## Summary

- Add `routes-d/routes/invoices.list.ts` — `GET /invoices` with auth, caller-scoped visibility (issuer/payer), `status` and date range filters, pagination sorted by `createdAt` descending
- Add `routes-d/routes/cards.freeze.ts` — `POST /cards/:id/freeze` with fresh-auth enforcement (`x-auth-timestamp`), audit event emission, rejects already-frozen and closed cards
- Add `routes-d/routes/cards.transactions.list.ts` — `GET /cards/:id/transactions` with `status` filter, `from`/`to` date range, pagination sorted newest-first
- Add `routes-d/routes/cards.pin.set.ts` — `POST /cards/:id/pin` with per-card rate limiting (3 attempts / 60 s), 4–6 digit numeric PIN validation, one-way hash storage (raw PIN never persisted or logged)
- Add tests for all four routes covering empty, filtered, paginated, authorized, unauthorized, and validation cases

## Test plan

- [ ] `npm test -- --testPathPattern=invoices.list` — all tests pass
- [ ] `npm test -- --testPathPattern=cards.freeze` — all tests pass
- [ ] `npm test -- --testPathPattern=cards.transactions.list` — all tests pass
- [ ] `npm test -- --testPathPattern=cards.pin.set` — all tests pass
- [ ] No regressions in existing route tests