### PR TITLE
feat(routes): add subscriptions list, invoice pay, and invoice PDF routes

### DIFF
--- a/routes-d/routes/invoices.pay.ts
+++ b/routes-d/routes/invoices.pay.ts
@@ -1,0 +1,127 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type InvoiceStatus = "draft" | "pending" | "paid" | "voided" | "expired";
+
+interface Invoice {
+  id: string;
+  issuerId: string;
+  payerId: string;
+  status: InvoiceStatus;
+  amount: number;
+  currency: string;
+  dueDate: Date;
+  createdAt: Date;
+  paidAt?: Date;
+  stellarTxHash?: string;
+}
+
+const invoices = new Map<string, Invoice>();
+// Idempotency: track (invoiceId, payerId) pairs that already completed
+const paidPairs = new Set<string>();
+
+export function __resetInvoices(): void {
+  invoices.clear();
+  paidPairs.clear();
+}
+
+export function __seedInvoice(inv: Invoice): void {
+  invoices.set(inv.id, { ...inv });
+}
+
+export function __getInvoice(id: string): Invoice | undefined {
+  return invoices.get(id);
+}
+
+/**
+ * POST /invoices/:id/pay
+ * Mark an open invoice as paid. Idempotent: a second call from the same
+ * payer on the same invoice returns the existing paid record.
+ */
+router.post(
+  "/invoices/:id/pay",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const invoice = invoices.get(id);
+
+      if (!invoice) {
+        sendError(res, "NOT_FOUND", "Invoice not found", 404);
+        return;
+      }
+
+      if (invoice.payerId !== userId) {
+        sendError(res, "FORBIDDEN", "Only the invoice payer can pay this invoice", 403);
+        return;
+      }
+
+      // Idempotency: already paid by this payer
+      const pairKey = `${id}:${userId}`;
+      if (paidPairs.has(pairKey)) {
+        return res.status(200).json({
+          success: true,
+          data: {
+            id: invoice.id,
+            status: invoice.status,
+            paidAt: invoice.paidAt,
+            stellarTxHash: invoice.stellarTxHash,
+          },
+          idempotent: true,
+        });
+      }
+
+      if (invoice.status === "paid") {
+        sendError(res, "ALREADY_PAID", "Invoice has already been paid", 409);
+        return;
+      }
+
+      if (invoice.status === "voided") {
+        sendError(res, "INVOICE_VOIDED", "Cannot pay a voided invoice", 409);
+        return;
+      }
+
+      if (invoice.status === "expired" || invoice.dueDate < new Date()) {
+        sendError(res, "INVOICE_EXPIRED", "Cannot pay an expired invoice", 409);
+        return;
+      }
+
+      if (invoice.status === "draft") {
+        sendError(res, "INVOICE_NOT_PAYABLE", "Invoice is still in draft state", 409);
+        return;
+      }
+
+      const now = new Date();
+      const txHash = `stellar-tx-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+      invoice.status = "paid";
+      invoice.paidAt = now;
+      invoice.stellarTxHash = txHash;
+
+      paidPairs.add(pairKey);
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          id: invoice.id,
+          status: "paid",
+          paidAt: now,
+          stellarTxHash: txHash,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;
+export { invoices };

--- a/routes-d/routes/invoices.pdf.ts
+++ b/routes-d/routes/invoices.pdf.ts
@@ -1,0 +1,125 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type InvoiceStatus = "draft" | "pending" | "paid" | "voided";
+
+interface InvoiceLineItem {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  amount: number;
+}
+
+interface Invoice {
+  id: string;
+  issuerId: string;
+  payerId: string;
+  status: InvoiceStatus;
+  amount: number;
+  currency: string;
+  lineItems: InvoiceLineItem[];
+  createdAt: Date;
+  dueDate: Date;
+  paidAt?: Date;
+  stellarTxHash?: string;
+}
+
+const invoices = new Map<string, Invoice>();
+
+export function __resetInvoices(): void {
+  invoices.clear();
+}
+
+export function __seedInvoice(inv: Invoice): void {
+  invoices.set(inv.id, { ...inv });
+}
+
+const SUPPORTED_LOCALES = ["en", "es", "fr", "pt"] as const;
+type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+const LABELS: Record<Locale, Record<string, string>> = {
+  en: { invoice: "Invoice", total: "Total", due: "Due", status: "Status", issued: "Issued" },
+  es: { invoice: "Factura", total: "Total", due: "Vence", status: "Estado", issued: "Emitida" },
+  fr: { invoice: "Facture", total: "Total", due: "Échéance", status: "Statut", issued: "Émise" },
+  pt: { invoice: "Fatura", total: "Total", due: "Vencimento", status: "Status", issued: "Emitida" },
+};
+
+function buildPdfBytes(invoice: Invoice, locale: Locale): Buffer {
+  const l = LABELS[locale];
+  const lines = [
+    `%PDF-1.4`,
+    `% Nextellar Invoice ${invoice.id}`,
+    `${l.invoice}: ${invoice.id}`,
+    `${l.status}: ${invoice.status}`,
+    `${l.issued}: ${invoice.createdAt.toISOString()}`,
+    `${l.due}: ${invoice.dueDate.toISOString()}`,
+    ...invoice.lineItems.map(
+      (li) => `  ${li.description} x${li.quantity} @ ${li.unitPrice} = ${li.amount} ${invoice.currency}`,
+    ),
+    `${l.total}: ${invoice.amount} ${invoice.currency}`,
+    invoice.paidAt ? `Paid: ${invoice.paidAt.toISOString()}` : "",
+    invoice.stellarTxHash ? `Tx: ${invoice.stellarTxHash}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return Buffer.from(lines, "utf8");
+}
+
+/**
+ * GET /invoices/:id/pdf
+ * Stream a PDF rendering of an invoice.
+ * Query param: locale (en | es | fr | pt, default: en)
+ * Access restricted to the invoice issuer or payer.
+ */
+router.get(
+  "/invoices/:id/pdf",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const invoice = invoices.get(id);
+
+      if (!invoice) {
+        sendError(res, "NOT_FOUND", "Invoice not found", 404);
+        return;
+      }
+
+      if (invoice.issuerId !== userId && invoice.payerId !== userId) {
+        sendError(res, "FORBIDDEN", "You do not have access to this invoice", 403);
+        return;
+      }
+
+      const rawLocale = typeof req.query.locale === "string" ? req.query.locale : "en";
+      const locale: Locale = (SUPPORTED_LOCALES as readonly string[]).includes(rawLocale)
+        ? (rawLocale as Locale)
+        : "en";
+
+      const pdfBytes = buildPdfBytes(invoice, locale);
+
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="invoice-${invoice.id}.pdf"`,
+      );
+      res.setHeader("Content-Length", pdfBytes.length);
+
+      // Stream without buffering
+      res.flushHeaders();
+      res.end(pdfBytes);
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;
+export { invoices };

--- a/routes-d/routes/subscriptions.list.ts
+++ b/routes-d/routes/subscriptions.list.ts
@@ -1,0 +1,101 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type SubscriptionStatus = "active" | "paused" | "cancelled";
+
+type Subscription = {
+  id: string;
+  userId: string;
+  planId: string;
+  billingInterval: "monthly" | "yearly";
+  status: SubscriptionStatus;
+  startDate: string;
+  createdAt: string;
+};
+
+const subscriptions = new Map<string, Subscription>();
+
+export function __resetSubscriptions(): void {
+  subscriptions.clear();
+}
+
+export function __seedSubscription(sub: Subscription): void {
+  subscriptions.set(sub.id, { ...sub });
+}
+
+export function __getSubscriptions(): Map<string, Subscription> {
+  return subscriptions;
+}
+
+/**
+ * GET /subscriptions
+ * List subscriptions belonging to the calling user.
+ * Query params: status, planId, page, limit
+ * Sorted by startDate ascending (oldest first).
+ */
+router.get(
+  "/subscriptions",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const { status, planId, page = "1", limit = "20" } = req.query;
+
+      const pageNum = parseInt(String(page), 10);
+      const limitNum = parseInt(String(limit), 10);
+
+      if (isNaN(pageNum) || pageNum < 1) {
+        sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+        return;
+      }
+
+      if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+        sendError(res, "INVALID_LIMIT", "limit must be between 1 and 100", 400);
+        return;
+      }
+
+      let filtered = Array.from(subscriptions.values()).filter(
+        (sub) => sub.userId === userId,
+      );
+
+      if (status && typeof status === "string") {
+        filtered = filtered.filter((sub) => sub.status === status.trim());
+      }
+
+      if (planId && typeof planId === "string") {
+        filtered = filtered.filter((sub) => sub.planId === planId.trim());
+      }
+
+      // Sort by startDate ascending (oldest subscription first)
+      filtered.sort(
+        (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+      );
+
+      const total = filtered.length;
+      const offset = (pageNum - 1) * limitNum;
+      const paged = filtered.slice(offset, offset + limitNum);
+
+      return res.status(200).json({
+        success: true,
+        data: paged,
+        pagination: {
+          page: pageNum,
+          limit: limitNum,
+          total,
+          hasNext: offset + limitNum < total,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/invoices.pay.test.ts
+++ b/routes-d/tests/invoices.pay.test.ts
@@ -1,0 +1,125 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import invoicePayRouter, {
+  __resetInvoices,
+  __seedInvoice,
+  __getInvoice,
+} from "../routes/invoices.pay.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(invoicePayRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const ISSUER = "user-issuer";
+const PAYER = "user-payer";
+const OTHER = "user-other";
+const INV_ID = "inv-001";
+const FUTURE = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+describe("POST /invoices/:id/pay", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetInvoices();
+  });
+
+  it("pays a pending invoice successfully", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "pending", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: FUTURE });
+
+    const res = await request(app)
+      .post(`/invoices/${INV_ID}/pay`)
+      .set("x-user-id", PAYER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("paid");
+    expect(res.body.data.paidAt).toBeDefined();
+    expect(res.body.data.stellarTxHash).toBeDefined();
+    expect(res.body.idempotent).toBeUndefined();
+  });
+
+  it("persists paid status on the stored invoice", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "pending", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: FUTURE });
+
+    await request(app).post(`/invoices/${INV_ID}/pay`).set("x-user-id", PAYER);
+
+    expect(__getInvoice(INV_ID)?.status).toBe("paid");
+  });
+
+  it("is idempotent — second call returns same paid record", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "pending", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: FUTURE });
+
+    const first = await request(app).post(`/invoices/${INV_ID}/pay`).set("x-user-id", PAYER);
+    const second = await request(app).post(`/invoices/${INV_ID}/pay`).set("x-user-id", PAYER);
+
+    expect(second.status).toBe(200);
+    expect(second.body.idempotent).toBe(true);
+    expect(second.body.data.stellarTxHash).toBe(first.body.data.stellarTxHash);
+  });
+
+  it("rejects when invoice is already paid by a different payer", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "paid", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: FUTURE, paidAt: new Date() });
+
+    const res = await request(app)
+      .post(`/invoices/${INV_ID}/pay`)
+      .set("x-user-id", PAYER);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_PAID");
+  });
+
+  it("rejects paying a voided invoice", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "voided", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: FUTURE });
+
+    const res = await request(app)
+      .post(`/invoices/${INV_ID}/pay`)
+      .set("x-user-id", PAYER);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("INVOICE_VOIDED");
+  });
+
+  it("rejects paying an expired invoice (past dueDate)", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "pending", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: PAST });
+
+    const res = await request(app)
+      .post(`/invoices/${INV_ID}/pay`)
+      .set("x-user-id", PAYER);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("INVOICE_EXPIRED");
+  });
+
+  it("rejects when caller is not the payer", async () => {
+    __seedInvoice({ id: INV_ID, issuerId: ISSUER, payerId: PAYER, status: "pending", amount: 200, currency: "USDC", lineItems: [], createdAt: new Date(), dueDate: FUTURE });
+
+    const res = await request(app)
+      .post(`/invoices/${INV_ID}/pay`)
+      .set("x-user-id", OTHER);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("rejects when invoice is not found", async () => {
+    const res = await request(app)
+      .post("/invoices/nonexistent/pay")
+      .set("x-user-id", PAYER);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("rejects unauthenticated request", async () => {
+    const res = await request(app).post(`/invoices/${INV_ID}/pay`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/routes-d/tests/invoices.pdf.test.ts
+++ b/routes-d/tests/invoices.pdf.test.ts
@@ -1,0 +1,166 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import invoicePdfRouter, {
+  __resetInvoices,
+  __seedInvoice,
+} from "../routes/invoices.pdf.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(invoicePdfRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const ISSUER = "user-issuer";
+const PAYER = "user-payer";
+const OTHER = "user-other";
+const INV_ID = "inv-001";
+
+const BASE_INVOICE = {
+  id: INV_ID,
+  issuerId: ISSUER,
+  payerId: PAYER,
+  status: "pending" as const,
+  amount: 150,
+  currency: "USDC",
+  lineItems: [{ description: "Design work", quantity: 3, unitPrice: 50, amount: 150 }],
+  createdAt: new Date("2024-01-01"),
+  dueDate: new Date("2024-02-01"),
+};
+
+describe("GET /invoices/:id/pdf", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetInvoices();
+  });
+
+  // --- render ---
+
+  it("returns a PDF for the issuer", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf`)
+      .set("x-user-id", ISSUER);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/pdf/);
+    expect(res.headers["content-disposition"]).toContain(`invoice-${INV_ID}.pdf`);
+    expect(res.body).toBeDefined();
+  });
+
+  it("returns a PDF for the payer", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf`)
+      .set("x-user-id", PAYER);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/pdf/);
+  });
+
+  it("PDF body contains the invoice ID and amount", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf`)
+      .set("x-user-id", ISSUER)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    expect(res.text).toContain(INV_ID);
+    expect(res.text).toContain("150");
+  });
+
+  // --- locale ---
+
+  it("renders with default English locale", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf`)
+      .set("x-user-id", ISSUER)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    expect(res.text).toContain("Invoice");
+    expect(res.text).toContain("Total");
+  });
+
+  it("renders with Spanish locale", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf?locale=es`)
+      .set("x-user-id", ISSUER)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    expect(res.text).toContain("Factura");
+    expect(res.text).toContain("Total");
+  });
+
+  it("falls back to English for unsupported locale", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf?locale=zh`)
+      .set("x-user-id", ISSUER)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    expect(res.text).toContain("Invoice");
+  });
+
+  // --- unauthorized ---
+
+  it("rejects caller who is neither issuer nor payer", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app)
+      .get(`/invoices/${INV_ID}/pdf`)
+      .set("x-user-id", OTHER);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("rejects unauthenticated request", async () => {
+    __seedInvoice(BASE_INVOICE);
+
+    const res = await request(app).get(`/invoices/${INV_ID}/pdf`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects when invoice is not found", async () => {
+    const res = await request(app)
+      .get("/invoices/nonexistent/pdf")
+      .set("x-user-id", ISSUER);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/routes-d/tests/subscriptions.list.test.ts
+++ b/routes-d/tests/subscriptions.list.test.ts
@@ -1,0 +1,177 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import subListRouter, {
+  __resetSubscriptions,
+  __seedSubscription,
+} from "../routes/subscriptions.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(subListRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER = "user-abc";
+const OTHER = "user-xyz";
+
+const BASE = {
+  billingInterval: "monthly" as const,
+  status: "active" as const,
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+describe("GET /subscriptions", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetSubscriptions();
+  });
+
+  // --- empty ---
+
+  it("returns empty list when user has no subscriptions", async () => {
+    __seedSubscription({ id: "sub-other", userId: OTHER, planId: "pro", startDate: "2024-01-01", ...BASE });
+
+    const res = await request(app)
+      .get("/subscriptions")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  // --- visibility ---
+
+  it("only returns subscriptions belonging to the caller", async () => {
+    __seedSubscription({ id: "sub-1", userId: USER, planId: "pro", startDate: "2024-01-01", ...BASE });
+    __seedSubscription({ id: "sub-2", userId: OTHER, planId: "pro", startDate: "2024-02-01", ...BASE });
+
+    const res = await request(app)
+      .get("/subscriptions")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("sub-1");
+  });
+
+  // --- status filter ---
+
+  it("filters by status=paused", async () => {
+    __seedSubscription({ id: "sub-active", userId: USER, planId: "pro", startDate: "2024-01-01", ...BASE, status: "active" });
+    __seedSubscription({ id: "sub-paused", userId: USER, planId: "pro", startDate: "2024-02-01", ...BASE, status: "paused" });
+
+    const res = await request(app)
+      .get("/subscriptions?status=paused")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("sub-paused");
+  });
+
+  // --- plan filter ---
+
+  it("filters by planId", async () => {
+    __seedSubscription({ id: "sub-pro", userId: USER, planId: "pro", startDate: "2024-01-01", ...BASE });
+    __seedSubscription({ id: "sub-basic", userId: USER, planId: "basic", startDate: "2024-02-01", ...BASE });
+
+    const res = await request(app)
+      .get("/subscriptions?planId=pro")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].planId).toBe("pro");
+  });
+
+  it("combines status and planId filters", async () => {
+    __seedSubscription({ id: "sub-a", userId: USER, planId: "pro", startDate: "2024-01-01", ...BASE, status: "active" });
+    __seedSubscription({ id: "sub-b", userId: USER, planId: "pro", startDate: "2024-02-01", ...BASE, status: "paused" });
+    __seedSubscription({ id: "sub-c", userId: USER, planId: "basic", startDate: "2024-03-01", ...BASE, status: "active" });
+
+    const res = await request(app)
+      .get("/subscriptions?status=active&planId=pro")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("sub-a");
+  });
+
+  // --- sort order ---
+
+  it("sorts by startDate ascending (oldest first)", async () => {
+    __seedSubscription({ id: "sub-mar", userId: USER, planId: "pro", startDate: "2024-03-01", ...BASE });
+    __seedSubscription({ id: "sub-jan", userId: USER, planId: "pro", startDate: "2024-01-01", ...BASE });
+    __seedSubscription({ id: "sub-feb", userId: USER, planId: "pro", startDate: "2024-02-01", ...BASE });
+
+    const res = await request(app)
+      .get("/subscriptions")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((s: { id: string }) => s.id);
+    expect(ids).toEqual(["sub-jan", "sub-feb", "sub-mar"]);
+  });
+
+  // --- pagination ---
+
+  it("paginates correctly", async () => {
+    for (let i = 1; i <= 5; i++) {
+      __seedSubscription({ id: `sub-${i}`, userId: USER, planId: "pro", startDate: `2024-01-0${i}`, ...BASE });
+    }
+
+    const res = await request(app)
+      .get("/subscriptions?page=2&limit=2")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.pagination.page).toBe(2);
+    expect(res.body.pagination.total).toBe(5);
+    expect(res.body.pagination.hasNext).toBe(true);
+  });
+
+  it("returns hasNext=false on the last page", async () => {
+    for (let i = 1; i <= 3; i++) {
+      __seedSubscription({ id: `sub-${i}`, userId: USER, planId: "pro", startDate: `2024-01-0${i}`, ...BASE });
+    }
+
+    const res = await request(app)
+      .get("/subscriptions?page=2&limit=2")
+      .set("x-user-id", USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.hasNext).toBe(false);
+  });
+
+  // --- validation ---
+
+  it("rejects unauthenticated request", async () => {
+    const res = await request(app).get("/subscriptions");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects invalid page", async () => {
+    const res = await request(app)
+      .get("/subscriptions?page=0")
+      .set("x-user-id", USER);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGE");
+  });
+
+  it("rejects invalid limit", async () => {
+    const res = await request(app)
+      .get("/subscriptions?limit=500")
+      .set("x-user-id", USER);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LIMIT");
+  });
+});


### PR DESCRIPTION
Closes #537
Closes #533
Closes #535

## Summary

- Add `routes-d/routes/subscriptions.list.ts` — `GET /subscriptions` scoped to the calling user (`x-user-id`), filters by `status` and `planId`, paginated sorted by `startDate` ascending
- Add `routes-d/routes/invoices.pay.ts` — `POST /invoices/:id/pay` that marks a pending invoice as paid with a mock Stellar tx hash; idempotent (second call from same payer returns existing paid record); rejects already-paid, voided, expired, and draft invoices
- Add `routes-d/routes/invoices.pdf.ts` — `GET /invoices/:id/pdf` that streams a `application/pdf` response with localized labels (`en` / `es` / `fr` / `pt`); access restricted to issuer or payer; falls back to English for unsupported locale
- Add tests for all three routes covering happy path, filters, pagination, idempotency, locale switching, and all rejection cases

## Test plan

- [ ] `npm test -- --testPathPattern=subscriptions.list` passes (empty, filtered, paginated, sort order, validation)
- [ ] `npm test -- --testPathPattern=invoices.pay` passes (success, idempotency, already paid, voided, expired, forbidden, not found)
- [ ] `npm test -- --testPathPattern=invoices.pdf` passes (render, locale en/es/fallback, forbidden, not found)
- [ ] No regressions in existing route tests