### PR TITLE
feat: add webhook list, test delivery, admin unfreeze, and admin stats routes

### DIFF
--- a/routes-d/routes/admin.stats.get.ts
+++ b/routes-d/routes/admin.stats.get.ts
@@ -1,0 +1,105 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type PlatformStats = {
+  activeUsers: number;
+  paymentVolumeUsd: number;
+  webhookHealthPercent: number;
+  cachedAt: string;
+};
+
+type StatsStore = {
+  activeUsers: number;
+  paymentVolumeUsd: number;
+  webhookDeliveriesTotal: number;
+  webhookDeliveriesSuccess: number;
+};
+
+// In-memory aggregate data
+let statsStore: StatsStore = {
+  activeUsers: 0,
+  paymentVolumeUsd: 0,
+  webhookDeliveriesTotal: 0,
+  webhookDeliveriesSuccess: 0,
+};
+
+// Brief in-memory cache (30 seconds TTL)
+const CACHE_TTL_MS = 30_000;
+let cachedStats: PlatformStats | null = null;
+let cacheExpiresAt = 0;
+
+function computeStats(): PlatformStats {
+  const webhookHealthPercent =
+    statsStore.webhookDeliveriesTotal === 0
+      ? 100
+      : Math.round(
+          (statsStore.webhookDeliveriesSuccess / statsStore.webhookDeliveriesTotal) * 100,
+        );
+
+  return {
+    activeUsers: statsStore.activeUsers,
+    paymentVolumeUsd: statsStore.paymentVolumeUsd,
+    webhookHealthPercent,
+    cachedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * GET /admin/stats
+ * Return aggregate platform stats: active users, payment volume, webhook health.
+ * Restricted to operator role (x-operator-id header required).
+ * Results are cached for 30 seconds to reduce compute on repeated calls.
+ */
+router.get(
+  "/admin/stats",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const operatorId =
+        (req.headers["x-operator-id"] as string | undefined) ||
+        (req.body?.operatorId as string | undefined);
+
+      if (!operatorId || !operatorId.trim()) {
+        sendError(res, "UNAUTHORIZED", "Operator identity required", 401);
+        return;
+      }
+
+      const now = Date.now();
+      if (cachedStats && now < cacheExpiresAt) {
+        return res.status(200).json({ success: true, data: cachedStats });
+      }
+
+      cachedStats = computeStats();
+      cacheExpiresAt = now + CACHE_TTL_MS;
+
+      return res.status(200).json({ success: true, data: cachedStats });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __setStatsStore(data: Partial<StatsStore>): void {
+  statsStore = { ...statsStore, ...data };
+  cachedStats = null;
+  cacheExpiresAt = 0;
+}
+
+export function __resetStats(): void {
+  statsStore = {
+    activeUsers: 0,
+    paymentVolumeUsd: 0,
+    webhookDeliveriesTotal: 0,
+    webhookDeliveriesSuccess: 0,
+  };
+  cachedStats = null;
+  cacheExpiresAt = 0;
+}
+
+export function __expireCache(): void {
+  cachedStats = null;
+  cacheExpiresAt = 0;
+}
+
+export default router;

--- a/routes-d/routes/admin.users.unfreeze.ts
+++ b/routes-d/routes/admin.users.unfreeze.ts
@@ -1,0 +1,120 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type UserStatus = "active" | "frozen" | "closed";
+
+type UserRecord = {
+  id: string;
+  status: UserStatus;
+  frozenAt?: string;
+  unfrozenAt?: string;
+  unfrozenBy?: string;
+  updatedAt: string;
+};
+
+type AuditEvent = {
+  userId: string;
+  action: "user.unfreeze";
+  performedBy: string;
+  scope: string;
+  timestamp: string;
+};
+
+// In-memory store
+const users = new Map<string, UserRecord>();
+const auditLog: AuditEvent[] = [];
+
+/**
+ * POST /admin/users/:id/unfreeze
+ * Lift a freeze on a Nextellar user account.
+ * Requires an operator identity with the "freeze" scope.
+ * Emits an audit event on success.
+ * Rejects with 409 when the account is not currently frozen.
+ */
+router.post(
+  "/admin/users/:id/unfreeze",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.params.id?.trim();
+      if (!userId) {
+        sendError(res, "INVALID_USER_ID", "User ID is required", 400);
+        return;
+      }
+
+      const operatorId =
+        (req.body?.operatorId as string | undefined) ||
+        (req.headers["x-operator-id"] as string | undefined);
+
+      if (!operatorId || !operatorId.trim()) {
+        sendError(res, "UNAUTHORIZED", "Operator identity required", 401);
+        return;
+      }
+
+      const scopesHeader = req.headers["x-operator-scopes"] as string | undefined;
+      const scopes = scopesHeader ? scopesHeader.split(",").map((s) => s.trim()) : [];
+
+      if (!scopes.includes("freeze")) {
+        sendError(res, "FORBIDDEN", "Operator does not have the freeze scope", 403);
+        return;
+      }
+
+      const user = users.get(userId);
+      if (!user) {
+        sendError(res, "USER_NOT_FOUND", "User not found", 404);
+        return;
+      }
+
+      if (user.status !== "frozen") {
+        sendError(res, "NOT_FROZEN", "Account is not currently frozen", 409);
+        return;
+      }
+
+      const now = new Date().toISOString();
+      user.status = "active";
+      user.unfrozenAt = now;
+      user.unfrozenBy = operatorId.trim();
+      user.updatedAt = now;
+
+      auditLog.push({
+        userId,
+        action: "user.unfreeze",
+        performedBy: operatorId.trim(),
+        scope: "freeze",
+        timestamp: now,
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          userId,
+          status: "active",
+          unfrozenAt: now,
+          unfrozenBy: operatorId.trim(),
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedUser(user: UserRecord): void {
+  users.set(user.id, { ...user });
+}
+
+export function __getUser(id: string): UserRecord | undefined {
+  return users.get(id);
+}
+
+export function __getAuditLog(): AuditEvent[] {
+  return auditLog;
+}
+
+export function __resetUsers(): void {
+  users.clear();
+  auditLog.length = 0;
+}
+
+export default router;

--- a/routes-d/routes/webhooks.list.ts
+++ b/routes-d/routes/webhooks.list.ts
@@ -1,0 +1,79 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Webhook = {
+  id: string;
+  url: string;
+  userId: string;
+  events: string[];
+  sharedSecret: string;
+  createdAt: string;
+};
+
+type MaskedWebhook = Omit<Webhook, "sharedSecret"> & { sharedSecret: string };
+
+// In-memory storage for webhooks (mock database)
+const webhooks = new Map<string, Webhook>();
+
+function maskSecret(secret: string): string {
+  if (secret.length <= 4) return "****";
+  return secret.slice(0, 4) + "****";
+}
+
+/**
+ * GET /webhooks
+ * List webhook subscriptions belonging to the calling user.
+ * Shared secrets are masked in the response.
+ * Optionally filter by event type via ?eventType=<type>.
+ */
+router.get(
+  "/webhooks",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.body?.userId || (req.headers["x-user-id"] as string | undefined);
+
+      if (!userId || typeof userId !== "string") {
+        sendError(res, "UNAUTHORIZED", "User authentication required", 401);
+        return;
+      }
+
+      const eventType = req.query.eventType as string | undefined;
+
+      let userWebhooks = Array.from(webhooks.values()).filter(
+        (w) => w.userId === userId,
+      );
+
+      if (eventType) {
+        userWebhooks = userWebhooks.filter((w) => w.events.includes(eventType));
+      }
+
+      const masked: MaskedWebhook[] = userWebhooks.map((w) => ({
+        ...w,
+        sharedSecret: maskSecret(w.sharedSecret),
+      }));
+
+      return res.status(200).json({
+        success: true,
+        data: masked,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedWebhook(webhook: Webhook): void {
+  webhooks.set(webhook.id, webhook);
+}
+
+export function __resetWebhooks(): void {
+  webhooks.clear();
+}
+
+export function __getWebhooks(): Map<string, Webhook> {
+  return webhooks;
+}
+
+export default router;

--- a/routes-d/routes/webhooks.test.ts
+++ b/routes-d/routes/webhooks.test.ts
@@ -1,0 +1,120 @@
+import { createHmac } from "node:crypto";
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Webhook = {
+  id: string;
+  url: string;
+  userId: string;
+  events: string[];
+  sharedSecret: string;
+  createdAt: string;
+};
+
+type DeliveryResult = {
+  webhookId: string;
+  responseCode: number;
+  latencyMs: number;
+  success: boolean;
+  deliveredAt: string;
+};
+
+// In-memory webhook store shared with other webhook routes via seed helpers
+const webhooks = new Map<string, Webhook>();
+
+// Recorded test deliveries (for inspection in tests)
+const testDeliveries: DeliveryResult[] = [];
+
+export function buildSignature(secret: string, payload: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+/**
+ * POST /webhooks/:id/test
+ * Send a test payload to the webhook destination for setup verification.
+ * Signs the payload with HMAC-SHA256 using the webhook's sharedSecret,
+ * identical to production delivery.
+ * Returns the upstream HTTP response code and round-trip latency.
+ */
+router.post(
+  "/webhooks/:id/test",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const userId = req.body?.userId || (req.headers["x-user-id"] as string | undefined);
+
+      if (!userId || typeof userId !== "string") {
+        sendError(res, "UNAUTHORIZED", "User authentication required", 401);
+        return;
+      }
+
+      const webhook = webhooks.get(id);
+      if (!webhook) {
+        sendError(res, "WEBHOOK_NOT_FOUND", "Webhook not found", 404);
+        return;
+      }
+
+      if (webhook.userId !== userId) {
+        sendError(res, "FORBIDDEN", "You do not have permission to test this webhook", 403);
+        return;
+      }
+
+      const testPayload = JSON.stringify({
+        type: "test",
+        webhookId: id,
+        timestamp: new Date().toISOString(),
+      });
+
+      const signature = buildSignature(webhook.sharedSecret, testPayload);
+      const start = Date.now();
+
+      let responseCode: number;
+      try {
+        const upstream = await fetch(webhook.url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Nextellar-Signature": signature,
+          },
+          body: testPayload,
+          signal: AbortSignal.timeout(10_000),
+        });
+        responseCode = upstream.status;
+      } catch {
+        responseCode = 0;
+      }
+
+      const latencyMs = Date.now() - start;
+      const success = responseCode >= 200 && responseCode < 300;
+      const deliveredAt = new Date().toISOString();
+
+      const result: DeliveryResult = { webhookId: id, responseCode, latencyMs, success, deliveredAt };
+      testDeliveries.push(result);
+
+      return res.status(200).json({
+        success: true,
+        data: { responseCode, latencyMs, success, deliveredAt },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedWebhook(webhook: Webhook): void {
+  webhooks.set(webhook.id, webhook);
+}
+
+export function __resetWebhooks(): void {
+  webhooks.clear();
+  testDeliveries.length = 0;
+}
+
+export function __getTestDeliveries(): DeliveryResult[] {
+  return testDeliveries;
+}
+
+export default router;

--- a/routes-d/tests/admin.stats.get.test.ts
+++ b/routes-d/tests/admin.stats.get.test.ts
@@ -1,0 +1,115 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __setStatsStore,
+  __resetStats,
+  __expireCache,
+} from "../routes/admin.stats.get.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /admin/stats", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetStats();
+  });
+
+  it("returns aggregate platform stats for an authorized operator", async () => {
+    __setStatsStore({
+      activeUsers: 42,
+      paymentVolumeUsd: 100_000,
+      webhookDeliveriesTotal: 200,
+      webhookDeliveriesSuccess: 190,
+    });
+
+    const res = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.activeUsers).toBe(42);
+    expect(res.body.data.paymentVolumeUsd).toBe(100_000);
+    expect(res.body.data.webhookHealthPercent).toBe(95);
+    expect(res.body.data.cachedAt).toBeDefined();
+  });
+
+  it("returns 100% webhook health when there are no deliveries", async () => {
+    __setStatsStore({ activeUsers: 5, paymentVolumeUsd: 0 });
+
+    const res = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.webhookHealthPercent).toBe(100);
+  });
+
+  it("returns zeroed stats when underlying data is empty", async () => {
+    const res = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.activeUsers).toBe(0);
+    expect(res.body.data.paymentVolumeUsd).toBe(0);
+    expect(res.body.data.webhookHealthPercent).toBe(100);
+  });
+
+  it("serves cached stats without recomputing within the TTL", async () => {
+    __setStatsStore({ activeUsers: 10 });
+
+    const res1 = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+    const cachedAt1 = res1.body.data.cachedAt;
+
+    // Update the underlying data without expiring the cache
+    __setStatsStore({ activeUsers: 99 });
+    // Re-seed without expiring cache so the cached value persists
+    // (use __expireCache to bypass for the next assertion)
+
+    const res2 = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+
+    // After __setStatsStore the cache was cleared, so a new value is returned
+    expect(res2.body.data.activeUsers).toBe(99);
+
+    // Verify cache is served on a second call without changes
+    const res3 = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+    expect(res3.body.data.cachedAt).toBe(res2.body.data.cachedAt);
+  });
+
+  it("recomputes stats after the cache is expired", async () => {
+    __setStatsStore({ activeUsers: 10 });
+    await request(app).get("/admin/stats").set("x-operator-id", "op-1");
+
+    __expireCache();
+    __setStatsStore({ activeUsers: 55 });
+
+    const res = await request(app)
+      .get("/admin/stats")
+      .set("x-operator-id", "op-1");
+
+    expect(res.body.data.activeUsers).toBe(55);
+  });
+
+  it("returns 401 when operator identity is missing", async () => {
+    const res = await request(app).get("/admin/stats");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/routes-d/tests/admin.users.unfreeze.test.ts
+++ b/routes-d/tests/admin.users.unfreeze.test.ts
@@ -1,0 +1,127 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedUser,
+  __getUser,
+  __getAuditLog,
+  __resetUsers,
+} from "../routes/admin.users.unfreeze.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const FROZEN_USER = {
+  id: "user-1",
+  status: "frozen" as const,
+  frozenAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+const ACTIVE_USER = {
+  id: "user-2",
+  status: "active" as const,
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+describe("POST /admin/users/:id/unfreeze", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetUsers();
+    __seedUser(FROZEN_USER);
+    __seedUser(ACTIVE_USER);
+  });
+
+  it("unfreezes a frozen account and returns 200", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/unfreeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze,read");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("active");
+    expect(res.body.data.unfrozenBy).toBe("op-1");
+    expect(res.body.data.unfrozenAt).toBeDefined();
+  });
+
+  it("persists the status change in storage", async () => {
+    await request(app)
+      .post("/admin/users/user-1/unfreeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    const stored = __getUser("user-1")!;
+    expect(stored.status).toBe("active");
+    expect(stored.unfrozenAt).toBeDefined();
+  });
+
+  it("emits an audit event on successful unfreeze", async () => {
+    await request(app)
+      .post("/admin/users/user-1/unfreeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    const log = __getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].action).toBe("user.unfreeze");
+    expect(log[0].performedBy).toBe("op-1");
+    expect(log[0].userId).toBe("user-1");
+    expect(log[0].scope).toBe("freeze");
+  });
+
+  it("returns 409 when account is not currently frozen", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-2/unfreeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("NOT_FROZEN");
+  });
+
+  it("returns 403 when operator does not have the freeze scope", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/unfreeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "read,write");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 when operator identity is missing", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/unfreeze");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when user does not exist", async () => {
+    const res = await request(app)
+      .post("/admin/users/nonexistent/unfreeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("USER_NOT_FOUND");
+  });
+
+  it("accepts operatorId from the request body", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/unfreeze")
+      .set("x-operator-scopes", "freeze")
+      .send({ operatorId: "op-body" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.unfrozenBy).toBe("op-body");
+  });
+});

--- a/routes-d/tests/webhooks.list.test.ts
+++ b/routes-d/tests/webhooks.list.test.ts
@@ -1,0 +1,136 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedWebhook,
+  __resetWebhooks,
+} from "../routes/webhooks.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER_ID = "user-123";
+
+const WEBHOOK_A = {
+  id: "wh-1",
+  url: "https://example.com/hook1",
+  userId: USER_ID,
+  events: ["payment.completed", "payment.failed"],
+  sharedSecret: "supersecret1",
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+const WEBHOOK_B = {
+  id: "wh-2",
+  url: "https://example.com/hook2",
+  userId: USER_ID,
+  events: ["subscription.created"],
+  sharedSecret: "anothersecret",
+  createdAt: "2024-01-02T00:00:00Z",
+};
+
+const OTHER_USER_WEBHOOK = {
+  id: "wh-3",
+  url: "https://other.example.com/hook",
+  userId: "user-999",
+  events: ["payment.completed"],
+  sharedSecret: "theirsecret",
+  createdAt: "2024-01-03T00:00:00Z",
+};
+
+describe("GET /webhooks", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetWebhooks();
+  });
+
+  it("returns an empty list when the user has no webhooks", async () => {
+    const res = await request(app)
+      .get("/webhooks")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns only webhooks belonging to the calling user", async () => {
+    __seedWebhook(WEBHOOK_A);
+    __seedWebhook(WEBHOOK_B);
+    __seedWebhook(OTHER_USER_WEBHOOK);
+
+    const res = await request(app)
+      .get("/webhooks")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    const ids = res.body.data.map((w: { id: string }) => w.id);
+    expect(ids).toContain("wh-1");
+    expect(ids).toContain("wh-2");
+    expect(ids).not.toContain("wh-3");
+  });
+
+  it("masks shared secrets in the response", async () => {
+    __seedWebhook(WEBHOOK_A);
+
+    const res = await request(app)
+      .get("/webhooks")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    const webhook = res.body.data[0];
+    expect(webhook.sharedSecret).not.toBe("supersecret1");
+    expect(webhook.sharedSecret).toMatch(/^supe\*{4}$/);
+  });
+
+  it("filters by event type when ?eventType is supplied", async () => {
+    __seedWebhook(WEBHOOK_A);
+    __seedWebhook(WEBHOOK_B);
+
+    const res = await request(app)
+      .get("/webhooks?eventType=payment.completed")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("wh-1");
+  });
+
+  it("returns an empty list when event type filter matches nothing", async () => {
+    __seedWebhook(WEBHOOK_A);
+    __seedWebhook(WEBHOOK_B);
+
+    const res = await request(app)
+      .get("/webhooks?eventType=nonexistent.event")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns 401 when userId is not provided", async () => {
+    const res = await request(app).get("/webhooks").send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("accepts userId from x-user-id header", async () => {
+    __seedWebhook(WEBHOOK_A);
+
+    const res = await request(app)
+      .get("/webhooks")
+      .set("x-user-id", USER_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+});

--- a/routes-d/tests/webhooks.test.test.ts
+++ b/routes-d/tests/webhooks.test.test.ts
@@ -1,0 +1,131 @@
+import express from "express";
+import type { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedWebhook,
+  __resetWebhooks,
+  __getTestDeliveries,
+  buildSignature,
+} from "../routes/webhooks.test.js";
+
+// Patch global fetch so tests never reach the real network
+const originalFetch = globalThis.fetch;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER_ID = "user-123";
+const WEBHOOK = {
+  id: "wh-1",
+  url: "https://example.com/hook",
+  userId: USER_ID,
+  events: ["payment.completed"],
+  sharedSecret: "my-secret",
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+describe("POST /webhooks/:id/test", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetWebhooks();
+    globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("delivers a test payload and returns 200 responseCode on success", async () => {
+    __seedWebhook(WEBHOOK);
+    globalThis.fetch = async () => new globalThis.Response(null, { status: 200 }) as unknown as globalThis.Response;
+
+    const res = await request(app)
+      .post("/webhooks/wh-1/test")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.responseCode).toBe(200);
+    expect(res.body.data.success).toBe(true);
+    expect(typeof res.body.data.latencyMs).toBe("number");
+    expect(res.body.data.deliveredAt).toBeDefined();
+  });
+
+  it("returns upstream failure response code when destination returns 5xx", async () => {
+    __seedWebhook(WEBHOOK);
+    globalThis.fetch = async () => new globalThis.Response(null, { status: 503 }) as unknown as globalThis.Response;
+
+    const res = await request(app)
+      .post("/webhooks/wh-1/test")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.responseCode).toBe(503);
+    expect(res.body.data.success).toBe(false);
+  });
+
+  it("records the delivery in the test deliveries log", async () => {
+    __seedWebhook(WEBHOOK);
+    globalThis.fetch = async () => new globalThis.Response(null, { status: 200 }) as unknown as globalThis.Response;
+
+    await request(app)
+      .post("/webhooks/wh-1/test")
+      .send({ userId: USER_ID });
+
+    const deliveries = __getTestDeliveries();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].webhookId).toBe("wh-1");
+    expect(deliveries[0].responseCode).toBe(200);
+  });
+
+  it("signs the payload with the same HMAC-SHA256 as production", () => {
+    const secret = "my-secret";
+    const payload = JSON.stringify({ type: "test" });
+    const sig = buildSignature(secret, payload);
+    expect(sig).toMatch(/^sha256=[a-f0-9]{64}$/);
+
+    // Deterministic: same inputs produce the same signature
+    expect(buildSignature(secret, payload)).toBe(sig);
+    // Different secret produces a different signature
+    expect(buildSignature("other-secret", payload)).not.toBe(sig);
+  });
+
+  it("returns 404 when webhook does not exist", async () => {
+    const res = await request(app)
+      .post("/webhooks/nonexistent/test")
+      .send({ userId: USER_ID });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("WEBHOOK_NOT_FOUND");
+  });
+
+  it("returns 403 when caller does not own the webhook", async () => {
+    __seedWebhook(WEBHOOK);
+
+    const res = await request(app)
+      .post("/webhooks/wh-1/test")
+      .send({ userId: "user-999" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 when userId is not provided", async () => {
+    __seedWebhook(WEBHOOK);
+
+    const res = await request(app)
+      .post("/webhooks/wh-1/test")
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+});


### PR DESCRIPTION
Closes #552

---

Closes #544

---

Closes #541

---

## Summary

- **#541** — `GET /webhooks` (`routes-d/routes/webhooks.list.ts`): list the calling user's webhook subscriptions; shared secrets are masked (`supe****`); optional `?eventType` query filter
- **#544** — `POST /webhooks/:id/test` (`routes-d/routes/webhooks.test.ts`): send a signed test payload to the webhook destination using HMAC-SHA256 (same signing as production); returns upstream response code and round-trip latency in ms
- **#552** — `POST /admin/users/:id/unfreeze` (`routes-d/routes/admin.users.unfreeze.ts`): lift a user account freeze; requires operator identity with the `freeze` scope via `x-operator-scopes` header; emits an audit event; rejects 409 when the account is not currently frozen
- **#553** — `GET /admin/stats` (`routes-d/routes/admin.stats.get.ts`): return aggregate platform stats (active users, payment volume, webhook health %); restricted to operators via `x-operator-id`; results cached for 30 s

All route files live under `routes-d/routes/` and tests under `routes-d/tests/` per the scope constraints. No code was modified outside `routes-d/`.

## Test plan

- [x] `webhooks.list.test.ts` — empty list, user-scoped filtering, secret masking, `?eventType` filter, empty filter, 401 without auth, `x-user-id` header auth (7 tests)
- [x] `webhooks.test.test.ts` — success delivery, 5xx upstream, delivery log, HMAC signature determinism, 404 unknown webhook, 403 wrong owner, 401 unauthenticated (7 tests)
- [x] `admin.users.unfreeze.test.ts` — unfreeze success, storage persistence, audit event emitted, 409 not frozen, 403 missing freeze scope, 401 missing operator, 404 unknown user, body-supplied operatorId (8 tests)
- [x] `admin.stats.get.test.ts` — stats with data, 100% health on zero deliveries, zeroed stats, cache served within TTL, recompute after cache expiry, 401 without operator (6 tests)
- [x] 28/28 tests pass locally (`npm test`)