### PR TITLE
feat(routes-d): add admin users freeze route (#551)

### DIFF
--- a/routes-d/routes/admin.users.freeze.ts
+++ b/routes-d/routes/admin.users.freeze.ts
@@ -1,0 +1,111 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type UserStatus = "active" | "frozen" | "closed";
+
+type UserRecord = {
+  id: string;
+  status: UserStatus;
+  frozenAt?: string;
+  frozenBy?: string;
+  updatedAt: string;
+};
+
+type AuditEvent = {
+  userId: string;
+  action: "user.freeze";
+  performedBy: string;
+  scope: string;
+  timestamp: string;
+};
+
+const users = new Map<string, UserRecord>();
+const auditLog: AuditEvent[] = [];
+
+router.post(
+  "/admin/users/:id/freeze",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.params.id?.trim();
+      if (!userId) {
+        sendError(res, "INVALID_USER_ID", "User ID is required", 400);
+        return;
+      }
+
+      const operatorId =
+        (req.body?.operatorId as string | undefined) ||
+        (req.headers["x-operator-id"] as string | undefined);
+
+      if (!operatorId || !operatorId.trim()) {
+        sendError(res, "UNAUTHORIZED", "Operator identity required", 401);
+        return;
+      }
+
+      const scopesHeader = req.headers["x-operator-scopes"] as string | undefined;
+      const scopes = scopesHeader ? scopesHeader.split(",").map((s) => s.trim()) : [];
+
+      if (!scopes.includes("freeze")) {
+        sendError(res, "FORBIDDEN", "Operator does not have the freeze scope", 403);
+        return;
+      }
+
+      const user = users.get(userId);
+      if (!user) {
+        sendError(res, "USER_NOT_FOUND", "User not found", 404);
+        return;
+      }
+
+      if (user.status === "frozen") {
+        sendError(res, "ALREADY_FROZEN", "Account is already frozen", 409);
+        return;
+      }
+
+      const now = new Date().toISOString();
+      user.status = "frozen";
+      user.frozenAt = now;
+      user.frozenBy = operatorId.trim();
+      user.updatedAt = now;
+
+      auditLog.push({
+        userId,
+        action: "user.freeze",
+        performedBy: operatorId.trim(),
+        scope: "freeze",
+        timestamp: now,
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          userId,
+          status: "frozen",
+          frozenAt: now,
+          frozenBy: operatorId.trim(),
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedUser(user: UserRecord): void {
+  users.set(user.id, { ...user });
+}
+
+export function __getUser(id: string): UserRecord | undefined {
+  return users.get(id);
+}
+
+export function __getAuditLog(): AuditEvent[] {
+  return auditLog;
+}
+
+export function __resetUsers(): void {
+  users.clear();
+  auditLog.length = 0;
+}
+
+export default router;

--- a/routes-d/tests/admin.users.freeze.test.ts
+++ b/routes-d/tests/admin.users.freeze.test.ts
@@ -1,0 +1,127 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedUser,
+  __getUser,
+  __getAuditLog,
+  __resetUsers,
+} from "../routes/admin.users.freeze.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const ACTIVE_USER = {
+  id: "user-1",
+  status: "active" as const,
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+const FROZEN_USER = {
+  id: "user-2",
+  status: "frozen" as const,
+  frozenAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+describe("POST /admin/users/:id/freeze", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetUsers();
+    __seedUser(ACTIVE_USER);
+    __seedUser(FROZEN_USER);
+  });
+
+  it("freezes an active account and returns 200", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/freeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze,read");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("frozen");
+    expect(res.body.data.frozenBy).toBe("op-1");
+    expect(res.body.data.frozenAt).toBeDefined();
+  });
+
+  it("persists the status change in storage", async () => {
+    await request(app)
+      .post("/admin/users/user-1/freeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    const stored = __getUser("user-1")!;
+    expect(stored.status).toBe("frozen");
+    expect(stored.frozenAt).toBeDefined();
+  });
+
+  it("emits an audit event on successful freeze", async () => {
+    await request(app)
+      .post("/admin/users/user-1/freeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    const log = __getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].action).toBe("user.freeze");
+    expect(log[0].performedBy).toBe("op-1");
+    expect(log[0].userId).toBe("user-1");
+    expect(log[0].scope).toBe("freeze");
+  });
+
+  it("returns 409 when account is already frozen", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-2/freeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_FROZEN");
+  });
+
+  it("returns 403 when operator does not have the freeze scope", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/freeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "read,write");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 when operator identity is missing", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/freeze");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when user does not exist", async () => {
+    const res = await request(app)
+      .post("/admin/users/nonexistent/freeze")
+      .set("x-operator-id", "op-1")
+      .set("x-operator-scopes", "freeze");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("USER_NOT_FOUND");
+  });
+
+  it("accepts operatorId from the request body", async () => {
+    const res = await request(app)
+      .post("/admin/users/user-1/freeze")
+      .set("x-operator-scopes", "freeze")
+      .send({ operatorId: "op-body" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.frozenBy).toBe("op-body");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new route  under  to freeze a Nextellar user account in response to compliance or security review.

## Changes
- **routes-d/routes/admin.users.freeze.ts** — New route handler that:
  - Requires operator identity via `x-operator-id` header (or `req.body.operatorId`)
  - Validates the `freeze` scope via `x-operator-scopes` header
  - Sets user status to `frozen` and records `frozenAt` / `frozenBy`
  - Emits an audit event (`user.freeze`) on success
  - Returns 409 `ALREADY_FROZEN` if account is already frozen
  - Exports `__seedUser`, `__getUser`, `__getAuditLog`, `__resetUsers` for testing
- **routes-d/tests/admin.users.freeze.test.ts** — 8 tests covering:
  - Successful freeze of an active account (200)
  - Persisted status change in storage
  - Audit event emission
  - Already frozen rejection (409)
  - Missing freeze scope (403)
  - Missing operator identity (401)
  - Non-existent user (404)
  - Operator ID from request body

Closes #551