### PR TITLE
feat(lancepay): add annual tax year summary route (GET /lancepay/tax-forms/year-summary)

### DIFF
--- a/routes-d/routes/lancepay.tax.yearSummary.ts
+++ b/routes-d/routes/lancepay.tax.yearSummary.ts
@@ -1,0 +1,267 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PayoutStatus = "pending" | "processing" | "completed" | "failed";
+
+type PayoutRecord = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  amount: number;
+  currency: string;
+  status: PayoutStatus;
+  /** Tax withheld from this payout (in the payout's currency). */
+  withholding?: number;
+  /** Net amount after withholdings (in the payout's currency). */
+  netAmount?: number;
+  submittedAt: string;
+};
+
+type CurrencyConversion = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  fromCurrency: string;
+  toCurrency: string;
+  fromAmount: number;
+  toAmount: number;
+  rate: number;
+  convertedAt: string;
+};
+
+type CurrencyBreakdown = {
+  grossAmount: number;
+  netAmount: number;
+  withholding: number;
+  count: number;
+};
+
+type YearSummaryResponse = {
+  year: number;
+  workspaceId: string;
+  contractorId: string;
+  summary: {
+    totalGrossAmount: number;
+    totalWithholdings: number;
+    totalNetAmount: number;
+    payoutCount: number;
+    currencies: Record<string, CurrencyBreakdown>;
+    currencyConversions: Array<{
+      fromCurrency: string;
+      toCurrency: string;
+      fromAmount: number;
+      toAmount: number;
+      rate: number;
+      date: string;
+    }>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// In-memory stores
+// ---------------------------------------------------------------------------
+
+const payouts = new Map<string, PayoutRecord>();
+const conversions = new Map<string, CurrencyConversion>();
+
+// ---------------------------------------------------------------------------
+// Route: GET /lancepay/tax-forms/year-summary
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /lancepay/tax-forms/year-summary
+ *
+ * Return an annual tax summary for a contractor within a LancePay workspace.
+ * Aggregates payouts, withholdings, and currency conversions per year.
+ *
+ * Query parameters:
+ *   workspaceId   (required) – owning LancePay workspace
+ *   contractorId  (required) – target contractor
+ *   year          (optional) – fiscal year (defaults to current year)
+ *
+ * Auth:
+ *   The caller must either
+ *   (a) provide x-workspace-id matching the queried workspace, or
+ *   (b) provide x-caller-id matching the queried contractor.
+ *
+ * Responses:
+ *   200 – Year summary returned
+ *   400 – Missing or invalid query parameters
+ *   401 – Missing auth headers
+ *   403 – Caller not authorised for this workspace/contractor
+ */
+router.get(
+  "/lancepay/tax-forms/year-summary",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // --- Extract query parameters ---
+      const workspaceId = req.query.workspaceId as string | undefined;
+      const contractorId = req.query.contractorId as string | undefined;
+      const yearParam = req.query.year as string | undefined;
+
+      if (!workspaceId || typeof workspaceId !== "string" || !workspaceId.trim()) {
+        sendError(res, "MISSING_WORKSPACE_ID", "workspaceId query parameter is required", 400);
+        return;
+      }
+
+      if (!contractorId || typeof contractorId !== "string" || !contractorId.trim()) {
+        sendError(res, "MISSING_CONTRACTOR_ID", "contractorId query parameter is required", 400);
+        return;
+      }
+
+      const year = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+      if (isNaN(year) || year < 1900 || year > 2100) {
+        sendError(res, "INVALID_YEAR", "year must be a valid 4-digit year between 1900 and 2100", 400);
+        return;
+      }
+
+      // --- Authorisation ---
+      const callerWorkspaceId = req.headers["x-workspace-id"] as string | undefined;
+      const callerId = req.headers["x-caller-id"] as string | undefined;
+
+      // Missing auth must be checked before matching so we return 401, not 403
+      if (!callerWorkspaceId?.trim() && !callerId?.trim()) {
+        sendError(
+          res,
+          "MISSING_AUTH",
+          "x-workspace-id or x-caller-id header is required",
+          401,
+        );
+        return;
+      }
+
+      const isWorkspaceCaller = callerWorkspaceId?.trim() === workspaceId.trim();
+      const isContractorCaller = callerId?.trim() === contractorId.trim();
+
+      if (!isWorkspaceCaller && !isContractorCaller) {
+        sendError(
+          res,
+          "FORBIDDEN",
+          "Access denied: caller must be the workspace owner or the contractor",
+          403,
+        );
+        return;
+      }
+
+      const wsId = workspaceId.trim();
+      const conId = contractorId.trim();
+
+      // --- Compute year boundaries ---
+      const yearStart = new Date(`${year}-01-01T00:00:00.000Z`);
+      const yearEnd = new Date(`${year + 1}-01-01T00:00:00.000Z`);
+
+      // --- Aggregate payouts ---
+      const yearPayouts = Array.from(payouts.values()).filter((p) => {
+        if (p.workspaceId !== wsId) return false;
+        if (p.contractorId !== conId) return false;
+        if (p.status !== "completed") return false;
+        const ts = new Date(p.submittedAt).getTime();
+        return ts >= yearStart.getTime() && ts < yearEnd.getTime();
+      });
+
+      let totalGrossAmount = 0;
+      let totalWithholdings = 0;
+      let totalNetAmount = 0;
+      const currencies: Record<string, CurrencyBreakdown> = {};
+
+      for (const payout of yearPayouts) {
+        const cur = payout.currency;
+        const withholding = payout.withholding ?? 0;
+        const net = payout.netAmount ?? (payout.amount - withholding);
+
+        totalGrossAmount += payout.amount;
+        totalWithholdings += withholding;
+        totalNetAmount += net;
+
+        if (!currencies[cur]) {
+          currencies[cur] = { grossAmount: 0, netAmount: 0, withholding: 0, count: 0 };
+        }
+        currencies[cur].grossAmount += payout.amount;
+        currencies[cur].netAmount += net;
+        currencies[cur].withholding += withholding;
+        currencies[cur].count += 1;
+      }
+
+      // --- Aggregate currency conversions ---
+      const yearConversions = Array.from(conversions.values()).filter((c) => {
+        if (c.workspaceId !== wsId) return false;
+        if (c.contractorId !== conId) return false;
+        const ts = new Date(c.convertedAt).getTime();
+        return ts >= yearStart.getTime() && ts < yearEnd.getTime();
+      });
+
+      const conversionRecords = yearConversions.map((c) => ({
+        fromCurrency: c.fromCurrency,
+        toCurrency: c.toCurrency,
+        fromAmount: c.fromAmount,
+        toAmount: c.toAmount,
+        rate: c.rate,
+        date: c.convertedAt,
+      }));
+
+      // Round summary totals to 2 decimal places
+      const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+      const response: YearSummaryResponse = {
+        year,
+        workspaceId: wsId,
+        contractorId: conId,
+        summary: {
+          totalGrossAmount: round2(totalGrossAmount),
+          totalWithholdings: round2(totalWithholdings),
+          totalNetAmount: round2(totalNetAmount),
+          payoutCount: yearPayouts.length,
+          currencies: Object.fromEntries(
+            Object.entries(currencies).map(([cur, breakdown]) => [
+              cur,
+              {
+                grossAmount: round2(breakdown.grossAmount),
+                netAmount: round2(breakdown.netAmount),
+                withholding: round2(breakdown.withholding),
+                count: breakdown.count,
+              },
+            ]),
+          ),
+          currencyConversions: conversionRecords,
+        },
+      };
+
+      return res.status(200).json({ success: true, data: response });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export function __seedPayout(p: PayoutRecord): void {
+  payouts.set(p.id, { ...p });
+}
+
+export function __seedConversion(c: CurrencyConversion): void {
+  conversions.set(c.id, { ...c });
+}
+
+export function __resetData(): void {
+  payouts.clear();
+  conversions.clear();
+}
+
+export function __getPayouts(): Map<string, PayoutRecord> {
+  return payouts;
+}
+
+export function __getConversions(): Map<string, CurrencyConversion> {
+  return conversions;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.tax.yearSummary.test.ts
+++ b/routes-d/tests/lancepay.tax.yearSummary.test.ts
@@ -1,0 +1,321 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedPayout,
+  __seedConversion,
+  __resetData,
+} from "../routes/lancepay.tax.yearSummary.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const WS_ID = "ws-acmecorp";
+const CON_ID = "con-jane-doe";
+
+const USD_PAYOUT = {
+  id: "pay-usd-1",
+  workspaceId: WS_ID,
+  contractorId: CON_ID,
+  amount: 5000,
+  currency: "USD",
+  status: "completed" as const,
+  withholding: 750,
+  netAmount: 4250,
+  submittedAt: "2026-03-15T10:00:00Z",
+};
+
+const EUR_PAYOUT = {
+  id: "pay-eur-1",
+  workspaceId: WS_ID,
+  contractorId: CON_ID,
+  amount: 3000,
+  currency: "EUR",
+  status: "completed" as const,
+  withholding: 450,
+  netAmount: 2550,
+  submittedAt: "2026-06-20T14:30:00Z",
+};
+
+const USD_PAYOUT_2 = {
+  id: "pay-usd-2",
+  workspaceId: WS_ID,
+  contractorId: CON_ID,
+  amount: 2500,
+  currency: "USD",
+  status: "completed" as const,
+  withholding: 375,
+  netAmount: 2125,
+  submittedAt: "2026-09-01T08:00:00Z",
+};
+
+const OTHER_WS_PAYOUT = {
+  id: "pay-other-ws",
+  workspaceId: "ws-other",
+  contractorId: CON_ID,
+  amount: 1000,
+  currency: "USD",
+  status: "completed" as const,
+  submittedAt: "2026-04-01T12:00:00Z",
+};
+
+const PENDING_PAYOUT = {
+  id: "pay-pending",
+  workspaceId: WS_ID,
+  contractorId: CON_ID,
+  amount: 2000,
+  currency: "USD",
+  status: "pending" as const,
+  submittedAt: "2026-11-01T12:00:00Z",
+};
+
+const DIFFERENT_YEAR_PAYOUT = {
+  id: "pay-2025",
+  workspaceId: WS_ID,
+  contractorId: CON_ID,
+  amount: 1000,
+  currency: "USD",
+  status: "completed" as const,
+  submittedAt: "2025-12-31T23:59:59Z",
+};
+
+const EUR_CONVERSION = {
+  id: "conv-eur-usd-1",
+  workspaceId: WS_ID,
+  contractorId: CON_ID,
+  fromCurrency: "EUR",
+  toCurrency: "USD",
+  fromAmount: 3000,
+  toAmount: 3255,
+  rate: 1.085,
+  convertedAt: "2026-06-20T15:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /lancepay/tax-forms/year-summary", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetData();
+  });
+
+  // --- Happy path: full year with multi-currency payouts ---
+
+  it("returns aggregated year summary for a workspace caller", async () => {
+    __seedPayout(USD_PAYOUT);
+    __seedPayout(EUR_PAYOUT);
+    __seedPayout(USD_PAYOUT_2);
+    __seedConversion(EUR_CONVERSION);
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const data = res.body.data;
+    expect(data.year).toBe(2026);
+    expect(data.workspaceId).toBe(WS_ID);
+    expect(data.contractorId).toBe(CON_ID);
+
+    // Total aggregations
+    expect(data.summary.totalGrossAmount).toBe(5000 + 3000 + 2500); // 10500
+    expect(data.summary.totalWithholdings).toBe(750 + 450 + 375); // 1575
+    expect(data.summary.totalNetAmount).toBe(4250 + 2550 + 2125); // 8925
+    expect(data.summary.payoutCount).toBe(3);
+
+    // Currency breakdowns
+    expect(data.summary.currencies).toEqual({
+      USD: {
+        grossAmount: 7500,
+        netAmount: 6375,
+        withholding: 1125,
+        count: 2,
+      },
+      EUR: {
+        grossAmount: 3000,
+        netAmount: 2550,
+        withholding: 450,
+        count: 1,
+      },
+    });
+
+    // Currency conversions
+    expect(data.summary.currencyConversions).toHaveLength(1);
+    expect(data.summary.currencyConversions[0]).toEqual({
+      fromCurrency: "EUR",
+      toCurrency: "USD",
+      fromAmount: 3000,
+      toAmount: 3255,
+      rate: 1.085,
+      date: "2026-06-20T15:00:00Z",
+    });
+  });
+
+  // --- Contractor caller (x-caller-id) ---
+
+  it("allows the contractor to access their own summary", async () => {
+    __seedPayout(USD_PAYOUT);
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`)
+      .set("x-caller-id", CON_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.summary.payoutCount).toBe(1);
+    expect(res.body.data.summary.totalGrossAmount).toBe(5000);
+  });
+
+  // --- Empty year (no payouts) ---
+
+  it("returns empty summary when the year has no payouts", async () => {
+    __seedPayout(USD_PAYOUT); // 2026
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2027`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.summary.payoutCount).toBe(0);
+    expect(res.body.data.summary.totalGrossAmount).toBe(0);
+    expect(res.body.data.summary.totalWithholdings).toBe(0);
+    expect(res.body.data.summary.totalNetAmount).toBe(0);
+    expect(res.body.data.summary.currencies).toEqual({});
+    expect(res.body.data.summary.currencyConversions).toEqual([]);
+    expect(res.body.data.year).toBe(2027);
+  });
+
+  // --- Unauthorised caller ---
+
+  it("returns 403 when the caller is not the workspace or contractor", async () => {
+    __seedPayout(USD_PAYOUT);
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`)
+      .set("x-workspace-id", "ws-evil-corp");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 when no auth header is provided", async () => {
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("MISSING_AUTH");
+  });
+
+  // --- Missing query parameters ---
+
+  it("returns 400 when workspaceId is missing", async () => {
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?contractorId=${CON_ID}&year=2026`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_WORKSPACE_ID");
+  });
+
+  it("returns 400 when contractorId is missing", async () => {
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&year=2026`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_CONTRACTOR_ID");
+  });
+
+  it("returns 400 when year is invalid", async () => {
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=abcd`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_YEAR");
+  });
+
+  // --- Year defaults to current year ---
+
+  it("defaults to the current year when year is omitted", async () => {
+    __seedPayout(USD_PAYOUT); // 2026
+    __seedPayout(DIFFERENT_YEAR_PAYOUT); // 2025
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(200);
+    // The current date for this test environment is 2026-07-25 per system info
+    expect(res.body.data.year).toBe(2026);
+    expect(res.body.data.summary.payoutCount).toBe(1);
+    expect(res.body.data.summary.totalGrossAmount).toBe(5000);
+  });
+
+  // --- Only completed payouts are considered ---
+
+  it("only includes completed payouts in the summary", async () => {
+    __seedPayout(USD_PAYOUT);     // completed
+    __seedPayout(PENDING_PAYOUT); // pending
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.summary.payoutCount).toBe(1);
+    expect(res.body.data.summary.totalGrossAmount).toBe(5000);
+  });
+
+  // --- Cross-workspace payouts are excluded ---
+
+  it("excludes payouts from other workspaces", async () => {
+    __seedPayout(USD_PAYOUT);       // WS_ID
+    __seedPayout(OTHER_WS_PAYOUT);  // ws-other
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.summary.payoutCount).toBe(1);
+    expect(res.body.data.summary.totalGrossAmount).toBe(5000);
+  });
+
+  // --- Payouts without explicit withholdings/net use defaults ---
+
+  it("handles payouts without withholding fields", async () => {
+    __seedPayout({
+      id: "pay-no-withhold",
+      workspaceId: WS_ID,
+      contractorId: CON_ID,
+      amount: 1000,
+      currency: "USD",
+      status: "completed",
+      submittedAt: "2026-05-01T12:00:00Z",
+    });
+
+    const res = await request(app)
+      .get(`/lancepay/tax-forms/year-summary?workspaceId=${WS_ID}&contractorId=${CON_ID}&year=2026`)
+      .set("x-workspace-id", WS_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.summary.totalGrossAmount).toBe(1000);
+    expect(res.body.data.summary.totalWithholdings).toBe(0);
+    expect(res.body.data.summary.totalNetAmount).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new route `GET /lancepay/tax-forms/year-summary` that returns an aggregated annual tax summary for a contractor within a LancePay workspace.

## Changes

### New files

- **`routes-d/routes/lancepay.tax.yearSummary.ts`** — Route handler that:
  - Accepts `workspaceId`, `contractorId`, and optional `year` query parameters (defaults to current year)
  - Aggregates payouts (gross, withholdings, net) grouped by currency
  - Aggregates currency conversions for the year
  - Restricts access to the owning workspace (via `x-workspace-id` header) or the contractor party (via `x-caller-id` header)
  - Returns 401 for missing auth headers, 403 for unauthorized callers, 400 for invalid params
  - Exposes `__seedPayout`, `__seedConversion`, `__resetData`, `__getPayouts`, `__getConversions` test helpers

- **`routes-d/tests/lancepay.tax.yearSummary.test.ts`** — 12 test cases covering:
  - Happy path with multi-currency payouts and currency conversions
  - Access by contractor via `x-caller-id`
  - Empty year (no payouts) — returns zeroed summary
  - Cross-workspace exclusion
  - Only completed payouts included
  - Payouts without withholding fields
  - Unauthorized caller (403)
  - Missing auth headers (401)
  - Missing/invalid query parameters (400)
  - Year defaults to current year when omitted

## Related

Closes #595

## Testing

All 12 tests pass with `NODE_OPTIONS="--experimental-vm-modules"`:
```
Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
```
