### PR TITLE
Add LancePay timesheet rejection route with notification dispatching

### DIFF
--- a/routes-d/routes/lancepay.timesheets.reject.ts
+++ b/routes-d/routes/lancepay.timesheets.reject.ts
@@ -1,0 +1,199 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+const VALID_REASON_CODES = new Set([
+  "incomplete_hours",
+  "missing_project",
+  "unapproved_overtime",
+  "incorrect_dates",
+  "duplicate_submission",
+  "quality_issue",
+  "policy_violation",
+  "other",
+]);
+
+type TimesheetStatus = "pending" | "approved" | "rejected" | "paid";
+
+type Timesheet = {
+  id: string;
+  contractorId: string;
+  workspaceId: string;
+  status: TimesheetStatus;
+  hours: number;
+  projectId: string;
+  weekStart: string;
+  submittedAt: string;
+};
+
+type RejectBody = {
+  reasonCode: string;
+  comment: string;
+};
+
+type RejectionNotification = {
+  contractorId: string;
+  timesheetId: string;
+  reasonCode: string;
+  comment: string;
+  rejectedBy: string;
+  rejectedAt: string;
+};
+
+// In-memory stores
+const timesheets = new Map<string, Timesheet>();
+const sentNotifications: RejectionNotification[] = [];
+
+/**
+ * Dispatch a rejection notification to the contractor
+ */
+function dispatchRejectionNotification(
+  contractorId: string,
+  timesheetId: string,
+  reasonCode: string,
+  comment: string,
+  rejectedBy: string,
+): void {
+  const notification: RejectionNotification = {
+    contractorId,
+    timesheetId,
+    reasonCode,
+    comment,
+    rejectedBy,
+    rejectedAt: new Date().toISOString(),
+  };
+  sentNotifications.push(notification);
+}
+
+/**
+ * POST /lancepay/timesheets/:id/reject
+ * Reject a submitted LancePay timesheet with a structured reason code and free-text comment.
+ * Notifies the contractor via notification dispatchers.
+ */
+router.post(
+  "/lancepay/timesheets/:id/reject",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const timesheetId = req.params.id?.trim();
+      if (!timesheetId) {
+        sendError(res, "INVALID_TIMESHEET_ID", "timesheetId is required", 400);
+        return;
+      }
+
+      const adminId = req.headers["x-admin-id"] as string | undefined;
+      if (!adminId || typeof adminId !== "string" || !adminId.trim()) {
+        sendError(
+          res,
+          "UNAUTHORIZED",
+          "workspace-admin identity required",
+          403,
+        );
+        return;
+      }
+
+      const body = req.body as RejectBody;
+
+      if (!body.reasonCode || typeof body.reasonCode !== "string") {
+        sendError(res, "MISSING_REASON_CODE", "reasonCode is required", 400);
+        return;
+      }
+
+      const reasonCode = body.reasonCode.trim().toLowerCase();
+      if (!VALID_REASON_CODES.has(reasonCode)) {
+        sendError(
+          res,
+          "INVALID_REASON_CODE",
+          `reasonCode must be one of: ${[...VALID_REASON_CODES].join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      if (!body.comment || typeof body.comment !== "string") {
+        sendError(res, "MISSING_COMMENT", "comment is required", 400);
+        return;
+      }
+
+      const comment = body.comment.trim();
+      if (comment.length === 0) {
+        sendError(res, "INVALID_COMMENT", "comment cannot be empty", 400);
+        return;
+      }
+
+      if (comment.length > 1000) {
+        sendError(
+          res,
+          "INVALID_COMMENT",
+          "comment must be 1000 characters or less",
+          400,
+        );
+        return;
+      }
+
+      const timesheet = timesheets.get(timesheetId);
+      if (!timesheet) {
+        sendError(res, "NOT_FOUND", "Timesheet not found", 404);
+        return;
+      }
+
+      if (timesheet.status !== "pending") {
+        sendError(
+          res,
+          "INVALID_STATUS",
+          "Only pending timesheets can be rejected",
+          400,
+        );
+        return;
+      }
+
+      // Update timesheet status
+      timesheet.status = "rejected";
+
+      // Dispatch notification to contractor
+      dispatchRejectionNotification(
+        timesheet.contractorId,
+        timesheetId,
+        reasonCode,
+        comment,
+        adminId.trim(),
+      );
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          timesheetId,
+          status: timesheet.status,
+          reasonCode,
+          comment,
+          rejectedAt: new Date().toISOString(),
+        },
+        message: "Timesheet rejected and contractor notified",
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedTimesheet(t: Timesheet): void {
+  timesheets.set(t.id, { ...t });
+}
+
+export function __getTimesheet(id: string): Timesheet | undefined {
+  return timesheets.get(id);
+}
+
+export function __resetTimesheets(): void {
+  timesheets.clear();
+}
+
+export function __getRejectionNotifications(): RejectionNotification[] {
+  return sentNotifications;
+}
+
+export function __resetRejectionNotifications(): void {
+  sentNotifications.length = 0;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.timesheets.reject.test.ts
+++ b/routes-d/tests/lancepay.timesheets.reject.test.ts
@@ -1,0 +1,288 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedTimesheet,
+  __getTimesheet,
+  __resetTimesheets,
+  __getRejectionNotifications,
+  __resetRejectionNotifications,
+} from "../routes/lancepay.timesheets.reject.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/timesheets/:id/reject", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetTimesheets();
+    __resetRejectionNotifications();
+  });
+
+  it("rejects a pending timesheet with valid reason code and comment", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "incomplete_hours",
+        comment: "Missing hours for Friday",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.timesheetId).toBe("ts1");
+    expect(res.body.data.status).toBe("rejected");
+    expect(res.body.data.reasonCode).toBe("incomplete_hours");
+    expect(res.body.data.comment).toBe("Missing hours for Friday");
+    expect(res.body.message).toBe("Timesheet rejected and contractor notified");
+
+    const timesheet = __getTimesheet("ts1");
+    expect(timesheet?.status).toBe("rejected");
+
+    const notifications = __getRejectionNotifications();
+    expect(notifications.length).toBe(1);
+    expect(notifications[0].contractorId).toBe("con1");
+    expect(notifications[0].timesheetId).toBe("ts1");
+    expect(notifications[0].reasonCode).toBe("incomplete_hours");
+    expect(notifications[0].comment).toBe("Missing hours for Friday");
+    expect(notifications[0].rejectedBy).toBe("admin1");
+  });
+
+  it("rejects request when reasonCode is missing", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        comment: "Missing hours for Friday",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_REASON_CODE");
+  });
+
+  it("rejects request when comment is missing", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "incomplete_hours",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_COMMENT");
+  });
+
+  it("rejects request when reasonCode is invalid", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "invalid_reason",
+        comment: "Missing hours for Friday",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_REASON_CODE");
+  });
+
+  it("rejects request when comment is empty", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "incomplete_hours",
+        comment: "   ",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_COMMENT");
+  });
+
+  it("rejects request when comment exceeds 1000 characters", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const longComment = "a".repeat(1001);
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "incomplete_hours",
+        comment: longComment,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_COMMENT");
+  });
+
+  it("rejects unauthorized caller (no adminId)", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "pending",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .send({
+        reasonCode: "incomplete_hours",
+        comment: "Missing hours for Friday",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects request when timesheet is not found", async () => {
+    const res = await request(app)
+      .post("/lancepay/timesheets/nonexistent/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "incomplete_hours",
+        comment: "Missing hours for Friday",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("rejects request when timesheet is not in pending status", async () => {
+    __seedTimesheet({
+      id: "ts1",
+      contractorId: "con1",
+      workspaceId: "ws1",
+      status: "approved",
+      hours: 40,
+      projectId: "proj1",
+      weekStart: "2024-01-01",
+      submittedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/lancepay/timesheets/ts1/reject")
+      .set("x-admin-id", "admin1")
+      .send({
+        reasonCode: "incomplete_hours",
+        comment: "Missing hours for Friday",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_STATUS");
+  });
+
+  it("accepts all valid reason codes", async () => {
+    const validReasonCodes = [
+      "incomplete_hours",
+      "missing_project",
+      "unapproved_overtime",
+      "incorrect_dates",
+      "duplicate_submission",
+      "quality_issue",
+      "policy_violation",
+      "other",
+    ];
+
+    for (const reasonCode of validReasonCodes) {
+      __resetTimesheets();
+      __resetRejectionNotifications();
+
+      __seedTimesheet({
+        id: "ts1",
+        contractorId: "con1",
+        workspaceId: "ws1",
+        status: "pending",
+        hours: 40,
+        projectId: "proj1",
+        weekStart: "2024-01-01",
+        submittedAt: new Date().toISOString(),
+      });
+
+      const res = await request(app)
+        .post("/lancepay/timesheets/ts1/reject")
+        .set("x-admin-id", "admin1")
+        .send({
+          reasonCode,
+          comment: "Test comment",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.reasonCode).toBe(reasonCode);
+    }
+  });
+});


### PR DESCRIPTION
- Add POST /lancepay/timesheets/:id/reject endpoint
- Require structured reason code and free-text comment
- Validate reason codes against allowed values
- Dispatch rejection notifications to contractors
- Add comprehensive test coverage for reject, missing reason, and unauthorized scenarios


closes   #587