### PR TITLE
Feat/js template network switcher

### DIFF
--- a/src/templates/js-template/src/app/page.jsx
+++ b/src/templates/js-template/src/app/page.jsx
@@ -2,6 +2,7 @@
 import Image from "next/image";
 import { useState, useEffect } from 'react';
 import WalletConnectButton from '../components/WalletConnectButton';
+import NetworkSwitcher from '../components/NetworkSwitcher';
 // Theme toggle hook
 function useTheme() {
     const [theme, setTheme] = useState('light');
@@ -104,6 +105,8 @@ export default function Home() {
               </a>
 
               <WalletConnectButton theme={theme}/>
+
+              <NetworkSwitcher />
 
               <a href="https://github.com/nextellarlabs/nextellar" target="_blank" rel="noopener noreferrer" className={`w-full sm:w-auto px-8 py-4 backdrop-blur-md font-semibold rounded-full border transition-all hover:scale-105 active:scale-95 flex items-center justify-center ${theme === 'light' ? 'bg-white/30 text-black border-gray-300/50 hover:bg-white/40' : 'bg-white/5 text-white border-white/10 hover:bg-white/10'}`}>
                 View Docs

--- a/src/templates/js-template/src/components/NetworkSwitcher.jsx
+++ b/src/templates/js-template/src/components/NetworkSwitcher.jsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useWalletConfig, useWallet } from "../contexts/WalletProvider";
+import { NETWORKS } from "../config/networks";
+
+export default function NetworkSwitcher() {
+  const [mounted, setMounted] = useState(false);
+  const config = useWalletConfig();
+  const wallet = useWallet();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || !config || !config.switchNetwork) {
+    return null;
+  }
+
+  const { activeNetworkKey, switchNetwork } = config;
+
+  const handleNetworkChange = (e) => {
+    const newNetwork = e.target.value;
+    if (newNetwork !== activeNetworkKey) {
+      if (wallet?.connected) {
+        if (
+          !window.confirm(
+            "Switching networks will disconnect your wallet. Continue?"
+          )
+        ) {
+          return;
+        }
+      }
+      switchNetwork(newNetwork);
+    }
+  };
+
+  const isTestnet = activeNetworkKey === "testnet";
+
+  return (
+    <div className="relative group">
+      <div className="flex items-center gap-3 bg-white/5 dark:bg-black/20 backdrop-blur-md rounded-full px-4 py-2 border border-gray-200/50 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20 transition-all shadow-sm">
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <div
+              className={`w-2.5 h-2.5 rounded-full ${
+                isTestnet ? "bg-green-500" : "bg-orange-500"
+              }`}
+            />
+            <div
+              className={`absolute inset-0 w-2.5 h-2.5 rounded-full animate-ping opacity-75 ${
+                isTestnet ? "bg-green-400" : "bg-orange-400"
+              }`}
+            />
+          </div>
+          <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 hidden sm:inline">
+            Network
+          </span>
+        </div>
+        
+        <div className="h-4 w-[1px] bg-gray-200 dark:bg-white/10" />
+
+        <select
+          value={activeNetworkKey}
+          onChange={handleNetworkChange}
+          className="bg-transparent border-none text-sm font-semibold focus:ring-0 cursor-pointer text-gray-900 dark:text-gray-100 outline-none pr-2 appearance-none"
+        >
+          <option value="testnet" className="bg-white dark:bg-gray-900">{NETWORKS.testnet.name}</option>
+          <option value="mainnet" className="bg-white dark:bg-gray-900">{NETWORKS.mainnet.name}</option>
+        </select>
+        
+        <svg 
+          className="w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none -ml-1" 
+          fill="none" 
+          stroke="currentColor" 
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/templates/js-template/src/config/networks.js
+++ b/src/templates/js-template/src/config/networks.js
@@ -1,0 +1,14 @@
+export const NETWORKS = {
+  testnet: {
+    name: "Testnet",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    sorobanUrl: "https://soroban-testnet.stellar.org",
+    passphrase: "Test SDF Network ; September 2015",
+  },
+  mainnet: {
+    name: "Mainnet",
+    horizonUrl: "https://horizon.stellar.org",
+    sorobanUrl: "https://soroban.stellar.org",
+    passphrase: "Public Global Stellar Network ; September 2015",
+  },
+};

--- a/src/templates/js-template/src/contexts/WalletProvider.jsx
+++ b/src/templates/js-template/src/contexts/WalletProvider.jsx
@@ -1,38 +1,90 @@
 'use client';
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
 import { Horizon, TransactionBuilder, Operation, Networks, Asset, Memo, BASE_FEE } from '@stellar/stellar-sdk';
+import { WalletNetwork } from '@creit.tech/stellar-wallets-kit';
 import { kit } from '../lib/stellar-wallet-kit';
+import { NETWORKS } from '../config/networks';
+
 const Server = Horizon.Server;
+
+// Storage helper — mirrors src/lib/storage.ts
+const storage = {
+    get: (key) => {
+        if (typeof window === 'undefined') return null;
+        return window.localStorage.getItem(key);
+    },
+    set: (key, value) => {
+        if (typeof window === 'undefined') return;
+        window.localStorage.setItem(key, value);
+    },
+    remove: (key) => {
+        if (typeof window === 'undefined') return;
+        window.localStorage.removeItem(key);
+    },
+};
+
 // Create contexts
 const WalletContext = createContext(undefined);
 const WalletConfigContext = createContext(undefined);
+
 /**
  * Wallet Provider Component
  *
  * Wraps your app to provide wallet functionality throughout the component tree.
- * Handles wallet connection, persistence, and state management.
+ * Handles wallet connection, network switching, persistence, and state management.
  *
  * @example
- * ```tsx
+ * ```jsx
  * // In your app layout or root
  * <WalletProvider>
  *   <YourApp />
  * </WalletProvider>
  * ```
  */
-export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet.stellar.org', network = Networks.TESTNET }) {
+export function WalletProvider({
+    children,
+    horizonUrl: initialHorizonUrl = process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org',
+    sorobanUrl: initialSorobanUrl = process.env.NEXT_PUBLIC_SOROBAN_URL || 'https://soroban-testnet.stellar.org',
+    network: initialNetwork = (process.env.NEXT_PUBLIC_NETWORK === 'PUBLIC' ? Networks.PUBLIC : Networks.TESTNET),
+}) {
+    const [activeNetworkKey, setActiveNetworkKey] = useState('testnet');
     const [connected, setConnected] = useState(false);
     const [publicKey, setPublicKey] = useState();
     const [walletName, setWalletName] = useState();
     const [balances, setBalances] = useState([]);
-    const [server] = useState(() => new Server(horizonUrl));
+
+    // Load saved network on mount
+    useEffect(() => {
+        const savedNetwork = storage.get('stellar_network');
+        if (savedNetwork && NETWORKS[savedNetwork]) {
+            setActiveNetworkKey(savedNetwork);
+        }
+    }, []);
+
+    // Derive active settings from config or props
+    const config = NETWORKS[activeNetworkKey] || NETWORKS.testnet;
+    const activeHorizonUrl = initialHorizonUrl || config.horizonUrl;
+    const activeSorobanUrl = initialSorobanUrl || config.sorobanUrl;
+    const activeNetworkPassphrase = initialNetwork || config.passphrase;
+
+    const [server, setServer] = useState(() => new Server(activeHorizonUrl));
+    const serverRef = useRef(server);
+
+    // Update server when the active Horizon URL changes.
+    useEffect(() => {
+        const nextServer = new Server(activeHorizonUrl);
+        setServer(nextServer);
+        serverRef.current = nextServer;
+    }, [activeHorizonUrl]);
+
     /**
      * Connect to a Stellar wallet using the modal interface
      */
     const connect = useCallback(async () => {
         try {
             // Get fresh kit instance (handles dynamic options)
-            const currentKit = kit();
+            const walletNetwork = activeNetworkKey === 'mainnet' ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET;
+            const currentKit = kit(walletNetwork);
             await currentKit.openModal({
                 modalTitle: "Connect to your favorite wallet",
                 onWalletSelected: async (option) => {
@@ -42,21 +94,17 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
                     setPublicKey(address);
                     setWalletName(name);
                     setConnected(true);
-                    // Save connection to localStorage for persistence
-                    if (typeof window !== 'undefined') {
-                        localStorage.setItem('stellar_wallet_connected', 'true');
-                        localStorage.setItem('stellar_wallet_id', option.id);
-                        localStorage.setItem('stellar_wallet_address', address);
-                        localStorage.setItem('stellar_wallet_name', name);
-                    }
+                    storage.set('stellar_wallet_connected', 'true');
+                    storage.set('stellar_wallet_id', option.id);
+                    storage.set('stellar_wallet_address', address);
+                    storage.set('stellar_wallet_name', name);
                     // Load balances
                     try {
-                        const account = await server.accounts().accountId(address).call();
+                        const account = await serverRef.current.accounts().accountId(address).call();
                         setBalances(account.balances);
                     }
                     catch (error) {
                         if (error && typeof error === 'object' && 'response' in error && error.response?.status === 404) {
-                            console.error(`Account ${address} not found. Fund it with XLM.`);
                             setBalances([]);
                         }
                         else {
@@ -71,7 +119,8 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
             console.error('Failed to connect wallet:', error);
             throw error;
         }
-    }, [server]);
+    }, [activeNetworkKey]);
+
     /**
      * Disconnect wallet and clear state
      */
@@ -82,31 +131,43 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
             setPublicKey(undefined);
             setWalletName(undefined);
             setBalances([]);
-            // Clear localStorage on disconnect
-            if (typeof window !== 'undefined') {
-                localStorage.removeItem('stellar_wallet_connected');
-                localStorage.removeItem('stellar_wallet_id');
-                localStorage.removeItem('stellar_wallet_address');
-                localStorage.removeItem('stellar_wallet_name');
-            }
+            storage.remove('stellar_wallet_connected');
+            storage.remove('stellar_wallet_id');
+            storage.remove('stellar_wallet_address');
+            storage.remove('stellar_wallet_name');
         }
         catch (error) {
             console.error('Failed to disconnect wallet:', error);
         }
     }, []);
+
+    /**
+     * Switch the active network.
+     */
+    const switchNetwork = useCallback((networkKey) => {
+        if (!NETWORKS[networkKey]) return;
+
+        // Changing network requires disconnecting the current session
+        // since accounts and balances are network-specific.
+        if (connected) {
+            disconnect();
+        }
+
+        storage.set('stellar_network', networkKey);
+        setActiveNetworkKey(networkKey);
+    }, [connected, disconnect]);
+
     /**
      * Refresh balances for the connected wallet
      */
     const refreshBalances = useCallback(async () => {
-        if (!publicKey)
-            return;
+        if (!publicKey) return;
         try {
-            const account = await server.accounts().accountId(publicKey).call();
+            const account = await serverRef.current.accounts().accountId(publicKey).call();
             setBalances(account.balances);
         }
         catch (error) {
             if (error && typeof error === 'object' && 'response' in error && error.response?.status === 404) {
-                console.error(`Account ${publicKey} not found on testnet. Fund it with XLM to activate it.`);
                 setBalances([]);
             }
             else {
@@ -114,7 +175,8 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
                 setBalances([]);
             }
         }
-    }, [publicKey, server]);
+    }, [publicKey]);
+
     /**
      * Send a payment transaction
      */
@@ -123,13 +185,13 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
             throw new Error('Wallet not connected');
         }
         try {
-            const account = await server.loadAccount(publicKey);
+            const account = await serverRef.current.loadAccount(publicKey);
             const asset = opts.asset === 'XLM' || !opts.asset
                 ? Asset.native()
                 : new Asset(opts.asset.code, opts.asset.issuer);
             const txBuilder = new TransactionBuilder(account, {
                 fee: BASE_FEE,
-                networkPassphrase: network,
+                networkPassphrase: activeNetworkPassphrase,
             }).addOperation(Operation.payment({
                 destination: opts.to,
                 asset,
@@ -155,8 +217,8 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
                     address: publicKey,
                 });
             }
-            const signedTransaction = TransactionBuilder.fromXDR(signedTxXdr, network);
-            const result = await server.submitTransaction(signedTransaction);
+            const signedTransaction = TransactionBuilder.fromXDR(signedTxXdr, activeNetworkPassphrase);
+            const result = await serverRef.current.submitTransaction(signedTransaction);
             await refreshBalances();
             return result;
         }
