### PR TITLE
feat(nextellar): create-server-sent-events-for-payment-status-in-

### DIFF
--- a/routes-d/lib/boundedEventBuffer.ts
+++ b/routes-d/lib/boundedEventBuffer.ts
@@ -1,0 +1,35 @@
+/**
+ * Fixed-capacity FIFO buffer; oldest entries are dropped when capacity is exceeded.
+ */
+export class BoundedEventBuffer<T> {
+  private readonly items: T[] = [];
+
+  constructor(private readonly maxSize: number) {
+    if (!Number.isInteger(maxSize) || maxSize < 1) {
+      throw new Error('maxSize must be a positive integer');
+    }
+  }
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  get capacity(): number {
+    return this.maxSize;
+  }
+
+  push(item: T): void {
+    this.items.push(item);
+    while (this.items.length > this.maxSize) {
+      this.items.shift();
+    }
+  }
+
+  toArray(): T[] {
+    return [...this.items];
+  }
+
+  clear(): void {
+    this.items.length = 0;
+  }
+}

--- a/routes-d/routes/payments.sse.ts
+++ b/routes-d/routes/payments.sse.ts
@@ -1,0 +1,350 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { sendError } from '../lib/response.js';
+import { BoundedEventBuffer } from '../lib/boundedEventBuffer.js';
+
+const router = Router();
+
+export type PaymentStatus =
+  | 'pending'
+  | 'processing'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type PaymentStatusEvent = {
+  id: string;
+  paymentId: string;
+  status: PaymentStatus;
+  previousStatus: PaymentStatus | null;
+  at: string;
+};
+
+type Payment = {
+  id: string;
+  userId: string;
+  status: PaymentStatus;
+  amount: number;
+  currency: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** Events retained per payment for Last-Event-ID replay (server-side). */
+const PAYMENT_EVENT_HISTORY_CAPACITY = 128;
+
+/** Pending outbound events per SSE connection when the client is slow. */
+const CONNECTION_EVENT_BUFFER_CAPACITY = 32;
+
+const DEFAULT_HEARTBEAT_MS = 15_000;
+
+const payments = new Map<string, Payment>();
+const paymentEventHistory = new Map<string, BoundedEventBuffer<PaymentStatusEvent>>();
+let nextEventId = 1;
+
+type SseSubscriber = {
+  paymentId: string;
+  res: Response;
+  pending: BoundedEventBuffer<PaymentStatusEvent>;
+  closed: boolean;
+};
+
+const subscribersByPayment = new Map<string, Set<SseSubscriber>>();
+
+function getOrCreateHistory(paymentId: string): BoundedEventBuffer<PaymentStatusEvent> {
+  let history = paymentEventHistory.get(paymentId);
+  if (!history) {
+    history = new BoundedEventBuffer<PaymentStatusEvent>(PAYMENT_EVENT_HISTORY_CAPACITY);
+    paymentEventHistory.set(paymentId, history);
+  }
+  return history;
+}
+
+function formatSseMessage(event: PaymentStatusEvent): string {
+  const payload = JSON.stringify({
+    paymentId: event.paymentId,
+    status: event.status,
+    previousStatus: event.previousStatus,
+    at: event.at,
+  });
+  return `id: ${event.id}\nevent: status\ndata: ${payload}\n\n`;
+}
+
+function parseLastEventId(header: string | undefined): number | null {
+  if (!header || header.trim() === '') {
+    return null;
+  }
+  const parsed = Number.parseInt(header.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function eventsAfterId(
+  history: BoundedEventBuffer<PaymentStatusEvent>,
+  lastId: number,
+): PaymentStatusEvent[] {
+  return history.toArray().filter((event) => Number.parseInt(event.id, 10) > lastId);
+}
+
+function writeEventToResponse(res: Response, event: PaymentStatusEvent): boolean {
+  return res.write(formatSseMessage(event));
+}
+
+function dequeuePending(subscriber: SseSubscriber): PaymentStatusEvent | undefined {
+  const queue = subscriber.pending.toArray();
+  if (queue.length === 0) {
+    return undefined;
+  }
+  const [head, ...rest] = queue;
+  subscriber.pending.clear();
+  for (const item of rest) {
+    subscriber.pending.push(item);
+  }
+  return head;
+}
+
+function enqueueForSubscriber(subscriber: SseSubscriber, event: PaymentStatusEvent): void {
+  if (subscriber.closed) {
+    return;
+  }
+
+  subscriber.pending.push(event);
+
+  while (!subscriber.closed && subscriber.pending.size > 0) {
+    const next = dequeuePending(subscriber);
+    if (!next) {
+      break;
+    }
+    const ok = writeEventToResponse(subscriber.res, next);
+    if (!ok) {
+      subscriber.pending.push(next);
+      break;
+    }
+  }
+}
+
+function removeSubscriber(subscriber: SseSubscriber): void {
+  subscriber.closed = true;
+  const set = subscribersByPayment.get(subscriber.paymentId);
+  if (set) {
+    set.delete(subscriber);
+    if (set.size === 0) {
+      subscribersByPayment.delete(subscriber.paymentId);
+    }
+  }
+}
+
+function broadcastStatusEvent(event: PaymentStatusEvent): void {
+  const set = subscribersByPayment.get(event.paymentId);
+  if (!set) {
+    return;
+  }
+  for (const subscriber of set) {
+    enqueueForSubscriber(subscriber, event);
+  }
+}
+
+function recordStatusTransition(
+  payment: Payment,
+  nextStatus: PaymentStatus,
+): PaymentStatusEvent {
+  const previousStatus = payment.status;
+  const at = new Date().toISOString();
+  payment.status = nextStatus;
+  payment.updatedAt = at;
+
+  const event: PaymentStatusEvent = {
+    id: String(nextEventId++),
+    paymentId: payment.id,
+    status: nextStatus,
+    previousStatus,
+    at,
+  };
+
+  getOrCreateHistory(payment.id).push(event);
+  broadcastStatusEvent(event);
+  return event;
+}
+
+export function __resetPaymentsSse(): void {
+  payments.clear();
+  paymentEventHistory.clear();
+  subscribersByPayment.clear();
+  nextEventId = 1;
+}
+
+export function __seedPayment(payment: Payment): void {
+  payments.set(payment.id, { ...payment });
+  const history = getOrCreateHistory(payment.id);
+  if (history.size === 0) {
+    history.push({
+      id: String(nextEventId++),
+      paymentId: payment.id,
+      status: payment.status,
+      previousStatus: null,
+      at: payment.updatedAt,
+    });
+  }
+}
+
+export function __getPayment(paymentId: string): Payment | undefined {
+  const payment = payments.get(paymentId);
+  return payment ? { ...payment } : undefined;
+}
+
+export function __getPaymentEventHistory(paymentId: string): PaymentStatusEvent[] {
+  return getOrCreateHistory(paymentId).toArray();
+}
+
+/** Test hook: transition payment status and emit SSE to active subscribers. */
+export function __transitionPaymentStatus(
+  paymentId: string,
+  status: PaymentStatus,
+): PaymentStatusEvent | null {
+  const payment = payments.get(paymentId);
+  if (!payment) {
+    return null;
+  }
+  if (payment.status === status) {
+    return null;
+  }
+  return recordStatusTransition(payment, status);
+}
+
+export function __enqueueEventForSubscriber(
+  subscriber: SseSubscriber,
+  event: PaymentStatusEvent,
+): void {
+  enqueueForSubscriber(subscriber, event);
+}
+
+export function __createSubscriberForTest(
+  paymentId: string,
+  res: Response,
+): SseSubscriber {
+  const subscriber: SseSubscriber = {
+    paymentId,
+    res,
+    pending: new BoundedEventBuffer<PaymentStatusEvent>(CONNECTION_EVENT_BUFFER_CAPACITY),
+    closed: false,
+  };
+  let set = subscribersByPayment.get(paymentId);
+  if (!set) {
+    set = new Set();
+    subscribersByPayment.set(paymentId, set);
+  }
+  set.add(subscriber);
+  return subscriber;
+}
+
+export const __CONNECTION_EVENT_BUFFER_CAPACITY = CONNECTION_EVENT_BUFFER_CAPACITY;
+
+/**
+ * GET /payments/:paymentId/status/stream
+ * Server-sent events stream for payment status transitions.
+ * Supports Last-Event-ID for reconnect replay.
+ */
+router.get(
+  '/payments/:paymentId/status/stream',
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers['x-user-id'] as string | undefined;
+      if (!userId) {
+        sendError(res, 'UNAUTHORIZED', 'x-user-id header is required', 401);
+        return;
+      }
+
+      const paymentId = req.params.paymentId?.trim();
+      if (!paymentId) {
+        sendError(res, 'INVALID_PAYMENT_ID', 'paymentId is required', 400);
+        return;
+      }
+
+      const payment = payments.get(paymentId);
+      if (!payment) {
+        sendError(res, 'NOT_FOUND', 'Payment not found', 404);
+        return;
+      }
+
+      if (payment.userId !== userId) {
+        sendError(res, 'FORBIDDEN', 'Access denied for this payment', 403);
+        return;
+      }
+
+      res.status(200);
+      res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.flushHeaders();
+
+      const subscriber: SseSubscriber = {
+        paymentId,
+        res,
+        pending: new BoundedEventBuffer<PaymentStatusEvent>(CONNECTION_EVENT_BUFFER_CAPACITY),
+        closed: false,
+      };
+
+      let set = subscribersByPayment.get(paymentId);
+      if (!set) {
+        set = new Set();
+        subscribersByPayment.set(paymentId, set);
+      }
+      set.add(subscriber);
+
+      const lastEventId = parseLastEventId(req.headers['last-event-id'] as string | undefined);
+      const history = getOrCreateHistory(paymentId);
+
+      const replay =
+        lastEventId === null
+          ? history.toArray()
+          : eventsAfterId(history, lastEventId);
+
+      for (const event of replay) {
+        enqueueForSubscriber(subscriber, event);
+      }
+
+      const heartbeatMs = Number.parseInt(
+        String(req.query.heartbeatMs ?? DEFAULT_HEARTBEAT_MS),
+        10,
+      );
+      const heartbeatInterval = setInterval(() => {
+        if (!subscriber.closed) {
+          res.write(': heartbeat\n\n');
+        }
+      }, Number.isFinite(heartbeatMs) && heartbeatMs > 0 ? heartbeatMs : DEFAULT_HEARTBEAT_MS);
+
+      const onDrain = (): void => {
+        if (subscriber.closed) {
+          return;
+        }
+        while (subscriber.pending.size > 0) {
+          const next = dequeuePending(subscriber);
+          if (!next) {
+            break;
+          }
+          const ok = writeEventToResponse(res, next);
+          if (!ok) {
+            subscriber.pending.push(next);
+            break;
+          }
+        }
+      };
+
+      res.on('drain', onDrain);
+
+      req.on('close', () => {
+        clearInterval(heartbeatInterval);
+        res.off('drain', onDrain);
+        removeSubscriber(subscriber);
+        if (!res.writableEnded) {
+          res.end();
+        }
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/integration/payments.sse.integration.test.ts
+++ b/routes-d/tests/integration/payments.sse.integration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Integration tests for payment status SSE streaming.
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import paymentsSseRouter, {
+  __resetPaymentsSse,
+  __seedPayment,
+  __transitionPaymentStatus,
+  __getPayment,
+} from '../../routes/payments.sse.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(paymentsSseRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe('Payment status SSE integration', () => {
+  const app = buildApp();
+  const userId = 'integration-user';
+  const paymentId = 'integration-pay';
+
+  beforeEach(() => {
+    __resetPaymentsSse();
+    __seedPayment({
+      id: paymentId,
+      userId,
+      status: 'pending',
+      amount: 250,
+      currency: 'XLM',
+      createdAt: '2026-07-10T08:00:00.000Z',
+      updatedAt: '2026-07-10T08:00:00.000Z',
+    });
+  });
+
+  it('connects, receives live transitions, and persists payment status', async () => {
+    let resolveBody: (body: string) => void;
+    const bodyPromise = new Promise<string>((resolve) => {
+      resolveBody = resolve;
+    });
+
+    const streamReq = request(app)
+      .get(`/payments/${paymentId}/status/stream`)
+      .set('x-user-id', userId)
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        response.on('data', (chunk: Buffer) => {
+          body += chunk.toString('utf8');
+          if (body.includes('"status":"failed"')) {
+            response.destroy();
+            resolveBody(body);
+            callback(null, body);
+          }
+        });
+        response.on('error', (err: Error) => {
+          if ((err as NodeJS.ErrnoException).code === 'ECONNRESET') {
+            resolveBody(body);
+            callback(null, body);
+            return;
+          }
+          callback(err, body);
+        });
+      })
+      .end();
+
+    await new Promise((r) => setTimeout(r, 40));
+    __transitionPaymentStatus(paymentId, 'processing');
+    __transitionPaymentStatus(paymentId, 'failed');
+
+    const body = await bodyPromise;
+    await streamReq;
+
+    expect(body).toContain('"status":"pending"');
+    expect(body).toContain('"status":"processing"');
+    expect(body).toContain('"status":"failed"');
+    expect(__getPayment(paymentId)?.status).toBe('failed');
+  });
+
+  it('replays missed events after reconnect with Last-Event-ID', async () => {
+    __transitionPaymentStatus(paymentId, 'processing');
+
+    const res = await request(app)
+      .get(`/payments/${paymentId}/status/stream`)
+      .set('x-user-id', userId)
+      .set('Last-Event-ID', '1')
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        const timer = setTimeout(() => {
+          response.destroy();
+          callback(null, body);
+        }, 200);
+        response.on('data', (chunk: Buffer) => {
+          body += chunk.toString('utf8');
+        });
+        response.on('error', () => {
+          clearTimeout(timer);
+          callback(null, body);
+        });
+      });
+
+    expect(res.status).toBe(200);
+    expect(String(res.body)).toContain('"status":"processing"');
+    expect(String(res.body)).not.toContain('"status":"pending"');
+  });
+});

