### PR TITLE
feat(cli): components feature for `add`, project-template sourcing, and upgrade tests

### DIFF
--- a/bin/nextellar.ts
+++ b/bin/nextellar.ts
@@ -78,11 +78,21 @@ program
       const { listFeatures } = await import("../src/lib/features.js");
       if (cmdOpts.list) {
         const list = listFeatures();
+        const width = Math.max(...list.map((f) => f.id.length)) + 2;
+        const groups: { title: string; kind: string }[] = [
+          { title: "Hooks & providers:", kind: "hook" },
+          { title: "UI components:", kind: "component" },
+        ];
         console.log(pc.bold("Available features:\n"));
-        list.forEach(({ id, description }) => {
-          console.log(`  ${pc.cyan(id.padEnd(12))} ${pc.dim(description)}`);
+        groups.forEach(({ title, kind }) => {
+          const items = list.filter((f) => f.kind === kind);
+          if (items.length === 0) return;
+          console.log(pc.bold(title));
+          items.forEach(({ id, description }) => {
+            console.log(`  ${pc.cyan(id.padEnd(width))} ${pc.dim(description)}`);
+          });
+          console.log("");
         });
-        console.log("");
         return;
       }
       if (!feature || feature.trim() === "") {

--- a/src/lib/add.ts
+++ b/src/lib/add.ts
@@ -25,16 +25,65 @@ export interface AddOptions {
   packageManager?: string;
 }
 
+export const DEFAULT_TEMPLATE = "default";
+
+/**
+ * Resolve a named template directory, or null when it isn't bundled.
+ */
+function findTemplateDir(templateName: string): string | null {
+  const base = path.resolve(__dirname, "..");
+  const fromSrc = path.resolve(base, "templates", templateName);
+  const fromDist = path.resolve(__dirname, "../../../src/templates", templateName);
+  if (fs.existsSync(fromSrc)) return fromSrc;
+  if (fs.existsSync(fromDist)) return fromDist;
+  return null;
+}
+
 /**
  * Resolve the default template directory (TypeScript template).
  */
-function getTemplateDir(): string {
-  const base = path.resolve(__dirname, "..");
-  const fromSrc = path.resolve(base, "templates/default");
-  const fromDist = path.resolve(__dirname, "../../../src/templates/default");
-  if (fs.existsSync(fromSrc)) return fromSrc;
-  if (fs.existsSync(fromDist)) return fromDist;
-  throw new Error("Nextellar default template not found.");
+function getDefaultTemplateDir(): string {
+  const dir = findTemplateDir(DEFAULT_TEMPLATE);
+  if (!dir) throw new Error("Nextellar default template not found.");
+  return dir;
+}
+
+export interface ResolvedTemplate {
+  /** Template recorded in .nextellar/config.json (or "default" when absent) */
+  name: string;
+  /** Directory the feature files are read from first */
+  dir: string;
+  /** Default template dir, used when a file is missing from `dir` */
+  defaultDir: string;
+}
+
+/**
+ * Read the project's template from .nextellar/config.json, the same marker
+ * `nextellar upgrade` uses. Pre-1.1 projects (and hand-made ones) have no
+ * config, so they fall back to the default template.
+ */
+export async function resolveProjectTemplate(
+  cwd: string
+): Promise<ResolvedTemplate> {
+  const defaultDir = getDefaultTemplateDir();
+  const configPath = path.join(cwd, ".nextellar", "config.json");
+
+  let name = DEFAULT_TEMPLATE;
+  if (await fs.pathExists(configPath)) {
+    const config = await fs.readJson(configPath).catch(() => ({}));
+    if (typeof config.template === "string" && config.template.trim()) {
+      name = config.template.trim();
+    }
+  }
+
+  if (name === DEFAULT_TEMPLATE) return { name, dir: defaultDir, defaultDir };
+
+  const dir = findTemplateDir(name);
+  if (!dir) {
+    // Config names a template this CLI version doesn't ship — treat it as default.
+    return { name: DEFAULT_TEMPLATE, dir: defaultDir, defaultDir };
+  }
+  return { name, dir, defaultDir };
 }
 
 /**
@@ -82,55 +131,108 @@ async function installPackages(
 
 type CopyResult = "copied" | "skipped" | "missing";
 
+const JS_EXTENSIONS: Record<string, string> = { ".ts": ".js", ".tsx": ".jsx" };
+
 /**
- * Copy a single file from template to target. Skips if destination exists and !force.
+ * Feature files are registered with TypeScript paths; the JS template ships the
+ * same files as .js/.jsx, so try that variant before giving up on a template.
+ */
+function relativeVariants(relativePath: string): string[] {
+  const ext = path.extname(relativePath);
+  const jsExt = JS_EXTENSIONS[ext];
+  if (!jsExt) return [relativePath];
+  return [relativePath, relativePath.slice(0, -ext.length) + jsExt];
+}
+
+/** First variant of `relativePath` that exists under `templateDir/src`. */
+async function findInTemplate(
+  templateDir: string,
+  relativePath: string
+): Promise<string | null> {
+  for (const rel of relativeVariants(relativePath)) {
+    if (await fs.pathExists(path.join(templateDir, "src", rel))) return rel;
+  }
+  return null;
+}
+
+/**
+ * Copy a single file from the project's template to the target, falling back to
+ * the default template when the file isn't part of that template (e.g. Soroban
+ * hooks, which the defi template doesn't ship).
  */
 async function copyFile(
-  templateDir: string,
+  template: ResolvedTemplate,
   targetDir: string,
   relativePath: string,
   force: boolean
-): Promise<{ result: CopyResult; path: string }> {
-  const src = path.join(templateDir, "src", relativePath);
-  const dest = path.join(targetDir, "src", relativePath);
+): Promise<{ result: CopyResult; path: string; fromDefault: boolean }> {
+  let fromDefault = false;
+  let rel = await findInTemplate(template.dir, relativePath);
 
-  if (!(await fs.pathExists(src))) {
-    return { result: "missing", path: relativePath };
+  if (!rel && template.dir !== template.defaultDir) {
+    rel = await findInTemplate(template.defaultDir, relativePath);
+    fromDefault = rel !== null;
   }
 
-  if (await fs.pathExists(dest) && !force) {
-    return { result: "skipped", path: relativePath };
+  if (!rel) {
+    return { result: "missing", path: relativePath, fromDefault: false };
+  }
+
+  const src = path.join(
+    fromDefault ? template.defaultDir : template.dir,
+    "src",
+    rel
+  );
+  const dest = path.join(targetDir, "src", rel);
+
+  if ((await fs.pathExists(dest)) && !force) {
+    return { result: "skipped", path: rel, fromDefault };
   }
 
   await fs.ensureDir(path.dirname(dest));
   await fs.copy(src, dest, { overwrite: true });
-  return { result: "copied", path: relativePath };
+  return { result: "copied", path: rel, fromDefault };
+}
+
+interface FeatureCopyReport {
+  copied: string[];
+  skipped: string[];
+  /** Copied from the default template because the project's template lacks them */
+  fallback: string[];
+  /** Not present in either template (e.g. a component that hasn't landed yet) */
+  missing: string[];
 }
 
 /**
  * Add a single feature: copy its files and record npm deps. Does not install deps.
  */
 async function addFeatureFiles(
-  templateDir: string,
+  template: ResolvedTemplate,
   targetDir: string,
   feature: FeatureDef,
   force: boolean
-): Promise<{ copied: string[]; skipped: string[] }> {
-  const copied: string[] = [];
-  const skipped: string[] = [];
+): Promise<FeatureCopyReport> {
+  const report: FeatureCopyReport = {
+    copied: [],
+    skipped: [],
+    fallback: [],
+    missing: [],
+  };
 
   for (const rel of feature.files) {
-    const { result, path: p } = await copyFile(
-      templateDir,
+    const { result, path: p, fromDefault } = await copyFile(
+      template,
       targetDir,
       rel,
       force
     );
-    if (result === "copied") copied.push(p);
-    else if (result === "skipped") skipped.push(p);
+    if (result === "copied") report.copied.push(p);
+    else if (result === "skipped") report.skipped.push(p);
+    else report.missing.push(p);
+    if (fromDefault && result !== "missing") report.fallback.push(p);
   }
 
-  return { copied, skipped };
+  return report;
 }
 
 /**
@@ -163,22 +265,35 @@ export async function runAdd(
     };
   }
 
-  const templateDir = getTemplateDir();
+  const template = await resolveProjectTemplate(cwd);
+  // resolveFeatureWithDeps returns dependencies first, so hooks are always
+  // written before the components that import them.
   const featuresToAdd = resolveFeatureWithDeps(rawId);
   const allCopied: string[] = [];
   const allSkipped: string[] = [];
+  const allFallback: string[] = [];
+  const allMissing: string[] = [];
   const allNpmDeps = new Set<string>();
 
   for (const f of featuresToAdd) {
-    const { copied, skipped } = await addFeatureFiles(
-      templateDir,
+    const { copied, skipped, fallback, missing } = await addFeatureFiles(
+      template,
       cwd,
       f,
       force
     );
     allCopied.push(...copied);
     allSkipped.push(...skipped);
+    allFallback.push(...fallback);
+    allMissing.push(...missing);
     f.npmDependencies.forEach((d) => allNpmDeps.add(d));
+  }
+
+  if (allCopied.length === 0 && allSkipped.length === 0 && allMissing.length > 0) {
+    return {
+      success: false,
+      message: `No files for "${rawId}" are available in the ${pc.bold(template.name)} or ${pc.bold(DEFAULT_TEMPLATE)} template:\n  ${allMissing.join("\n  ")}`,
+    };
   }
 
   if (allCopied.length === 0 && allSkipped.length > 0) {
@@ -208,6 +323,7 @@ export async function runAdd(
 
   const lines: string[] = [];
   lines.push(pc.green("✔") + " " + pc.bold(`Feature "${rawId}" added.`));
+  lines.push(pc.dim(`Source template: ${template.name}`));
   if (allCopied.length > 0) {
     lines.push("");
     lines.push(pc.dim("Added files:"));
@@ -217,6 +333,24 @@ export async function runAdd(
     lines.push("");
     lines.push(pc.dim("Skipped (already exist):"));
     allSkipped.forEach((p) => lines.push("  " + p));
+  }
+  if (allFallback.length > 0) {
+    lines.push("");
+    lines.push(
+      pc.yellow(
+        `Not in the ${pc.bold(template.name)} template — copied from ${pc.bold(DEFAULT_TEMPLATE)}:`
+      )
+    );
+    allFallback.forEach((p) => lines.push("  " + p));
+  }
+  if (allMissing.length > 0) {
+    lines.push("");
+    lines.push(
+      pc.yellow(
+        `Not available in any template yet (skipped):`
+      )
+    );
+    allMissing.forEach((p) => lines.push("  " + p));
   }
   lines.push("");
   lines.push(pc.dim("Next steps:"));

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -4,6 +4,8 @@
  * Dependencies are other feature keys that must be added first.
  */
 
+export type FeatureKind = "hook" | "component";
+
 export interface FeatureDef {
   id: string;
   description: string;
@@ -13,6 +15,8 @@ export interface FeatureDef {
   dependsOn: string[];
   /** npm packages to ensure installed (e.g. @stellar/stellar-sdk) */
   npmDependencies: string[];
+  /** How the feature is grouped in `nextellar add --list` (default: "hook") */
+  kind?: FeatureKind;
 }
 
 const FEATURES: Record<string, FeatureDef> = {
@@ -70,6 +74,58 @@ const FEATURES: Record<string, FeatureDef> = {
     dependsOn: ["wallet"],
     npmDependencies: ["@stellar/stellar-sdk"],
   },
+
+  // UI components. Each one is addable on its own so a project can pull in a
+  // single widget, and each depends on the hook feature it imports from — that
+  // is what guarantees the hooks land before the component that needs them.
+  "network-switcher": {
+    id: "network-switcher",
+    description: "NetworkSwitcher component (testnet/mainnet toggle)",
+    files: ["components/NetworkSwitcher.tsx"],
+    dependsOn: ["wallet"],
+    npmDependencies: [],
+    kind: "component",
+  },
+  "balance-display": {
+    id: "balance-display",
+    description: "BalanceDisplay component (renders useStellarBalances)",
+    files: ["components/BalanceDisplay.tsx"],
+    dependsOn: ["balances"],
+    npmDependencies: [],
+    kind: "component",
+  },
+  "send-form": {
+    id: "send-form",
+    description: "SendForm component (renders useStellarPayment)",
+    files: ["components/SendForm.tsx"],
+    dependsOn: ["payments"],
+    npmDependencies: [],
+    kind: "component",
+  },
+  "transaction-list": {
+    id: "transaction-list",
+    description: "TransactionList component (renders useTransactionHistory)",
+    files: ["components/TransactionList.tsx"],
+    dependsOn: ["wallet", "history"],
+    npmDependencies: [],
+    kind: "component",
+  },
+  components: {
+    id: "components",
+    description: "All Nextellar UI components and the hooks they render",
+    // No files of its own: the umbrella exists so `nextellar add components`
+    // pulls every component feature (and transitively their hooks) at once.
+    files: [],
+    dependsOn: [
+      "wallet",
+      "network-switcher",
+      "balance-display",
+      "send-form",
+      "transaction-list",
+    ],
+    npmDependencies: [],
+    kind: "component",
+  },
 };
 
 /**
@@ -87,12 +143,16 @@ export function getFeature(id: string): FeatureDef | undefined {
 }
 
 /**
- * Returns feature definitions for listing (id, description).
+ * Returns feature definitions for listing (id, description, kind).
  */
-export function listFeatures(): { id: string; description: string }[] {
+export function listFeatures(): {
+  id: string;
+  description: string;
+  kind: FeatureKind;
+}[] {
   return getFeatureIds().map((id) => {
     const f = FEATURES[id];
-    return { id, description: f.description };
+    return { id, description: f.description, kind: f.kind ?? "hook" };
   });
 }
 

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -19,9 +19,14 @@ function findTemplateDir(templateName: string) {
   const base = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
   );
-  const devPath = path.resolve(base, "../../templates", templateName);
-  const prodPath = path.resolve(base, "../../../src/templates", templateName);
-  return fs.existsSync(devPath) ? devPath : prodPath;
+  // src/lib/upgrade.ts, dist/src/lib/upgrade.js and a bundled dist/templates
+  // all resolve the template from a different depth.
+  const candidates = [
+    path.resolve(base, "../templates", templateName),
+    path.resolve(base, "../../templates", templateName),
+    path.resolve(base, "../../../src/templates", templateName),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[candidates.length - 1];
 }
 
 export async function upgrade(opts: UpgradeOptions = {}) {

--- a/tests/add.test.ts
+++ b/tests/add.test.ts
@@ -1,0 +1,252 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { runAdd } from '../src/lib/add.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TEMPLATES = path.resolve(__dirname, '../src/templates');
+const templateFile = (template: string, rel: string) =>
+  path.join(TEMPLATES, template, 'src', rel);
+
+jest.setTimeout(30000);
+
+describe('runAdd', () => {
+  const tmpDirs: string[] = [];
+  let logSpy: jest.SpyInstance;
+
+  /** Minimal Next.js project; `template` writes the .nextellar marker. */
+  const makeProject = async (template?: string) => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'nextellar-add-'));
+    tmpDirs.push(dir);
+    await fs.writeJson(path.join(dir, 'package.json'), {
+      name: 'demo',
+      dependencies: { next: '16.1.2' },
+    });
+    if (template) {
+      await fs.outputJson(path.join(dir, '.nextellar/config.json'), {
+        template,
+        nextellarVersion: '1.0.0',
+      });
+    }
+    return dir;
+  };
+
+  const output = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+  const read = (file: string) => fs.readFile(file, 'utf8');
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    await Promise.all(tmpDirs.map((d) => fs.remove(d).catch(() => {})));
+    tmpDirs.length = 0;
+  });
+
+  describe('guards', () => {
+    it('rejects an unknown feature', async () => {
+      const cwd = await makeProject();
+      const result = await runAdd('not-a-feature', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Unknown feature');
+    });
+
+    it('rejects a directory without package.json', async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'nextellar-add-'));
+      tmpDirs.push(dir);
+
+      const result = await runAdd('wallet', { cwd: dir, skipInstall: true });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('No package.json');
+    });
+
+    it('skips existing files unless --force is passed', async () => {
+      const cwd = await makeProject();
+      await runAdd('wallet', { cwd, skipInstall: true });
+
+      const hook = path.join(cwd, 'src/hooks/useStellarWallet.ts');
+      await fs.writeFile(hook, '// user edit\n');
+
+      const second = await runAdd('wallet', { cwd, skipInstall: true });
+      expect(second.success).toBe(false);
+      expect(second.message).toContain('--force');
+      expect(await read(hook)).toBe('// user edit\n');
+
+      const forced = await runAdd('wallet', { cwd, skipInstall: true, force: true });
+      expect(forced.success).toBe(true);
+      expect(await read(hook)).toBe(
+        await read(templateFile('default', 'hooks/useStellarWallet.ts'))
+      );
+    });
+  });
+
+  describe('template resolution', () => {
+    it('sources files from the project template recorded in .nextellar/config.json', async () => {
+      const cwd = await makeProject('defi');
+
+      const result = await runAdd('trustlines', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      const copied = await read(path.join(cwd, 'src/hooks/useTrustlines.ts'));
+      expect(copied).toBe(await read(templateFile('defi', 'hooks/useTrustlines.ts')));
+      expect(copied).not.toBe(
+        await read(templateFile('default', 'hooks/useTrustlines.ts'))
+      );
+      // Its wallet dependency comes from the defi template too.
+      expect(await read(path.join(cwd, 'src/hooks/useStellarWallet.ts'))).toBe(
+        await read(templateFile('defi', 'hooks/useStellarWallet.ts'))
+      );
+      expect(output()).toContain('Source template: defi');
+    });
+
+    it('falls back to the default template and says so when a file is missing', async () => {
+      const cwd = await makeProject('defi');
+      // The defi template ships no Soroban hooks today.
+      expect(
+        await fs.pathExists(templateFile('defi', 'hooks/useSorobanContract.ts'))
+      ).toBe(false);
+
+      const result = await runAdd('contracts', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      expect(await read(path.join(cwd, 'src/hooks/useSorobanContract.ts'))).toBe(
+        await read(templateFile('default', 'hooks/useSorobanContract.ts'))
+      );
+
+      const logged = output();
+      expect(logged).toContain('copied from');
+      expect(logged).toContain('hooks/useSorobanContract.ts');
+      expect(logged).toContain('hooks/useSorobanEvents.ts');
+    });
+
+    it('does not report a fallback for files the project template does ship', async () => {
+      const cwd = await makeProject('defi');
+
+      await runAdd('balances', { cwd, skipInstall: true });
+
+      expect(output()).not.toContain('copied from');
+    });
+
+    it('uses the default template when .nextellar/config.json is absent', async () => {
+      const cwd = await makeProject();
+
+      const result = await runAdd('trustlines', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      expect(await read(path.join(cwd, 'src/hooks/useTrustlines.ts'))).toBe(
+        await read(templateFile('default', 'hooks/useTrustlines.ts'))
+      );
+      expect(output()).toContain('Source template: default');
+    });
+
+    it('copies the .js/.jsx variants for a JavaScript project', async () => {
+      const cwd = await makeProject('js-template');
+
+      const result = await runAdd('wallet', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      expect(await read(path.join(cwd, 'src/hooks/useStellarWallet.js'))).toBe(
+        await read(templateFile('js-template', 'hooks/useStellarWallet.js'))
+      );
+      expect(
+        await fs.pathExists(path.join(cwd, 'src/contexts/WalletProvider.jsx'))
+      ).toBe(true);
+      // No TypeScript files leak into a JS project.
+      expect(
+        await fs.pathExists(path.join(cwd, 'src/hooks/useStellarWallet.ts'))
+      ).toBe(false);
+      expect(output()).not.toContain('copied from');
+    });
+
+    it('uses the default template when the configured template is unknown', async () => {
+      const cwd = await makeProject('template-from-the-future');
+
+      const result = await runAdd('balances', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      expect(await read(path.join(cwd, 'src/hooks/useStellarBalances.ts'))).toBe(
+        await read(templateFile('default', 'hooks/useStellarBalances.ts'))
+      );
+      expect(output()).toContain('Source template: default');
+    });
+  });
+
+  describe('components feature', () => {
+    it('copies a component together with the hook it renders', async () => {
+      const cwd = await makeProject();
+
+      const result = await runAdd('network-switcher', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      expect(
+        await fs.pathExists(path.join(cwd, 'src/components/NetworkSwitcher.tsx'))
+      ).toBe(true);
+      // wallet is its dependency, so the provider/hook land as well.
+      expect(
+        await fs.pathExists(path.join(cwd, 'src/hooks/useStellarWallet.ts'))
+      ).toBe(true);
+      expect(
+        await fs.pathExists(path.join(cwd, 'src/contexts/WalletProvider.tsx'))
+      ).toBe(true);
+    });
+
+    it('pulls every component plus its hook dependencies', async () => {
+      const cwd = await makeProject();
+
+      const result = await runAdd('components', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      for (const rel of [
+        'src/hooks/useStellarWallet.ts',
+        'src/hooks/useStellarBalances.ts',
+        'src/hooks/useStellarPayment.ts',
+        'src/hooks/useTransactionHistory.ts',
+        'src/components/WalletConnectButton.tsx',
+        'src/components/NetworkSwitcher.tsx',
+      ]) {
+        expect(await fs.pathExists(path.join(cwd, rel))).toBe(true);
+      }
+    });
+
+    it('reports components that no template ships yet instead of failing silently', async () => {
+      const cwd = await makeProject();
+
+      const result = await runAdd('components', { cwd, skipInstall: true });
+
+      expect(result.success).toBe(true);
+      const logged = output();
+      for (const rel of [
+        'components/BalanceDisplay.tsx',
+        'components/SendForm.tsx',
+        'components/TransactionList.tsx',
+      ]) {
+        // Guard: once the component lands in the template this flips to a copy.
+        if (!(await fs.pathExists(templateFile('default', rel)))) {
+          expect(logged).toContain(rel);
+        }
+      }
+    });
+
+    it('still installs the hook dependency when only the component is unavailable', async () => {
+      const cwd = await makeProject();
+
+      const result = await runAdd('send-form', { cwd, skipInstall: true });
+
+      if (await fs.pathExists(templateFile('default', 'components/SendForm.tsx'))) {
+        expect(result.success).toBe(true);
+      } else {
+        // The hook dependency still lands; only the component is unavailable.
+        expect(
+          await fs.pathExists(path.join(cwd, 'src/hooks/useStellarPayment.ts'))
+        ).toBe(true);
+        expect(output()).toContain('components/SendForm.tsx');
+      }
+    });
+  });
+});

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1,0 +1,109 @@
+import {
+  getFeature,
+  getFeatureIds,
+  listFeatures,
+  resolveFeatureWithDeps,
+} from '../src/lib/features.js';
+
+const orderOf = (ids: string[], id: string) => ids.indexOf(id);
+
+describe('feature registry', () => {
+  it('registers the UI component features alongside the hook features', () => {
+    const ids = getFeatureIds();
+
+    expect(ids).toEqual(
+      expect.arrayContaining(['wallet', 'balances', 'payments', 'history'])
+    );
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'components',
+        'network-switcher',
+        'balance-display',
+        'send-form',
+        'transaction-list',
+      ])
+    );
+  });
+
+  it('marks component features so `add --list` can group them', () => {
+    const byId = Object.fromEntries(listFeatures().map((f) => [f.id, f]));
+
+    expect(byId['wallet'].kind).toBe('hook');
+    expect(byId['components'].kind).toBe('component');
+    expect(byId['send-form'].kind).toBe('component');
+    expect(byId['send-form'].description).toEqual(expect.any(String));
+  });
+
+  it('points component features at components/*.tsx', () => {
+    expect(getFeature('balance-display')?.files).toEqual([
+      'components/BalanceDisplay.tsx',
+    ]);
+    expect(getFeature('send-form')?.files).toEqual(['components/SendForm.tsx']);
+    expect(getFeature('transaction-list')?.files).toEqual([
+      'components/TransactionList.tsx',
+    ]);
+    expect(getFeature('network-switcher')?.files).toEqual([
+      'components/NetworkSwitcher.tsx',
+    ]);
+  });
+
+  it('ties each component to the hook feature it renders', () => {
+    expect(getFeature('balance-display')?.dependsOn).toContain('balances');
+    expect(getFeature('send-form')?.dependsOn).toContain('payments');
+    expect(getFeature('transaction-list')?.dependsOn).toContain('history');
+    expect(getFeature('network-switcher')?.dependsOn).toContain('wallet');
+  });
+
+  describe('resolveFeatureWithDeps', () => {
+    it('returns an empty list for an unknown feature', () => {
+      expect(resolveFeatureWithDeps('nope')).toEqual([]);
+    });
+
+    it('puts a component after the hook feature it depends on', () => {
+      const ids = resolveFeatureWithDeps('transaction-list').map((f) => f.id);
+
+      expect(ids).toEqual(['wallet', 'history', 'transaction-list']);
+      expect(orderOf(ids, 'history')).toBeLessThan(
+        orderOf(ids, 'transaction-list')
+      );
+    });
+
+    it('resolves the components umbrella with every hook before its component', () => {
+      const ids = resolveFeatureWithDeps('components').map((f) => f.id);
+
+      expect(ids).toEqual(
+        expect.arrayContaining([
+          'wallet',
+          'balances',
+          'payments',
+          'history',
+          'network-switcher',
+          'balance-display',
+          'send-form',
+          'transaction-list',
+          'components',
+        ])
+      );
+
+      const pairs: [string, string][] = [
+        ['wallet', 'network-switcher'],
+        ['balances', 'balance-display'],
+        ['payments', 'send-form'],
+        ['history', 'transaction-list'],
+      ];
+      for (const [hook, component] of pairs) {
+        expect(orderOf(ids, hook)).toBeGreaterThanOrEqual(0);
+        expect(orderOf(ids, hook)).toBeLessThan(orderOf(ids, component));
+      }
+
+      // The umbrella itself is installed last and contributes no files.
+      expect(ids[ids.length - 1]).toBe('components');
+      expect(getFeature('components')?.files).toEqual([]);
+    });
+
+    it('lists each feature once even when several components share a hook', () => {
+      const ids = resolveFeatureWithDeps('components').map((f) => f.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+});

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -1,0 +1,216 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { upgrade } from '../src/lib/upgrade.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TEMPLATES = path.resolve(__dirname, '../src/templates');
+const templateFile = (template: string, rel: string) =>
+  path.join(TEMPLATES, template, 'src', rel);
+
+jest.setTimeout(30000);
+
+/** Files the minimal template ships under src/hooks and src/lib. */
+const MINIMAL_MANAGED = [
+  'hooks/useStellarBalances.ts',
+  'hooks/useStellarWallet.ts',
+  'lib/stellar-wallet-kit.ts',
+  'lib/storage.ts',
+];
+
+/** Files a user owns that upgrade must never touch. */
+const UNMANAGED = {
+  'src/app/page.tsx': '// my page\n',
+  'src/components/WalletConnectButton.tsx': '// my button\n',
+  'src/contexts/WalletProvider.tsx': '// my provider\n',
+};
+
+describe('upgrade', () => {
+  const tmpDirs: string[] = [];
+  let origCwd: string;
+  let logSpy: jest.SpyInstance;
+
+  const read = (file: string) => fs.readFile(file, 'utf8');
+  const output = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+
+  /**
+   * Project fixture: .nextellar marker, a package.json whose Stellar deps match
+   * the template (so only file changes show up), the template's managed files,
+   * and a few user-owned files outside src/hooks|src/lib.
+   */
+  const makeProject = async (opts: {
+    template?: string;
+    managed?: string[];
+    overrides?: Record<string, string>;
+  } = {}) => {
+    const { template = 'minimal', managed = MINIMAL_MANAGED, overrides = {} } = opts;
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'nextellar-upgrade-'));
+    tmpDirs.push(dir);
+
+    await fs.outputJson(path.join(dir, '.nextellar/config.json'), {
+      template,
+      nextellarVersion: '1.0.0',
+    });
+
+    const tplPkg = await fs.readJson(path.join(TEMPLATES, template, 'package.json'));
+    await fs.writeJson(path.join(dir, 'package.json'), {
+      name: 'demo',
+      dependencies: { ...tplPkg.dependencies },
+      devDependencies: { ...tplPkg.devDependencies },
+    });
+
+    for (const rel of managed) {
+      const dest = path.join(dir, 'src', rel);
+      await fs.ensureDir(path.dirname(dest));
+      await fs.copyFile(templateFile(template, rel), dest);
+    }
+    for (const [rel, content] of Object.entries(overrides)) {
+      await fs.outputFile(path.join(dir, rel), content);
+    }
+    for (const [rel, content] of Object.entries(UNMANAGED)) {
+      await fs.outputFile(path.join(dir, rel), content);
+    }
+
+    return dir;
+  };
+
+  beforeEach(() => {
+    origCwd = process.cwd();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    process.chdir(origCwd);
+    logSpy.mockRestore();
+    await Promise.all(tmpDirs.map((d) => fs.remove(d).catch(() => {})));
+    tmpDirs.length = 0;
+  });
+
+  it('errors when .nextellar/config.json is missing', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'nextellar-upgrade-'));
+    tmpDirs.push(dir);
+    await fs.writeJson(path.join(dir, 'package.json'), { name: 'demo' });
+    process.chdir(dir);
+
+    await expect(upgrade({ yes: true })).rejects.toThrow(
+      /Not a Nextellar project/
+    );
+  });
+
+  it('resolves the template named in .nextellar/config.json', async () => {
+    const minimal = await makeProject({ template: 'minimal', managed: [] });
+    process.chdir(minimal);
+    await upgrade({ dryRun: true });
+    const minimalOut = output();
+
+    expect(minimalOut).toMatch(/Project template:\s*\S*minimal/);
+    expect(minimalOut).toContain('hooks/useStellarWallet.ts');
+    expect(minimalOut).toContain('lib/storage.ts');
+    // Not part of the minimal template.
+    expect(minimalOut).not.toContain('hooks/useTrustlines.ts');
+
+    logSpy.mockClear();
+    process.chdir(origCwd);
+
+    const defi = await makeProject({ template: 'defi', managed: [] });
+    process.chdir(defi);
+    await upgrade({ dryRun: true });
+    const defiOut = output();
+
+    expect(defiOut).toMatch(/Project template:\s*\S*defi/);
+    // Only the defi template ships these two.
+    expect(defiOut).toContain('hooks/useTrustlines.ts');
+    expect(defiOut).toContain('hooks/useOfferBook.ts');
+    expect(defiOut).not.toContain('lib/storage.ts');
+  });
+
+  it('reports an up-to-date project when every managed file is identical', async () => {
+    const dir = await makeProject();
+    process.chdir(dir);
+
+    await upgrade({ yes: true });
+
+    expect(output()).toContain('No template updates to apply.');
+    expect(await fs.pathExists(path.join(dir, '.nextellar/backups'))).toBe(false);
+  });
+
+  it('updates only the files that differ from the template', async () => {
+    const dir = await makeProject({
+      overrides: { 'src/hooks/useStellarBalances.ts': '// stale copy\n' },
+    });
+    process.chdir(dir);
+
+    await upgrade({ yes: true });
+
+    const logged = output();
+    expect(logged).toContain('hooks/useStellarBalances.ts');
+    expect(logged).not.toContain('hooks/useStellarWallet.ts');
+
+    expect(await read(path.join(dir, 'src/hooks/useStellarBalances.ts'))).toBe(
+      await read(templateFile('minimal', 'hooks/useStellarBalances.ts'))
+    );
+    // The stale copy is backed up before being overwritten.
+    const backups = await fs.readdir(path.join(dir, '.nextellar/backups'));
+    expect(backups).toHaveLength(1);
+    expect(
+      await read(
+        path.join(
+          dir,
+          '.nextellar/backups',
+          backups[0],
+          'src/hooks/useStellarBalances.ts'
+        )
+      )
+    ).toBe('// stale copy\n');
+  });
+
+  it('only considers files under src/hooks and src/lib', async () => {
+    const dir = await makeProject({
+      overrides: { 'src/hooks/useStellarBalances.ts': '// stale copy\n' },
+    });
+    process.chdir(dir);
+
+    await upgrade({ yes: true });
+
+    const logged = output();
+    for (const rel of Object.keys(UNMANAGED)) {
+      // Neither listed as a change...
+      expect(logged).not.toContain(rel.replace('src/', ''));
+      // ...nor rewritten on disk.
+      expect(await read(path.join(dir, rel))).toBe(
+        UNMANAGED[rel as keyof typeof UNMANAGED]
+      );
+    }
+  });
+
+  it('writes nothing when --dry-run is passed', async () => {
+    const dir = await makeProject({
+      overrides: { 'src/hooks/useStellarBalances.ts': '// stale copy\n' },
+    });
+    process.chdir(dir);
+
+    await upgrade({ dryRun: true });
+
+    expect(output()).toContain('no files were modified');
+    expect(await read(path.join(dir, 'src/hooks/useStellarBalances.ts'))).toBe(
+      '// stale copy\n'
+    );
+    expect(await fs.pathExists(path.join(dir, '.nextellar/backups'))).toBe(false);
+  });
+
+  it('records the CLI version in .nextellar/config.json after upgrading', async () => {
+    const dir = await makeProject({
+      overrides: { 'src/hooks/useStellarBalances.ts': '// stale copy\n' },
+    });
+    process.chdir(dir);
+
+    await upgrade({ yes: true });
+
+    const config = await fs.readJson(path.join(dir, '.nextellar/config.json'));
+    expect(config.template).toBe('minimal');
+    expect(config.updatedAt).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
closes #667 - Adds per-component features (network-switcher, balance-display, send-form, transaction-list) and a `components` umbrella to the add registry, each depending on the hook feature it renders so hooks are always copied before the components that import them.
`add --list` now groups hooks and UI components, and runAdd reports component files that no template ships yet instead of skipping them silently.

closes #671 - `add` now reads `template` from `.nextellar/config.json` (the same marker `upgrade` uses) and sources feature files from that template, falling back to `default` per file with an explicit "Not in the <template> template — copied from default" notice.
Projects with no config (pre-1.1) or an unknown template name still resolve to `default`, and JS-template projects now get the .js/.jsx variants instead of TypeScript files.

closes #640 - Adds tests/upgrade.test.ts covering the missing-config error, template resolution from `.nextellar/config.json`, the src/hooks + src/lib candidate scope, and identical-vs-differing file handling under `--yes`.
User-owned files outside src/hooks|src/lib are asserted byte-identical after an upgrade, and a `--dry-run` no-write case is included; fixes upgrade's template lookup, which previously only resolved in the built dist layout.
closes #660  - Splits background refetch from pagination growth in the explore grid: a floating "Updating…" pill appears on `isFetching && !isLoading`, anchored in a relative wrapper so it causes no layout shift.
Stale results dim to 50% opacity with `aria-busy` and a screen-reader live region, while append-skeletons remain gated to limit growth only.
