### PR TITLE
feat(routes-d): Add contractor create, contract sign, payout get, and…

### DIFF
--- a/routes-d/routes/lancepay.contractors.create.ts
+++ b/routes-d/routes/lancepay.contractors.create.ts
@@ -1,0 +1,164 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+const VALID_CONTRACT_TYPES = new Set(["fixed", "hourly", "milestone"]);
+
+type ContractorRecord = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  email: string;
+  taxId: string;
+  payoutWallet: string;
+  homeJurisdiction: string;
+  contractType: string;
+  status: string;
+  createdAt: string;
+};
+
+type CreateContractorBody = {
+  name: string;
+  email: string;
+  taxId: string;
+  payoutWallet: string;
+  homeJurisdiction: string;
+  contractType: string;
+};
+
+// In-memory store
+const contractors = new Map<string, ContractorRecord>();
+const emailIndex = new Map<string, string>(); // email+workspaceId -> contractorId
+
+/**
+ * POST /lancepay/contractors
+ * Create a contractor profile under the calling workspace owner.
+ * Validates identity fields, payout wallet, and home jurisdiction.
+ * Rejects duplicate email within the same workspace.
+ */
+router.post(
+  "/lancepay/contractors",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const workspaceId = req.headers["x-workspace-id"] as string | undefined;
+      if (!workspaceId) {
+        sendError(res, "MISSING_WORKSPACE", "x-workspace-id header is required", 401);
+        return;
+      }
+
+      const body = req.body as CreateContractorBody;
+
+      if (!body.name || typeof body.name !== "string" || !body.name.trim()) {
+        sendError(res, "INVALID_NAME", "name is required", 400);
+        return;
+      }
+
+      if (!body.email || typeof body.email !== "string") {
+        sendError(res, "INVALID_EMAIL", "email is required", 400);
+        return;
+      }
+
+      const email = body.email.trim().toLowerCase();
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        sendError(res, "INVALID_EMAIL", "email must be a valid email address", 400);
+        return;
+      }
+
+      if (!body.taxId || typeof body.taxId !== "string" || !body.taxId.trim()) {
+        sendError(res, "INVALID_TAX_ID", "taxId is required", 400);
+        return;
+      }
+
+      if (!body.payoutWallet || typeof body.payoutWallet !== "string") {
+        sendError(res, "INVALID_PAYOUT_WALLET", "payoutWallet is required", 400);
+        return;
+      }
+
+      const wallet = body.payoutWallet.trim();
+      if (!/^G[A-Z2-7]{55}$/.test(wallet)) {
+        sendError(
+          res,
+          "INVALID_PAYOUT_WALLET",
+          "payoutWallet must be a valid Stellar public key (G...)",
+          400,
+        );
+        return;
+      }
+
+      if (
+        !body.homeJurisdiction ||
+        typeof body.homeJurisdiction !== "string" ||
+        !body.homeJurisdiction.trim()
+      ) {
+        sendError(res, "INVALID_HOME_JURISDICTION", "homeJurisdiction is required", 400);
+        return;
+      }
+
+      if (!body.contractType || typeof body.contractType !== "string") {
+        sendError(res, "INVALID_CONTRACT_TYPE", "contractType is required", 400);
+        return;
+      }
+
+      const contractType = body.contractType.trim().toLowerCase();
+      if (!VALID_CONTRACT_TYPES.has(contractType)) {
+        sendError(
+          res,
+          "INVALID_CONTRACT_TYPE",
+          `contractType must be one of: ${[...VALID_CONTRACT_TYPES].join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      // Duplicate check within workspace
+      const dupKey = `${workspaceId}:${email}`;
+      if (emailIndex.has(dupKey)) {
+        sendError(
+          res,
+          "DUPLICATE_IDENTIFIER",
+          "A contractor with this email already exists in the workspace",
+          409,
+        );
+        return;
+      }
+
+      const id = `con-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const contractor: ContractorRecord = {
+        id,
+        workspaceId,
+        name: body.name.trim(),
+        email,
+        taxId: body.taxId.trim(),
+        payoutWallet: wallet,
+        homeJurisdiction: body.homeJurisdiction.trim(),
+        contractType,
+        status: "active",
+        createdAt: new Date().toISOString(),
+      };
+
+      contractors.set(id, contractor);
+      emailIndex.set(dupKey, id);
+
+      return res.status(201).json({ success: true, data: contractor });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedContractor(c: ContractorRecord): void {
+  contractors.set(c.id, { ...c });
+  emailIndex.set(`${c.workspaceId}:${c.email}`, c.id);
+}
+
+export function __resetContractors(): void {
+  contractors.clear();
+  emailIndex.clear();
+}
+
+export function __getContractors(): Map<string, ContractorRecord> {
+  return contractors;
+}
+
+export default router;

--- a/routes-d/routes/lancepay.contractors.payouts.list.ts
+++ b/routes-d/routes/lancepay.contractors.payouts.list.ts
@@ -1,0 +1,122 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type PayoutStatus = "pending" | "processing" | "completed" | "failed";
+
+type PayoutRecord = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  amount: number;
+  currency: string;
+  status: PayoutStatus;
+  submittedAt: string;
+};
+
+// In-memory store
+const payouts = new Map<string, PayoutRecord>();
+
+/**
+ * GET /lancepay/contractors/:id/payouts
+ * Return the payout history for a single LancePay contractor.
+ * Supports filtering by date range (from/to) and status.
+ * Paginated and sorted by submittedAt descending.
+ */
+router.get(
+  "/lancepay/contractors/:id/payouts",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const contractorId = req.params.id?.trim();
+      if (!contractorId) {
+        sendError(res, "INVALID_CONTRACTOR_ID", "contractorId is required", 400);
+        return;
+      }
+
+      const { status, from, to, page = "1", limit = "20" } = req.query;
+
+      const pageNum = parseInt(String(page), 10);
+      const limitNum = parseInt(String(limit), 10);
+
+      if (isNaN(pageNum) || pageNum < 1) {
+        sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+        return;
+      }
+
+      if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+        sendError(res, "INVALID_LIMIT", "limit must be between 1 and 100", 400);
+        return;
+      }
+
+      let fromDate: Date | undefined;
+      let toDate: Date | undefined;
+
+      if (from && typeof from === "string") {
+        fromDate = new Date(from);
+        if (isNaN(fromDate.getTime())) {
+          sendError(res, "INVALID_FROM_DATE", "from must be a valid ISO date string", 400);
+          return;
+        }
+      }
+
+      if (to && typeof to === "string") {
+        toDate = new Date(to);
+        if (isNaN(toDate.getTime())) {
+          sendError(res, "INVALID_TO_DATE", "to must be a valid ISO date string", 400);
+          return;
+        }
+      }
+
+      let filtered = Array.from(payouts.values()).filter(
+        (p) => p.contractorId === contractorId,
+      );
+
+      if (status && typeof status === "string") {
+        filtered = filtered.filter((p) => p.status === status.trim());
+      }
+
+      if (fromDate) {
+        filtered = filtered.filter((p) => new Date(p.submittedAt) >= fromDate!);
+      }
+
+      if (toDate) {
+        filtered = filtered.filter((p) => new Date(p.submittedAt) <= toDate!);
+      }
+
+      filtered.sort(
+        (a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+      );
+
+      const offset = (pageNum - 1) * limitNum;
+      const paged = filtered.slice(offset, offset + limitNum);
+
+      return res.status(200).json({
+        success: true,
+        data: paged,
+        pagination: {
+          page: pageNum,
+          limit: limitNum,
+          total: filtered.length,
+          hasNext: offset + limitNum < filtered.length,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedPayout(p: PayoutRecord): void {
+  payouts.set(p.id, { ...p });
+}
+
+export function __resetPayouts(): void {
+  payouts.clear();
+}
+
+export function __getPayouts(): Map<string, PayoutRecord> {
+  return payouts;
+}
+
+export default router;

--- a/routes-d/routes/lancepay.contracts.sign.ts
+++ b/routes-d/routes/lancepay.contracts.sign.ts
@@ -1,0 +1,128 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import crypto from "crypto";
+
+const router = Router();
+
+type Contract = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  content: string;
+  signedHash?: string;
+  signedAt?: string;
+  signedBy?: string;
+};
+
+type SignContractBody = {
+  signerId: string;
+  intentToken: string;
+};
+
+// In-memory store
+const contracts = new Map<string, Contract>();
+
+function computeHash(contractId: string, signerId: string, intentToken: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${contractId}:${signerId}:${intentToken}`)
+    .digest("hex");
+}
+
+/**
+ * POST /lancepay/contracts/:id/sign
+ * Capture a binding signature on a LancePay contract.
+ * Verifies signer identity and intent token, then persists
+ * a tamper-evident signed hash with timestamp.
+ */
+router.post(
+  "/lancepay/contracts/:id/sign",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const contractId = req.params.id?.trim();
+      if (!contractId) {
+        sendError(res, "INVALID_CONTRACT_ID", "contractId is required", 400);
+        return;
+      }
+
+      const body = req.body as SignContractBody;
+
+      if (!body.signerId || typeof body.signerId !== "string" || !body.signerId.trim()) {
+        sendError(res, "INVALID_SIGNER_ID", "signerId is required", 400);
+        return;
+      }
+
+      if (
+        !body.intentToken ||
+        typeof body.intentToken !== "string" ||
+        !body.intentToken.trim()
+      ) {
+        sendError(res, "INVALID_INTENT_TOKEN", "intentToken is required", 400);
+        return;
+      }
+
+      const contract = contracts.get(contractId);
+      if (!contract) {
+        sendError(res, "NOT_FOUND", "Contract not found", 404);
+        return;
+      }
+
+      // Reject already-signed contracts
+      if (contract.signedHash) {
+        sendError(
+          res,
+          "ALREADY_SIGNED",
+          "This contract has already been signed",
+          409,
+        );
+        return;
+      }
+
+      const signerId = body.signerId.trim();
+
+      // Signer must be the workspace owner or the assigned contractor
+      if (signerId !== contract.workspaceId && signerId !== contract.contractorId) {
+        sendError(
+          res,
+          "UNAUTHORIZED_SIGNER",
+          "signerId is not authorized to sign this contract",
+          403,
+        );
+        return;
+      }
+
+      const signedHash = computeHash(contractId, signerId, body.intentToken.trim());
+      const signedAt = new Date().toISOString();
+
+      contract.signedHash = signedHash;
+      contract.signedAt = signedAt;
+      contract.signedBy = signerId;
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          contractId,
+          signedBy: signerId,
+          signedHash,
+          signedAt,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedContract(c: Contract): void {
+  contracts.set(c.id, { ...c });
+}
+
+export function __resetContracts(): void {
+  contracts.clear();
+}
+
+export function __getContract(id: string): Contract | undefined {
+  return contracts.get(id);
+}
+
+export default router;

--- a/routes-d/routes/lancepay.payouts.get.ts
+++ b/routes-d/routes/lancepay.payouts.get.ts
@@ -1,0 +1,107 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type PayoutStatus = "pending" | "processing" | "completed" | "failed";
+
+type RetryEntry = {
+  attemptedAt: string;
+  reason: string;
+};
+
+type Payout = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  destinationWallet: string;
+  amount: number;
+  currency: string;
+  status: PayoutStatus;
+  fees?: number;
+  stellarTxHash?: string;
+  retryHistory?: RetryEntry[];
+  createdAt: string;
+  settledAt?: string;
+};
+
+// In-memory store
+const payouts = new Map<string, Payout>();
+
+/**
+ * GET /lancepay/payouts/:id
+ * Return a single payout with status, fees, and Stellar tx hash.
+ * Restricted to workspace members and the destination contractor.
+ * Includes retry history when present.
+ */
+router.get(
+  "/lancepay/payouts/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const callerId = req.headers["x-caller-id"] as string | undefined;
+      if (!callerId) {
+        sendError(res, "MISSING_CALLER", "x-caller-id header is required", 401);
+        return;
+      }
+
+      const payoutId = req.params.id?.trim();
+      if (!payoutId) {
+        sendError(res, "INVALID_PAYOUT_ID", "payoutId is required", 400);
+        return;
+      }
+
+      const payout = payouts.get(payoutId);
+      if (!payout) {
+        sendError(res, "NOT_FOUND", "Payout not found", 404);
+        return;
+      }
+
+      // Caller must be a workspace member or the destination contractor
+      if (callerId !== payout.workspaceId && callerId !== payout.contractorId) {
+        sendError(
+          res,
+          "FORBIDDEN",
+          "Access denied: caller is not a workspace member or the destination contractor",
+          403,
+        );
+        return;
+      }
+
+      const response: Record<string, unknown> = {
+        id: payout.id,
+        workspaceId: payout.workspaceId,
+        contractorId: payout.contractorId,
+        destinationWallet: payout.destinationWallet,
+        amount: payout.amount,
+        currency: payout.currency,
+        status: payout.status,
+        createdAt: payout.createdAt,
+      };
+
+      if (payout.fees !== undefined) response.fees = payout.fees;
+      if (payout.stellarTxHash) response.stellarTxHash = payout.stellarTxHash;
+      if (payout.settledAt) response.settledAt = payout.settledAt;
+      if (payout.retryHistory && payout.retryHistory.length > 0) {
+        response.retryHistory = payout.retryHistory;
+      }
+
+      return res.status(200).json({ success: true, data: response });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedPayout(p: Payout): void {
+  payouts.set(p.id, { ...p });
+}
+
+export function __resetPayouts(): void {
+  payouts.clear();
+}
+
+export function __getPayouts(): Map<string, Payout> {
+  return payouts;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.contractors.create.test.ts
+++ b/routes-d/tests/lancepay.contractors.create.test.ts
@@ -1,0 +1,169 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedContractor,
+  __resetContractors,
+  __getContractors,
+} from "../routes/lancepay.contractors.create.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_BODY = {
+  name: "Alice Nakamura",
+  email: "alice@example.com",
+  taxId: "US-123456789",
+  payoutWallet: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  homeJurisdiction: "US",
+  contractType: "fixed",
+};
+
+describe("POST /lancepay/contractors", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetContractors();
+  });
+
+  it("creates a contractor profile with valid data", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data.name).toBe("Alice Nakamura");
+    expect(res.body.data.email).toBe("alice@example.com");
+    expect(res.body.data.workspaceId).toBe("ws-1");
+    expect(res.body.data.status).toBe("active");
+    expect(res.body.data.payoutWallet).toBe(VALID_BODY.payoutWallet);
+    expect(res.body.data.homeJurisdiction).toBe("US");
+    expect(res.body.data.contractType).toBe("fixed");
+    expect(__getContractors().size).toBe(1);
+  });
+
+  it("returns 401 when x-workspace-id header is missing", async () => {
+    const res = await request(app).post("/lancepay/contractors").send(VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("MISSING_WORKSPACE");
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const { name: _n, ...rest } = VALID_BODY;
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(rest);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_NAME");
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send({ ...VALID_BODY, email: "not-an-email" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_EMAIL");
+  });
+
+  it("returns 400 when taxId is missing", async () => {
+    const { taxId: _t, ...rest } = VALID_BODY;
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(rest);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_TAX_ID");
+  });
+
+  it("returns 400 when payoutWallet is invalid", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send({ ...VALID_BODY, payoutWallet: "not-a-stellar-key" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAYOUT_WALLET");
+  });
+
+  it("returns 400 when homeJurisdiction is missing", async () => {
+    const { homeJurisdiction: _h, ...rest } = VALID_BODY;
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(rest);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_HOME_JURISDICTION");
+  });
+
+  it("returns 400 when contractType is unsupported", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send({ ...VALID_BODY, contractType: "retainer" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CONTRACT_TYPE");
+  });
+
+  it("returns 409 on duplicate email within the same workspace", async () => {
+    await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(VALID_BODY);
+
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("DUPLICATE_IDENTIFIER");
+    expect(__getContractors().size).toBe(1);
+  });
+
+  it("allows the same email in a different workspace", async () => {
+    const first = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send(VALID_BODY);
+    expect(first.status).toBe(201);
+
+    const second = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-2")
+      .send(VALID_BODY);
+    expect(second.status).toBe(201);
+    expect(second.body.data.workspaceId).toBe("ws-2");
+    expect(__getContractors().size).toBe(2);
+  });
+
+  it("normalises email to lowercase", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-1")
+      .send({ ...VALID_BODY, email: "ALICE@EXAMPLE.COM" });
+    expect(res.status).toBe(201);
+    expect(res.body.data.email).toBe("alice@example.com");
+  });
+
+  it("persists contractor bound to the calling workspace only", async () => {
+    const res = await request(app)
+      .post("/lancepay/contractors")
+      .set("x-workspace-id", "ws-99")
+      .send(VALID_BODY);
+    expect(res.status).toBe(201);
+    const created = res.body.data;
+    expect(created.workspaceId).toBe("ws-99");
+    const stored = __getContractors().get(created.id)!;
+    expect(stored.workspaceId).toBe("ws-99");
+  });
+});

--- a/routes-d/tests/lancepay.contractors.payouts.list.test.ts
+++ b/routes-d/tests/lancepay.contractors.payouts.list.test.ts
@@ -1,0 +1,165 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedPayout,
+  __resetPayouts,
+} from "../routes/lancepay.contractors.payouts.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const now = new Date("2026-06-20T12:00:00Z").getTime();
+
+function makePayout(
+  id: string,
+  contractorId: string,
+  status: "pending" | "processing" | "completed" | "failed",
+  offsetMs: number,
+) {
+  return {
+    id,
+    workspaceId: "ws-1",
+    contractorId,
+    amount: 100,
+    currency: "USD",
+    status,
+    submittedAt: new Date(now - offsetMs).toISOString(),
+  };
+}
+
+describe("GET /lancepay/contractors/:id/payouts", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetPayouts();
+  });
+
+  it("returns empty list when contractor has no payouts", async () => {
+    const res = await request(app).get("/lancepay/contractors/con-1/payouts");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("returns only payouts belonging to the specified contractor", async () => {
+    __seedPayout(makePayout("pay-1", "con-1", "completed", 3000));
+    __seedPayout(makePayout("pay-2", "con-1", "pending", 2000));
+    __seedPayout(makePayout("pay-3", "con-2", "completed", 1000));
+
+    const res = await request(app).get("/lancepay/contractors/con-1/payouts");
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.data.every((p: { contractorId: string }) => p.contractorId === "con-1")).toBe(
+      true,
+    );
+  });
+
+  it("filters by status", async () => {
+    __seedPayout(makePayout("pay-1", "con-1", "completed", 3000));
+    __seedPayout(makePayout("pay-2", "con-1", "pending", 2000));
+    __seedPayout(makePayout("pay-3", "con-1", "failed", 1000));
+
+    const res = await request(app).get(
+      "/lancepay/contractors/con-1/payouts?status=completed",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].status).toBe("completed");
+  });
+
+  it("filters by date range (from)", async () => {
+    __seedPayout(makePayout("pay-old", "con-1", "completed", 86400000)); // 1 day ago
+    __seedPayout(makePayout("pay-new", "con-1", "completed", 1000));
+
+    const from = new Date(now - 3600000).toISOString(); // 1 hour ago
+    const res = await request(app).get(
+      `/lancepay/contractors/con-1/payouts?from=${encodeURIComponent(from)}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("pay-new");
+  });
+
+  it("filters by date range (to)", async () => {
+    __seedPayout(makePayout("pay-old", "con-1", "completed", 86400000));
+    __seedPayout(makePayout("pay-new", "con-1", "completed", 1000));
+
+    const to = new Date(now - 3600000).toISOString(); // 1 hour ago
+    const res = await request(app).get(
+      `/lancepay/contractors/con-1/payouts?to=${encodeURIComponent(to)}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("pay-old");
+  });
+
+  it("returns results sorted by submittedAt descending", async () => {
+    __seedPayout(makePayout("pay-oldest", "con-1", "completed", 5000));
+    __seedPayout(makePayout("pay-newest", "con-1", "completed", 1000));
+    __seedPayout(makePayout("pay-middle", "con-1", "completed", 3000));
+
+    const res = await request(app).get("/lancepay/contractors/con-1/payouts");
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((p: { id: string }) => p.id);
+    expect(ids).toEqual(["pay-newest", "pay-middle", "pay-oldest"]);
+  });
+
+  it("paginates results", async () => {
+    for (let i = 1; i <= 15; i++) {
+      __seedPayout(makePayout(`pay-${i}`, "con-1", "completed", i * 1000));
+    }
+
+    const page1 = await request(app).get(
+      "/lancepay/contractors/con-1/payouts?page=1&limit=5",
+    );
+    expect(page1.status).toBe(200);
+    expect(page1.body.data.length).toBe(5);
+    expect(page1.body.pagination.total).toBe(15);
+    expect(page1.body.pagination.hasNext).toBe(true);
+
+    const page3 = await request(app).get(
+      "/lancepay/contractors/con-1/payouts?page=3&limit=5",
+    );
+    expect(page3.status).toBe(200);
+    expect(page3.body.data.length).toBe(5);
+    expect(page3.body.pagination.hasNext).toBe(false);
+  });
+
+  it("returns 400 for invalid page", async () => {
+    const res = await request(app).get("/lancepay/contractors/con-1/payouts?page=0");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGE");
+  });
+
+  it("returns 400 for invalid limit", async () => {
+    const res = await request(app).get(
+      "/lancepay/contractors/con-1/payouts?limit=200",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LIMIT");
+  });
+
+  it("returns 400 for invalid from date", async () => {
+    const res = await request(app).get(
+      "/lancepay/contractors/con-1/payouts?from=not-a-date",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_FROM_DATE");
+  });
+
+  it("returns 400 for invalid to date", async () => {
+    const res = await request(app).get(
+      "/lancepay/contractors/con-1/payouts?to=bad-date",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_TO_DATE");
+  });
+});

--- a/routes-d/tests/lancepay.contracts.sign.test.ts
+++ b/routes-d/tests/lancepay.contracts.sign.test.ts
@@ -1,0 +1,121 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedContract,
+  __getContract,
+  __resetContracts,
+} from "../routes/lancepay.contracts.sign.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const BASE_CONTRACT = {
+  id: "contract-1",
+  workspaceId: "ws-1",
+  contractorId: "con-1",
+  content: "Full-stack development, 12 months, $100/hr",
+};
+
+describe("POST /lancepay/contracts/:id/sign", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetContracts();
+    __seedContract(BASE_CONTRACT);
+  });
+
+  it("signs a contract with a valid workspace owner signer", async () => {
+    const res = await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "ws-1", intentToken: "tok-abc-123" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.contractId).toBe("contract-1");
+    expect(res.body.data.signedBy).toBe("ws-1");
+    expect(res.body.data).toHaveProperty("signedHash");
+    expect(res.body.data).toHaveProperty("signedAt");
+    expect(typeof res.body.data.signedHash).toBe("string");
+    expect(res.body.data.signedHash.length).toBeGreaterThan(0);
+  });
+
+  it("signs a contract with the assigned contractor signer", async () => {
+    const res = await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "con-1", intentToken: "tok-xyz-789" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.signedBy).toBe("con-1");
+    const stored = __getContract("contract-1")!;
+    expect(stored.signedBy).toBe("con-1");
+    expect(stored.signedHash).toBeDefined();
+    expect(stored.signedAt).toBeDefined();
+  });
+
+  it("returns 409 when the contract is already signed", async () => {
+    await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "ws-1", intentToken: "tok-first" });
+
+    const res = await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "ws-1", intentToken: "tok-second" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_SIGNED");
+  });
+
+  it("returns 403 when signer is not authorized", async () => {
+    const res = await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "intruder-99", intentToken: "tok-bad" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("UNAUTHORIZED_SIGNER");
+  });
+
+  it("returns 404 for unknown contract id", async () => {
+    const res = await request(app)
+      .post("/lancepay/contracts/nonexistent/sign")
+      .send({ signerId: "ws-1", intentToken: "tok-abc" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 400 when signerId is missing", async () => {
+    const res = await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ intentToken: "tok-abc" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_SIGNER_ID");
+  });
+
+  it("returns 400 when intentToken is missing", async () => {
+    const res = await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "ws-1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_INTENT_TOKEN");
+  });
+
+  it("persists a tamper-evident signed hash on the contract", async () => {
+    await request(app)
+      .post("/lancepay/contracts/contract-1/sign")
+      .send({ signerId: "ws-1", intentToken: "tok-tamper-test" });
+
+    const stored = __getContract("contract-1")!;
+    expect(stored.signedHash).toBeDefined();
+    expect(stored.signedHash!.length).toBe(64); // SHA-256 hex digest
+    expect(stored.signedAt).toBeDefined();
+  });
+});

--- a/routes-d/tests/lancepay.payouts.get.test.ts
+++ b/routes-d/tests/lancepay.payouts.get.test.ts
@@ -1,0 +1,118 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedPayout,
+  __resetPayouts,
+} from "../routes/lancepay.payouts.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const BASE_PAYOUT = {
+  id: "pay-1",
+  workspaceId: "ws-1",
+  contractorId: "con-1",
+  destinationWallet: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  amount: 500,
+  currency: "USD",
+  status: "completed" as const,
+  fees: 2.5,
+  stellarTxHash: "abc123stellartx",
+  createdAt: "2026-06-20T10:00:00Z",
+  settledAt: "2026-06-20T12:00:00Z",
+};
+
+describe("GET /lancepay/payouts/:id", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetPayouts();
+    __seedPayout(BASE_PAYOUT);
+  });
+
+  it("returns payout details for workspace member", async () => {
+    const res = await request(app)
+      .get("/lancepay/payouts/pay-1")
+      .set("x-caller-id", "ws-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe("pay-1");
+    expect(res.body.data.status).toBe("completed");
+    expect(res.body.data.amount).toBe(500);
+    expect(res.body.data.currency).toBe("USD");
+    expect(res.body.data.fees).toBe(2.5);
+    expect(res.body.data.stellarTxHash).toBe("abc123stellartx");
+    expect(res.body.data.settledAt).toBe("2026-06-20T12:00:00Z");
+  });
+
+  it("returns payout details for destination contractor", async () => {
+    const res = await request(app)
+      .get("/lancepay/payouts/pay-1")
+      .set("x-caller-id", "con-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe("pay-1");
+    expect(res.body.data.contractorId).toBe("con-1");
+  });
+
+  it("includes retry history when present", async () => {
+    __seedPayout({
+      ...BASE_PAYOUT,
+      id: "pay-retry",
+      status: "failed",
+      retryHistory: [
+        { attemptedAt: "2026-06-20T10:05:00Z", reason: "network timeout" },
+        { attemptedAt: "2026-06-20T10:15:00Z", reason: "insufficient funds" },
+      ],
+    });
+
+    const res = await request(app)
+      .get("/lancepay/payouts/pay-retry")
+      .set("x-caller-id", "ws-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.retryHistory).toHaveLength(2);
+    expect(res.body.data.retryHistory[0].reason).toBe("network timeout");
+  });
+
+  it("omits retryHistory when not present", async () => {
+    const res = await request(app)
+      .get("/lancepay/payouts/pay-1")
+      .set("x-caller-id", "ws-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).not.toHaveProperty("retryHistory");
+  });
+
+  it("returns 404 for unknown payout id", async () => {
+    const res = await request(app)
+      .get("/lancepay/payouts/nonexistent")
+      .set("x-caller-id", "ws-1");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 for cross-workspace caller", async () => {
+    const res = await request(app)
+      .get("/lancepay/payouts/pay-1")
+      .set("x-caller-id", "ws-other");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 when x-caller-id header is missing", async () => {
+    const res = await request(app).get("/lancepay/payouts/pay-1");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("MISSING_CALLER");
+  });
+});


### PR DESCRIPTION
  ## Summary

  Implements four missing LancePay routes inside `routes-d/routes/` with matching tests in `routes-d/tests/`,
  consistent with the existing codebase architecture, TypeScript style, and in-memory fixture patterns.

  ### Routes added

  | File | Method & Path | Issue |
  |---|---|---|
  | `lancepay.contractors.create.ts` | `POST /lancepay/contractors` | #554 |
  | `lancepay.contracts.sign.ts` | `POST /lancepay/contracts/:id/sign` | #568 |
  | `lancepay.payouts.get.ts` | `GET /lancepay/payouts/:id` | #574 |
  | `lancepay.contractors.payouts.list.ts` | `GET /lancepay/contractors/:id/payouts` | #562 |

  ### Details

  **#554 — Contractor profile creation (`lancepay.contractors.create.ts`)**
  - Validates name, email (format + normalised to lowercase), taxId, Stellar `payoutWallet` (`G...` 56-char
  key), `homeJurisdiction`, and `contractType` (`fixed` | `hourly` | `milestone`)
  - Rejects duplicate email within the same workspace (`409 DUPLICATE_IDENTIFIER`)
  - Cross-workspace isolation: the created profile is bound to the `x-workspace-id` header only; the same email
  is allowed in another workspace
  - Returns `201` with the full contractor record on success

  **#568 — Contract signing (`lancepay.contracts.sign.ts`)**
  - Validates `signerId` and `intentToken` before touching the record
  - Authorises only the workspace owner (`workspaceId`) or the assigned contractor (`contractorId`)
  - Rejects already-signed contracts (`409 ALREADY_SIGNED`)
  - Persists a tamper-evident `sha256(contractId:signerId:intentToken)` hex digest and ISO timestamp on the
  contract

  **#574 — Payout details (`lancepay.payouts.get.ts`)**
  - Requires `x-caller-id` header; rejects missing (`401`) and foreign callers (`403`)
  - Returns status, fees, `stellarTxHash`, `settledAt`, and `retryHistory` (included only when non-empty)
  - `retryHistory` entries carry `{ attemptedAt, reason }`

  **#562 — Contractor payout history (`lancepay.contractors.payouts.list.ts`)**
  - Filters by `status`, ISO date `from` / `to` range with validation
  - Paginated (`page`, `limit` 1–100) and sorted by `submittedAt` descending
  - Returns only payouts for the specified contractor ID

  ### Tests

  Each route has a dedicated test file covering:
  - Happy-path responses
  - Validation errors (400)
  - Auth / workspace isolation (401 / 403)
  - Business-rule rejections (409 duplicate, already-signed)
  - Pagination and filtering edge cases

  ### Scope

  No files outside `routes-d/` were modified.

  ---

  Closes #554
  Closes #568
  Closes #574
  Closes #562