--- a/routes-d/tests/payments.sse.test.ts
+++ b/routes-d/tests/payments.sse.test.ts
@@ -1,0 +1,215 @@
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import paymentsSseRouter, {
+  __resetPaymentsSse,
+  __seedPayment,
+  __transitionPaymentStatus,
+  __createSubscriberForTest,
+  __enqueueEventForSubscriber,
+  __CONNECTION_EVENT_BUFFER_CAPACITY,
+} from '../routes/payments.sse.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(paymentsSseRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+function parseSseEvents(raw: string): Array<{ id: string; event: string; data: Record<string, unknown> }> {
+  const events: Array<{ id: string; event: string; data: Record<string, unknown> }> = [];
+  const chunks = raw.split('\n\n').filter((block) => block.trim() && !block.startsWith(':'));
+  for (const block of chunks) {
+    const lines = block.split('\n');
+    let id = '';
+    let event = '';
+    let dataLine = '';
+    for (const line of lines) {
+      if (line.startsWith('id:')) id = line.slice(3).trim();
+      if (line.startsWith('event:')) event = line.slice(6).trim();
+      if (line.startsWith('data:')) dataLine = line.slice(5).trim();
+    }
+    if (dataLine) {
+      events.push({ id, event, data: JSON.parse(dataLine) as Record<string, unknown> });
+    }
+  }
+  return events;
+}
+
+const USER = 'user-pay-1';
+const PAYMENT_ID = 'pay-sse-1';
+const BASE_PAYMENT = {
+  id: PAYMENT_ID,
+  userId: USER,
+  status: 'pending' as const,
+  amount: 100,
+  currency: 'USDC',
+  createdAt: '2026-07-01T10:00:00.000Z',
+  updatedAt: '2026-07-01T10:00:00.000Z',
+};
+
+describe('GET /payments/:paymentId/status/stream', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetPaymentsSse();
+  });
+
+  it('streams initial payment status on connect', async () => {
+    __seedPayment(BASE_PAYMENT);
+
+    const res = await request(app)
+      .get(`/payments/${PAYMENT_ID}/status/stream`)
+      .set('x-user-id', USER)
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        response.on('data', (chunk: Buffer) => {
+          body += chunk.toString('utf8');
+          if (body.includes('"status":"pending"')) {
+            response.destroy();
+            callback(null, body);
+          }
+        });
+        response.on('error', (err: Error) => {
+          if ((err as NodeJS.ErrnoException).code === 'ECONNRESET') {
+            callback(null, body);
+            return;
+          }
+          callback(err, body);
+        });
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+
+    const events = parseSseEvents(String(res.body));
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0].event).toBe('status');
+    expect(events[0].data.status).toBe('pending');
+  });
+
+  it('emits status transitions to an active connection', async () => {
+    __seedPayment(BASE_PAYMENT);
+
+    let resolveBody: (body: string) => void;
+    const bodyPromise = new Promise<string>((resolve) => {
+      resolveBody = resolve;
+    });
+
+    const req = request(app)
+      .get(`/payments/${PAYMENT_ID}/status/stream`)
+      .set('x-user-id', USER)
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        response.on('data', (chunk: Buffer) => {
+          body += chunk.toString('utf8');
+          if (body.includes('"status":"processing"')) {
+            response.destroy();
+            resolveBody(body);
+            callback(null, body);
+          }
+        });
+        response.on('error', (err: Error) => {
+          if ((err as NodeJS.ErrnoException).code === 'ECONNRESET') {
+            resolveBody(body);
+            callback(null, body);
+            return;
+          }
+          callback(err, body);
+        });
+      });
+
+    const streamReq = req.end();
+
+    await new Promise((r) => setTimeout(r, 50));
+    __transitionPaymentStatus(PAYMENT_ID, 'processing');
+
+    const raw = await bodyPromise;
+    await streamReq;
+
+    const events = parseSseEvents(raw);
+    const statuses = events.map((e) => e.data.status);
+    expect(statuses).toContain('processing');
+  });
+
+  it('resumes from Last-Event-ID on reconnect', async () => {
+    __seedPayment(BASE_PAYMENT);
+    __transitionPaymentStatus(PAYMENT_ID, 'processing');
+    __transitionPaymentStatus(PAYMENT_ID, 'completed');
+
+    const res = await request(app)
+      .get(`/payments/${PAYMENT_ID}/status/stream`)
+      .set('x-user-id', USER)
+      .set('Last-Event-ID', '1')
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        const timer = setTimeout(() => {
+          response.destroy();
+          callback(null, body);
+        }, 150);
+        response.on('data', (chunk: Buffer) => {
+          body += chunk.toString('utf8');
+          if (body.includes('"status":"completed"')) {
+            clearTimeout(timer);
+            response.destroy();
+            callback(null, body);
+          }
+        });
+        response.on('error', () => {
+          clearTimeout(timer);
+          callback(null, body);
+        });
+      });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(String(res.body));
+    const statuses = events.map((e) => e.data.status);
+    expect(statuses).toContain('processing');
+    expect(statuses).toContain('completed');
+    for (const event of events) {
+      expect(Number.parseInt(event.id, 10)).toBeGreaterThan(1);
+    }
+  });
+
+  it('bounds per-connection buffer for slow consumers', () => {
+    const mockRes = {
+      write: () => false,
+    } as unknown as Response;
+
+    const subscriber = __createSubscriberForTest(PAYMENT_ID, mockRes);
+    const capacity = __CONNECTION_EVENT_BUFFER_CAPACITY;
+
+    for (let i = 0; i < capacity + 10; i += 1) {
+      __enqueueEventForSubscriber(subscriber, {
+        id: String(i + 1),
+        paymentId: PAYMENT_ID,
+        status: 'processing',
+        previousStatus: 'pending',
+        at: new Date().toISOString(),
+      });
+    }
+
+    expect(subscriber.pending.size).toBe(capacity);
+  });
+
+  it('returns 401 without x-user-id', async () => {
+    __seedPayment(BASE_PAYMENT);
+
+    const res = await request(app).get(`/payments/${PAYMENT_ID}/status/stream`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown payment', async () => {
+    const res = await request(app)
+      .get(`/payments/missing/status/stream`)
+      .set('x-user-id', USER);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/routes-d/tests/unit/boundedEventBuffer.test.ts
+++ b/routes-d/tests/unit/boundedEventBuffer.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Unit tests for boundedEventBuffer.ts
+ */
+
+import { BoundedEventBuffer } from '../../lib/boundedEventBuffer.js';
+
+describe('BoundedEventBuffer', () => {
+  it('drops oldest entries when capacity is exceeded', () => {
+    const buffer = new BoundedEventBuffer<number>(3);
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+    buffer.push(4);
+
+    expect(buffer.toArray()).toEqual([2, 3, 4]);
+  });
+
+  it('rejects invalid capacity', () => {
+    expect(() => new BoundedEventBuffer(0)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #397

## Summary
- Create server-sent events for payment status in routes-d

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths