### PR TITLE
feat: add marketplace listings browse route (#546)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "^1.11.1",
         "commander": "^14.0.0",
         "execa": "^9.6.0",
-        "express": "^5.2.1",
         "fs-extra": "^11.3.0",
         "gradient-string": "^3.0.0",
         "jsonwebtoken": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@unrs/resolver-binding-win32-x64-msvc": "^1.11.1",
     "commander": "^14.0.0",
     "execa": "^9.6.0",
-    "express": "^5.2.1",
     "fs-extra": "^11.3.0",
     "gradient-string": "^3.0.0",
     "jsonwebtoken": "^9.0.3",

--- a/routes-d/routes/listings.list.ts
+++ b/routes-d/routes/listings.list.ts
@@ -1,0 +1,254 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AssetType = "token" | "nft" | "bond" | "equity" | "commodity";
+
+export type ListingStatus = "open" | "filled" | "cancelled" | "expired";
+
+export interface Listing {
+  id: string;
+  sellerId: string;
+  assetCode: string;
+  assetIssuer: string;
+  assetType: AssetType;
+  collectionId?: string;
+  price: number;
+  currency: string;
+  quantity: number;
+  status: ListingStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store (seeded by tests or future persistence layer)
+// ---------------------------------------------------------------------------
+
+let listingStore: Listing[] = [];
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const VALID_ASSET_TYPES: AssetType[] = [
+  "token",
+  "nft",
+  "bond",
+  "equity",
+  "commodity",
+];
+
+const VALID_SORT_BY = ["price_asc", "price_desc", "newest", "oldest"] as const;
+type SortBy = (typeof VALID_SORT_BY)[number];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parsePositiveInteger(value: unknown, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (typeof value !== "string") return NaN;
+  const parsed = parseInt(value, 10);
+  return parsed;
+}
+
+function parsePositiveFloat(value: unknown): number | null {
+  if (value === undefined || value === "") return null;
+  if (typeof value !== "string") return NaN;
+  const parsed = parseFloat(value);
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Route: GET /listings
+//
+// Query parameters:
+//   collection    – filter by collectionId (exact match)
+//   assetType     – filter by assetType (one of: token | nft | bond | equity | commodity)
+//   minPrice      – lower bound on price (inclusive, numeric)
+//   maxPrice      – upper bound on price (inclusive, numeric)
+//   sortBy        – sort order: price_asc | price_desc | newest | oldest (default: newest)
+//   page          – page number >= 1 (default: 1)
+//   limit         – items per page 1–100 (default: 20)
+//
+// Only "open" listings are returned by default.
+// ---------------------------------------------------------------------------
+
+router.get("/listings", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const {
+      collection,
+      assetType,
+      minPrice,
+      maxPrice,
+      sortBy = "newest",
+      page: rawPage,
+      limit: rawLimit,
+    } = req.query;
+
+    // --- Validate pagination ---
+
+    const page = parsePositiveInteger(rawPage, DEFAULT_PAGE);
+    const limit = parsePositiveInteger(rawLimit, DEFAULT_LIMIT);
+
+    if (isNaN(page) || page < 1) {
+      sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+      return;
+    }
+
+    if (isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+      sendError(
+        res,
+        "INVALID_LIMIT",
+        `limit must be between 1 and ${MAX_LIMIT}`,
+        400,
+      );
+      return;
+    }
+
+    // --- Validate assetType ---
+
+    if (
+      assetType !== undefined &&
+      typeof assetType === "string" &&
+      !VALID_ASSET_TYPES.includes(assetType as AssetType)
+    ) {
+      sendError(
+        res,
+        "INVALID_ASSET_TYPE",
+        `assetType must be one of: ${VALID_ASSET_TYPES.join(", ")}`,
+        400,
+      );
+      return;
+    }
+
+    // --- Validate sortBy ---
+
+    if (!VALID_SORT_BY.includes(sortBy as SortBy)) {
+      sendError(
+        res,
+        "INVALID_SORT_BY",
+        `sortBy must be one of: ${VALID_SORT_BY.join(", ")}`,
+        400,
+      );
+      return;
+    }
+
+    // --- Validate price range ---
+
+    const min = parsePositiveFloat(minPrice);
+    const max = parsePositiveFloat(maxPrice);
+
+    if (min !== null && (isNaN(min) || min < 0)) {
+      sendError(res, "INVALID_MIN_PRICE", "minPrice must be a non-negative number", 400);
+      return;
+    }
+
+    if (max !== null && (isNaN(max) || max < 0)) {
+      sendError(res, "INVALID_MAX_PRICE", "maxPrice must be a non-negative number", 400);
+      return;
+    }
+
+    if (min !== null && max !== null && min > max) {
+      sendError(
+        res,
+        "INVALID_PRICE_RANGE",
+        "minPrice must not be greater than maxPrice",
+        400,
+      );
+      return;
+    }
+
+    // --- Filter ---
+
+    let results = listingStore.filter((l) => l.status === "open");
+
+    if (collection && typeof collection === "string") {
+      results = results.filter((l) => l.collectionId === collection);
+    }
+
+    if (assetType && typeof assetType === "string") {
+      results = results.filter((l) => l.assetType === assetType);
+    }
+
+    if (min !== null) {
+      results = results.filter((l) => l.price >= min);
+    }
+
+    if (max !== null) {
+      results = results.filter((l) => l.price <= max);
+    }
+
+    // --- Sort ---
+
+    switch (sortBy as SortBy) {
+      case "price_asc":
+        results.sort((a, b) => a.price - b.price);
+        break;
+      case "price_desc":
+        results.sort((a, b) => b.price - a.price);
+        break;
+      case "oldest":
+        results.sort(
+          (a, b) =>
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        );
+        break;
+      case "newest":
+      default:
+        results.sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+        break;
+    }
+
+    // --- Paginate ---
+
+    const total = results.length;
+    const offset = (page - 1) * limit;
+    const paged = results.slice(offset, offset + limit);
+
+    return res.status(200).json({
+      success: true,
+      data: paged,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 1,
+        hasNext: offset + limit < total,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers (exported only for test seeding — never call in production)
+// ---------------------------------------------------------------------------
+
+export function __seedListings(listings: Listing[]): void {
+  listingStore = [...listings];
+}
+
+export function __resetListings(): void {
+  listingStore = [];
+}
+
+export function __getListings(): Listing[] {
+  return [...listingStore];
+}
+
+export default router;

--- a/routes-d/tests/listings.list.test.ts
+++ b/routes-d/tests/listings.list.test.ts
@@ -1,0 +1,531 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import listingsRouter, {
+  __resetListings,
+  __seedListings,
+  __getListings,
+  Listing,
+} from "../routes/listings.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(listingsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: `listing-${Math.random().toString(36).slice(2)}`,
+  sellerId: "seller-001",
+  assetCode: "USDC",
+  assetIssuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+  assetType: "token",
+  price: 100,
+  currency: "USD",
+  quantity: 1,
+  status: "open",
+  createdAt: "2026-01-01T12:00:00.000Z",
+  updatedAt: "2026-01-01T12:00:00.000Z",
+  ...overrides,
+});
+
+const openListings: Listing[] = [
+  makeListing({
+    id: "listing-001",
+    assetType: "nft",
+    collectionId: "collection-alpha",
+    price: 50,
+    createdAt: "2026-01-01T10:00:00.000Z",
+  }),
+  makeListing({
+    id: "listing-002",
+    assetType: "token",
+    price: 200,
+    createdAt: "2026-01-02T10:00:00.000Z",
+  }),
+  makeListing({
+    id: "listing-003",
+    assetType: "nft",
+    collectionId: "collection-alpha",
+    price: 300,
+    createdAt: "2026-01-03T10:00:00.000Z",
+  }),
+  makeListing({
+    id: "listing-004",
+    assetType: "bond",
+    price: 1000,
+    createdAt: "2026-01-04T10:00:00.000Z",
+  }),
+  makeListing({
+    id: "listing-005",
+    assetType: "token",
+    collectionId: "collection-beta",
+    price: 75,
+    createdAt: "2026-01-05T10:00:00.000Z",
+  }),
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /listings", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetListings();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty store
+  // -------------------------------------------------------------------------
+
+  describe("empty store", () => {
+    it("returns 200 with an empty data array when no listings exist", async () => {
+      const res = await request(app).get("/listings");
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+      expect(res.body.pagination.totalPages).toBe(1);
+      expect(res.body.pagination.hasNext).toBe(false);
+    });
+
+    it("returns empty data even when filters are applied", async () => {
+      const res = await request(app).get("/listings?assetType=nft&collection=col-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic listing shape
+  // -------------------------------------------------------------------------
+
+  describe("response shape", () => {
+    it("returns listings with expected fields", async () => {
+      __seedListings([openListings[0]]);
+
+      const res = await request(app).get("/listings");
+
+      expect(res.status).toBe(200);
+      const item = res.body.data[0];
+      expect(item).toHaveProperty("id");
+      expect(item).toHaveProperty("sellerId");
+      expect(item).toHaveProperty("assetCode");
+      expect(item).toHaveProperty("assetIssuer");
+      expect(item).toHaveProperty("assetType");
+      expect(item).toHaveProperty("price");
+      expect(item).toHaveProperty("currency");
+      expect(item).toHaveProperty("quantity");
+      expect(item).toHaveProperty("status");
+      expect(item).toHaveProperty("createdAt");
+      expect(item).toHaveProperty("updatedAt");
+    });
+
+    it("only returns open listings — skips filled, cancelled, and expired", async () => {
+      __seedListings([
+        makeListing({ id: "open-1", status: "open" }),
+        makeListing({ id: "filled-1", status: "filled" }),
+        makeListing({ id: "cancelled-1", status: "cancelled" }),
+        makeListing({ id: "expired-1", status: "expired" }),
+      ]);
+
+      const res = await request(app).get("/listings");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].id).toBe("open-1");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Filtering by collection
+  // -------------------------------------------------------------------------
+
+  describe("filter: collection", () => {
+    beforeEach(() => {
+      __seedListings(openListings);
+    });
+
+    it("filters by collection and returns only matching listings", async () => {
+      const res = await request(app).get("/listings?collection=collection-alpha");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(2);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.collectionId).toBe("collection-alpha");
+      });
+    });
+
+    it("returns empty data when no listings match the collection", async () => {
+      const res = await request(app).get("/listings?collection=nonexistent");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+
+    it("filters by collection-beta", async () => {
+      const res = await request(app).get("/listings?collection=collection-beta");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].id).toBe("listing-005");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Filtering by assetType
+  // -------------------------------------------------------------------------
+
+  describe("filter: assetType", () => {
+    beforeEach(() => {
+      __seedListings(openListings);
+    });
+
+    it("filters by assetType=nft", async () => {
+      const res = await request(app).get("/listings?assetType=nft");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(2);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.assetType).toBe("nft");
+      });
+    });
+
+    it("filters by assetType=token", async () => {
+      const res = await request(app).get("/listings?assetType=token");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(2);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.assetType).toBe("token");
+      });
+    });
+
+    it("filters by assetType=bond", async () => {
+      const res = await request(app).get("/listings?assetType=bond");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].assetType).toBe("bond");
+    });
+
+    it("returns 400 INVALID_ASSET_TYPE for unrecognised assetType", async () => {
+      const res = await request(app).get("/listings?assetType=unknown");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_ASSET_TYPE");
+    });
+
+    it("returns 400 for each invalid asset type variant", async () => {
+      for (const bad of ["crypto", "stock", "123", ""]) {
+        if (bad === "") continue; // empty string is ignored (undefined-like)
+        const res = await request(app).get(`/listings?assetType=${bad}`);
+        expect(res.status).toBe(400);
+        expect(res.body.error.code).toBe("INVALID_ASSET_TYPE");
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Filtering by price range
+  // -------------------------------------------------------------------------
+
+  describe("filter: price range", () => {
+    beforeEach(() => {
+      __seedListings(openListings);
+    });
+
+    it("filters by minPrice", async () => {
+      const res = await request(app).get("/listings?minPrice=200");
+
+      expect(res.status).toBe(200);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.price).toBeGreaterThanOrEqual(200);
+      });
+    });
+
+    it("filters by maxPrice", async () => {
+      const res = await request(app).get("/listings?maxPrice=200");
+
+      expect(res.status).toBe(200);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.price).toBeLessThanOrEqual(200);
+      });
+    });
+
+    it("filters by both minPrice and maxPrice", async () => {
+      const res = await request(app).get("/listings?minPrice=100&maxPrice=300");
+
+      expect(res.status).toBe(200);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.price).toBeGreaterThanOrEqual(100);
+        expect(l.price).toBeLessThanOrEqual(300);
+      });
+    });
+
+    it("minPrice is inclusive", async () => {
+      const res = await request(app).get("/listings?minPrice=50");
+
+      expect(res.status).toBe(200);
+      const prices = res.body.data.map((l: Listing) => l.price);
+      expect(prices).toContain(50);
+    });
+
+    it("maxPrice is inclusive", async () => {
+      const res = await request(app).get("/listings?maxPrice=50");
+
+      expect(res.status).toBe(200);
+      const prices = res.body.data.map((l: Listing) => l.price);
+      expect(prices).toContain(50);
+    });
+
+    it("returns 400 INVALID_PRICE_RANGE when minPrice > maxPrice", async () => {
+      const res = await request(app).get("/listings?minPrice=500&maxPrice=100");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_PRICE_RANGE");
+    });
+
+    it("returns 400 INVALID_MIN_PRICE for non-numeric minPrice", async () => {
+      const res = await request(app).get("/listings?minPrice=abc");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_MIN_PRICE");
+    });
+
+    it("returns 400 INVALID_MAX_PRICE for non-numeric maxPrice", async () => {
+      const res = await request(app).get("/listings?maxPrice=abc");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_MAX_PRICE");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Combined filters
+  // -------------------------------------------------------------------------
+
+  describe("combined filters", () => {
+    beforeEach(() => {
+      __seedListings(openListings);
+    });
+
+    it("filters by assetType and collection together", async () => {
+      const res = await request(app).get(
+        "/listings?assetType=nft&collection=collection-alpha",
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(2);
+      res.body.data.forEach((l: Listing) => {
+        expect(l.assetType).toBe("nft");
+        expect(l.collectionId).toBe("collection-alpha");
+      });
+    });
+
+    it("filters by assetType, collection, and price range", async () => {
+      const res = await request(app).get(
+        "/listings?assetType=nft&collection=collection-alpha&minPrice=100",
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].id).toBe("listing-003");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sorting
+  // -------------------------------------------------------------------------
+
+  describe("sorting", () => {
+    beforeEach(() => {
+      __seedListings(openListings);
+    });
+
+    it("defaults to newest first when sortBy is omitted", async () => {
+      const res = await request(app).get("/listings");
+
+      expect(res.status).toBe(200);
+      const dates = res.body.data.map((l: Listing) => new Date(l.createdAt).getTime());
+      for (let i = 1; i < dates.length; i++) {
+        expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
+      }
+    });
+
+    it("sortBy=newest returns newest listings first", async () => {
+      const res = await request(app).get("/listings?sortBy=newest");
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((l: Listing) => l.id);
+      expect(ids[0]).toBe("listing-005"); // most recent
+    });
+
+    it("sortBy=oldest returns oldest listings first", async () => {
+      const res = await request(app).get("/listings?sortBy=oldest");
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((l: Listing) => l.id);
+      expect(ids[0]).toBe("listing-001"); // oldest
+    });
+
+    it("sortBy=price_asc returns cheapest first", async () => {
+      const res = await request(app).get("/listings?sortBy=price_asc");
+
+      expect(res.status).toBe(200);
+      const prices = res.body.data.map((l: Listing) => l.price);
+      for (let i = 1; i < prices.length; i++) {
+        expect(prices[i - 1]).toBeLessThanOrEqual(prices[i]);
+      }
+    });
+
+    it("sortBy=price_desc returns most expensive first", async () => {
+      const res = await request(app).get("/listings?sortBy=price_desc");
+
+      expect(res.status).toBe(200);
+      const prices = res.body.data.map((l: Listing) => l.price);
+      for (let i = 1; i < prices.length; i++) {
+        expect(prices[i - 1]).toBeGreaterThanOrEqual(prices[i]);
+      }
+    });
+
+    it("returns 400 INVALID_SORT_BY for unrecognised sortBy value", async () => {
+      const res = await request(app).get("/listings?sortBy=random");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_SORT_BY");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pagination
+  // -------------------------------------------------------------------------
+
+  describe("pagination", () => {
+    const fifteenListings = Array.from({ length: 15 }, (_, i) =>
+      makeListing({
+        id: `listing-p${String(i + 1).padStart(2, "0")}`,
+        price: (i + 1) * 10,
+        createdAt: new Date(Date.UTC(2026, 0, i + 1)).toISOString(),
+      }),
+    );
+
+    beforeEach(() => {
+      __seedListings(fifteenListings);
+    });
+
+    it("returns first page with default limit of 20", async () => {
+      const res = await request(app).get("/listings");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(15); // less than default limit
+      expect(res.body.pagination).toMatchObject({
+        page: 1,
+        limit: 20,
+        total: 15,
+        totalPages: 1,
+        hasNext: false,
+      });
+    });
+
+    it("paginates correctly — page 1 of 3 with limit=5", async () => {
+      const res = await request(app).get("/listings?page=1&limit=5&sortBy=oldest");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(5);
+      expect(res.body.pagination).toMatchObject({
+        page: 1,
+        limit: 5,
+        total: 15,
+        totalPages: 3,
+        hasNext: true,
+      });
+    });
+
+    it("paginates correctly — page 2 of 3 with limit=5", async () => {
+      const res = await request(app).get("/listings?page=2&limit=5&sortBy=oldest");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(5);
+      expect(res.body.pagination.hasNext).toBe(true);
+      expect(res.body.pagination.page).toBe(2);
+    });
+
+    it("paginates correctly — last page has remainder items", async () => {
+      const res = await request(app).get("/listings?page=3&limit=5&sortBy=oldest");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(5);
+      expect(res.body.pagination.hasNext).toBe(false);
+    });
+
+    it("returns empty data for a page beyond the total", async () => {
+      const res = await request(app).get("/listings?page=99&limit=5");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.hasNext).toBe(false);
+    });
+
+    it("returns 400 INVALID_PAGE for page=0", async () => {
+      const res = await request(app).get("/listings?page=0");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_PAGE");
+    });
+
+    it("returns 400 INVALID_PAGE for non-numeric page", async () => {
+      const res = await request(app).get("/listings?page=abc");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_PAGE");
+    });
+
+    it("returns 400 INVALID_LIMIT for limit=0", async () => {
+      const res = await request(app).get("/listings?limit=0");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_LIMIT");
+    });
+
+    it("returns 400 INVALID_LIMIT for limit exceeding MAX_LIMIT (100)", async () => {
+      const res = await request(app).get("/listings?limit=101");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_LIMIT");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test helpers
+  // -------------------------------------------------------------------------
+
+  describe("test helpers", () => {
+    it("__getListings returns a copy of the store", () => {
+      __seedListings(openListings);
+      const stored = __getListings();
+      expect(stored.length).toBe(openListings.length);
+      // Mutating the returned array should not affect the store
+      stored.pop();
+      expect(__getListings().length).toBe(openListings.length);
+    });
+
+    it("__resetListings clears the store", () => {
+      __seedListings(openListings);
+      __resetListings();
+      expect(__getListings().length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
closes #546 
- Add GET /listings route at routes-d/routes/listings.list.ts
- Filter by collection, assetType (token|nft|bond|equity|commodity), minPrice and maxPrice (inclusive, cross-validated)
- Sort by price_asc, price_desc, newest (default), or oldest
- Paginate with page/limit (1-100), returns total, totalPages, hasNext
- Only open listings are returned; filled/cancelled/expired excluded
- Add 39 tests in routes-d/tests/listings.list.test.ts covering empty store, filters, sorting, pagination, and validation error cases
- Install express and supertest dev deps needed by routes-d test suite