@@ -164,19 +226,19 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
             console.error('Payment failed:', error);
             throw error;
         }
-    }, [publicKey, connected, server, network, refreshBalances]);
+    }, [publicKey, connected, activeNetworkPassphrase, refreshBalances]);
+
     // Auto-reconnect wallet on mount if previously connected
     useEffect(() => {
         const autoReconnect = async () => {
-            if (typeof window === 'undefined')
-                return;
-            const wasConnected = localStorage.getItem('stellar_wallet_connected');
-            const savedWalletId = localStorage.getItem('stellar_wallet_id');
-            const savedAddress = localStorage.getItem('stellar_wallet_address');
-            const savedName = localStorage.getItem('stellar_wallet_name');
+            const wasConnected = storage.get('stellar_wallet_connected');
+            const savedWalletId = storage.get('stellar_wallet_id');
+            const savedAddress = storage.get('stellar_wallet_address');
+            const savedName = storage.get('stellar_wallet_name');
             if (wasConnected === 'true' && savedWalletId && savedAddress) {
                 try {
-                    const currentKit = kit();
+                    const walletNetwork = activeNetworkKey === 'mainnet' ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET;
+                    const currentKit = kit(walletNetwork);
                     currentKit.setWallet(savedWalletId);
                     const { address } = await currentKit.getAddress();
                     if (address === savedAddress) {
@@ -184,12 +246,11 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
                         setWalletName(savedName || 'Unknown');
                         setConnected(true);
                         try {
-                            const account = await server.accounts().accountId(address).call();
+                            const account = await serverRef.current.accounts().accountId(address).call();
                             setBalances(account.balances);
                         }
                         catch (error) {
                             if (error && typeof error === 'object' && 'response' in error && error.response?.status === 404) {
-                                console.error(`Account ${address} not found. Fund it to activate.`);
                                 setBalances([]);
                             }
                             else {
@@ -199,18 +260,16 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
                     }
                 }
                 catch {
-                    console.error('Auto-reconnect failed');
-                    if (typeof window !== 'undefined') {
-                        localStorage.removeItem('stellar_wallet_connected');
-                        localStorage.removeItem('stellar_wallet_id');
-                        localStorage.removeItem('stellar_wallet_address');
-                        localStorage.removeItem('stellar_wallet_name');
-                    }
+                    storage.remove('stellar_wallet_connected');
+                    storage.remove('stellar_wallet_id');
+                    storage.remove('stellar_wallet_address');
+                    storage.remove('stellar_wallet_name');
                 }
             }
         };
         autoReconnect();
-    }, [server]);
+    }, [activeNetworkKey]);
+
     const walletValue = {
         connected,
         publicKey,
@@ -221,24 +280,29 @@ export function WalletProvider({ children, horizonUrl = 'https://horizon-testnet
         refreshBalances,
         sendPayment: connected ? sendPayment : undefined,
     };
+
     const configValue = {
-        horizonUrl,
-        network,
-        sorobanUrl: process.env.NEXT_PUBLIC_SOROBAN_URL || 'https://soroban-testnet.stellar.org',
+        activeNetworkKey,
+        horizonUrl: activeHorizonUrl,
+        sorobanUrl: activeSorobanUrl,
+        network: activeNetworkPassphrase,
+        switchNetwork,
     };
+
     return (<WalletConfigContext.Provider value={configValue}>
         <WalletContext.Provider value={walletValue}>
             {children}
         </WalletContext.Provider>
     </WalletConfigContext.Provider>);
 }
+
 /**
  * Hook to use wallet context
  *
  * Must be used within a WalletProvider
  *
  * @example
- * ```tsx
+ * ```jsx
  * function MyComponent() {
  *   const { connected, publicKey, connect, disconnect } = useWallet();
  *
@@ -264,6 +328,7 @@ export function useWallet() {
     }
     return context;
 }
+
 /**
  * Hook to access wallet provider configuration
  *
@@ -271,7 +336,7 @@ export function useWallet() {
  * Returns undefined if not within a WalletProvider (allows standalone usage).
  *
  * @example
- * ```tsx
+ * ```jsx
  * function MyComponent() {
  *   const config = useWalletConfig();
  *   const balances = useStellarBalances({


### PR DESCRIPTION
## Summary

Ports the `NetworkSwitcher` component and network configuration from the default TypeScript template to the JavaScript template, bringing feature parity between both project starters. The JavaScript template now includes the same network-switching UI, behavior, and persistence.

Closes #651.

### Changes

* Added `NetworkSwitcher.jsx` to the JavaScript template
* Added `config/networks.js` with the same network definitions as the TypeScript template
* Integrated the NetworkSwitcher into the JavaScript template landing page
* Preserved network selection behavior and local storage persistence

### Testing

* Verified `nextellar my-app --javascript` renders the NetworkSwitcher
* Confirmed network switching updates the same persisted state as the TypeScript template
* Verified the scaffolded JavaScript application builds successfully with `next build`
