### PR TITLE
feat(routes-d): add velocity-based fraud scoring middleware

### DIFF
--- a/routes-d/docs/velocityScore.md
+++ b/routes-d/docs/velocityScore.md
@@ -1,0 +1,181 @@
+# Velocity-Based Fraud Scoring Middleware
+
+## Overview
+
+The `velocityScoreMiddleware` tracks request velocity per authenticated user and per IP address using configurable sliding windows. It computes a fraud/velocity score that considers request frequency, burst behavior, and natural window decay. Optionally, it blocks requests when the score exceeds a configurable threshold.
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│   Request    │────▶│  velocityScore   │────▶│  Route Handler  │
+│              │     │   Middleware      │     │  (req.velocity  │
+│              │     │                  │     │   Score)        │
+└──────────────┘     └──────────────────┘     └─────────────────┘
+       │                      │
+       ▼                      ▼
+┌──────────────┐     ┌──────────────────┐
+│  User Bucket │     │  Periodic        │
+│  IP Bucket   │     │  Cleanup         │
+│  (Sliding    │     │  (expired window │
+│   Windows)   │     │   eviction)      │
+└──────────────┘     └──────────────────┘
+```
+
+## Sliding Window Algorithm
+
+Each request updates two independent sliding-window buckets:
+
+- **User bucket**: keyed by `user:<userId>`
+- **IP bucket**: keyed by `ip:<address>`
+
+### Bucket Structure
+
+Each bucket stores a sorted array of epoch-millisecond timestamps for every request received within the current window.
+
+### Scoring Formula
+
+For each bucket, the score is calculated as:
+
+1. **Prune expired timestamps**: Remove any timestamp older than `now - windowSizeMs`.
+2. **Count**: `count = timestamps.length`
+3. **Burst count**: Count timestamps within the burst sub-window (`now - burstWindowMs`).
+4. **Burst ratio**: `burstRatio = burstCount / count`
+5. **Score**: `score = count × (1 + burstRatio × (burstMultiplier − 1))`
+
+When `burstRatio = 0` (no burst), the score equals the raw count. When `burstRatio = 1` (all traffic in burst window), the score is `count × burstMultiplier`.
+
+### Combined Score
+
+The final score attached to the request is `max(userScore, ipScore)`. This ensures neither dimension can be hidden by the other.
+
+## Configuration Options
+
+All options can be set via the middleware constructor and/or environment variables.
+
+| Option | Env Variable | Default | Description |
+|--------|-------------|---------|-------------|
+| `windowSizeMs` | `VELOCITY_WINDOW_MS` | `60000` (1 min) | Sliding window duration |
+| `burstWindowMs` | `VELOCITY_BURST_WINDOW_MS` | `5000` (5 s) | Burst detection sub-window |
+| `burstMultiplier` | `VELOCITY_BURST_MULTIPLIER` | `2.0` | Amplification for burst traffic |
+| `blockThreshold` | `VELOCITY_BLOCK_THRESHOLD` | `0` (disabled) | Score at which to auto-block. `0` disables. |
+| `cleanupIntervalMs` | `VELOCITY_CLEANUP_INTERVAL_MS` | `60000` (1 min) | Interval between cleanup sweeps |
+| `maxTrackedKeys` | `VELOCITY_MAX_TRACKED_KEYS` | `100000` | Max distinct user+IP keys before LRU eviction |
+
+## Request Context Fields
+
+The middleware augments `Request` with a `velocityScore` property:
+
+```typescript
+interface VelocityScoreResult {
+  score: number;        // Combined velocity score
+  userCount: number;    // Requests from this user in the window
+  ipCount: number;      // Requests from this IP in the window
+  blocked?: boolean;    // Present only when auto-blocked
+  threshold?: number;   // Present only when auto-blocked
+  computedAt: string;   // ISO-8601 timestamp
+}
+```
+
+Downstream handlers can read `req.velocityScore` to make decisions (e.g., step-up authentication, CAPTCHA, logging).
+
+## Blocking Behavior
+
+When `blockThreshold > 0` and the combined score reaches or exceeds it:
+
+- The middleware responds with **HTTP 429 Too Many Requests**.
+- The response body includes the error code `RATE_LIMITED` and the full `VelocityScoreResult`.
+- Subsequent handlers are **not** called.
+
+When `blockThreshold` is `0`, blocking is completely disabled and all requests pass through.
+
+## Memory Management
+
+- **Periodic cleanup**: A `setInterval` runs every `cleanupIntervalMs` to remove expired timestamps and empty buckets.
+- **LRU eviction**: When the number of tracked keys exceeds `maxTrackedKeys`, the least-recently-accessed buckets are evicted.
+- **Unref'd timer**: The cleanup timer is `.unref()`'d so it does not prevent Node.js from exiting.
+
+## Example Integration
+
+### Basic Usage
+
+```typescript
+import express from 'express';
+import { velocityScoreMiddleware } from './middleware/velocityScore.js';
+
+const app = express();
+
+// Apply velocity scoring globally
+app.use(velocityScoreMiddleware({ blockThreshold: 100 }));
+
+app.get('/api/data', (req, res) => {
+  console.log('Velocity score:', req.velocityScore?.score);
+  res.json({ ok: true });
+});
+
+app.listen(3000);
+```
+
+### Route-Specific Configuration
+
+```typescript
+import { velocityScoreMiddleware } from './middleware/velocityScore.js';
+
+// Stricter threshold for sensitive endpoints
+const strictVelocity = velocityScoreMiddleware({
+  blockThreshold: 30,
+  burstMultiplier: 3.0,
+  windowSizeMs: 30_000, // 30-second window
+});
+
+app.post('/api/withdraw', strictVelocity, withdrawHandler);
+```
+
+### Downstream Velocity-Based Decisions
+
+```typescript
+app.get('/api/data', velocityScoreMiddleware({}), (req, res) => {
+  const vs = req.velocityScore;
+  if (vs && vs.score > 50) {
+    // Require CAPTCHA or step-up auth
+    return res.status(403).json({ error: { code: 'CAPTCHA_REQUIRED' } });
+  }
+  res.json({ data: 'ok' });
+});
+```
+
+### Environment-Driven Configuration
+
+```bash
+# .env
+VELOCITY_WINDOW_MS=30000
+VELOCITY_BLOCK_THRESHOLD=80
+VELOCITY_BURST_MULTIPLIER=2.5
+```
+
+```typescript
+// Middleware picks up env vars automatically
+app.use(velocityScoreMiddleware());
+```
+
+## Testing
+
+```bash
+# Run velocity score tests only
+npx jest routes-d/tests/velocityScore.test.ts
+
+# Run all routes-d tests
+npx jest routes-d/tests/
+```
+
+## Test Helpers
+
+The module exports test-only utilities (prefixed with `__`):
+
+| Helper | Purpose |
+|--------|---------|
+| `__resetBuckets()` | Clear all internal state between tests |
+| `__getBuckets()` | Inspect raw bucket data for assertions |
+| `__getDefaultConfig()` | Read the frozen default configuration |
+| `runCleanup(config?)` | Manually trigger a cleanup sweep |
+| `stopCleanup()` | Stop the periodic cleanup interval |

--- a/routes-d/middleware/velocityScore.ts
+++ b/routes-d/middleware/velocityScore.ts
@@ -1,0 +1,412 @@
+/**
+ * Velocity-Based Fraud Scoring Middleware
+ *
+ * Tracks request velocity per authenticated user and per IP address using
+ * configurable sliding windows. Computes a fraud/velocity score that
+ * considers request frequency, burst behavior, and natural window decay.
+ * Optionally blocks requests when the score exceeds a configurable threshold.
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Configuration for the velocity scoring middleware. */
+export interface VelocityConfig {
+  /** Sliding window duration in milliseconds. Default: 60_000 (1 minute). */
+  windowSizeMs: number;
+  /** Short burst detection sub-window in milliseconds. Default: 5_000 (5 s). */
+  burstWindowMs: number;
+  /** Multiplier applied to the burst ratio to amplify burst-based scores. */
+  burstMultiplier: number;
+  /**
+   * Score threshold at or above which requests are automatically blocked.
+   * Set to 0 to disable automatic blocking. Default: 0 (disabled).
+   */
+  blockThreshold: number;
+  /**
+   * Interval in milliseconds between cleanup sweeps that remove expired
+   * timestamp entries and empty key buckets. Default: 60_000 (1 minute).
+   */
+  cleanupIntervalMs: number;
+  /**
+   * Maximum number of distinct keys (user + IP combinations) tracked
+   * simultaneously. When exceeded the oldest inactive bucket is evicted.
+   * Default: 100_000.
+   */
+  maxTrackedKeys: number;
+}
+
+/**
+ * Result attached to every request that passes through the middleware.
+ * Available on `req.velocityScore` for downstream handlers.
+ */
+export interface VelocityScoreResult {
+  /** Computed velocity score for this request. */
+  score: number;
+  /** Number of requests from this user within the sliding window. */
+  userCount: number;
+  /** Number of requests from this IP within the sliding window. */
+  ipCount: number;
+  /** Whether the request was auto-blocked (only present when blocked). */
+  blocked?: boolean;
+  /** The threshold that was exceeded (only present when blocked). */
+  threshold?: number;
+  /** Timestamp of when the score was computed. */
+  computedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Default configuration (overridable via env vars)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONFIG: VelocityConfig = {
+  windowSizeMs: parseInt(process.env.VELOCITY_WINDOW_MS ?? '60000', 10),
+  burstWindowMs: parseInt(process.env.VELOCITY_BURST_WINDOW_MS ?? '5000', 10),
+  burstMultiplier: parseFloat(process.env.VELOCITY_BURST_MULTIPLIER ?? '2.0'),
+  blockThreshold: parseInt(process.env.VELOCITY_BLOCK_THRESHOLD ?? '0', 10),
+  cleanupIntervalMs: parseInt(process.env.VELOCITY_CLEANUP_INTERVAL_MS ?? '60000', 10),
+  maxTrackedKeys: parseInt(process.env.VELOCITY_MAX_TRACKED_KEYS ?? '100000', 10),
+};
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+/** Per-key sliding-window buckets. Key format: "user:<id>" or "ip:<addr>". */
+const buckets = new Map<string, number[]>();
+/** Last-access time per key, used for eviction when maxTrackedKeys is hit. */
+const lastAccess = new Map<string, number>();
+/** Cleanup timer reference so we can tear down in tests. */
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+/** Whether cleanup is currently running (prevents overlapping sweeps). */
+let cleaning = false;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a stable, deduplicated key for a user bucket.
+ * Returns `null` when no user identifier can be extracted.
+ */
+function getUserKey(req: Request): string | null {
+  // Try common locations for a user identifier
+  const userId =
+    (req.body as Record<string, unknown> | undefined)?.userId ??
+    req.headers['x-user-id'];
+  if (typeof userId === 'string' && userId.trim().length > 0) {
+    return `user:${userId.trim()}`;
+  }
+  return null;
+}
+
+/**
+ * Returns a stable key for an IP bucket.
+ * Returns `null` when no IP can be determined.
+ */
+function getIpKey(req: Request): string | null {
+  const ip =
+    (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
+    req.ip ??
+    req.socket.remoteAddress;
+  if (typeof ip === 'string' && ip.trim().length > 0) {
+    return `ip:${ip.trim()}`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a velocity score for a single bucket's timestamp history.
+ *
+ * The score is the number of requests in the window multiplied by a burst
+ * factor. The burst factor amplifies the score when requests cluster
+ * tightly in time.
+ *
+ * @param timestamps - Sorted array of epoch-ms timestamps (mutated in place).
+ * @param now        - Current time in epoch ms.
+ * @param config     - Active velocity configuration.
+ * @returns The count of requests in the full window and the final score.
+ */
+function scoreBucket(
+  timestamps: number[],
+  now: number,
+  config: VelocityConfig,
+): { count: number; score: number } {
+  const cutoff = now - config.windowSizeMs;
+
+  // 1. Prune expired entries (sliding-window shift)
+  let pruneIdx = 0;
+  while (pruneIdx < timestamps.length && timestamps[pruneIdx] < cutoff) {
+    pruneIdx++;
+  }
+  if (pruneIdx > 0) {
+    timestamps.splice(0, pruneIdx);
+  }
+
+  const count = timestamps.length;
+  if (count === 0) {
+    return { count: 0, score: 0 };
+  }
+
+  // 2. Count requests in the burst sub-window
+  const burstCutoff = now - config.burstWindowMs;
+  let burstCount = 0;
+  for (let i = timestamps.length - 1; i >= 0; i--) {
+    if (timestamps[i] >= burstCutoff) {
+      burstCount++;
+    } else {
+      break; // timestamps are sorted ascending
+    }
+  }
+
+  // 3. Burst ratio: what fraction of total window traffic happened recently?
+  const burstRatio = burstCount / count;
+
+  // 4. Final score = count × (1 + burstRatio × (burstMultiplier - 1))
+  //    When burstRatio = 0 → score = count (no burst bonus)
+  //    When burstRatio = 1 → score = count × burstMultiplier (max burst)
+  const score = Math.round(count * (1 + burstRatio * (config.burstMultiplier - 1)));
+
+  return { count, score };
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Evict a batch of the least-recently-used keys until the bucket count
+ * is at or below the configured maximum.
+ */
+function evictLRU(maxKeys: number): void {
+  if (buckets.size <= maxKeys) return;
+
+  // Sort by last-access ascending (oldest first)
+  const entries = Array.from(lastAccess.entries());
+  entries.sort((a, b) => a[1] - b[1]);
+
+  const toRemove = buckets.size - maxKeys;
+  for (let i = 0; i < toRemove && i < entries.length; i++) {
+    const key = entries[i][0];
+    buckets.delete(key);
+    lastAccess.delete(key);
+  }
+}
+
+/**
+ * Remove expired timestamps from every bucket and delete empty buckets.
+ *
+ * Called periodically and on-demand (e.g., in tests). Designed to be
+ * safe for concurrent access via synchronous iteration.
+ */
+export function runCleanup(config: VelocityConfig = DEFAULT_CONFIG): void {
+  if (cleaning) return;
+  cleaning = true;
+
+  try {
+    const now = Date.now();
+    const cutoff = now - config.windowSizeMs;
+
+    for (const [key, timestamps] of buckets) {
+      // Remove expired entries
+      let pruneIdx = 0;
+      while (pruneIdx < timestamps.length && timestamps[pruneIdx] < cutoff) {
+        pruneIdx++;
+      }
+      if (pruneIdx > 0) {
+        timestamps.splice(0, pruneIdx);
+      }
+
+      // Drop entirely empty buckets
+      if (timestamps.length === 0) {
+        buckets.delete(key);
+        lastAccess.delete(key);
+      }
+    }
+
+    // Enforce max-key cap
+    evictLRU(config.maxTrackedKeys);
+  } finally {
+    cleaning = false;
+  }
+}
+
+/**
+ * Start the periodic cleanup interval.
+ * Safe to call multiple times (idempotent).
+ */
+export function startCleanup(config: VelocityConfig = DEFAULT_CONFIG): void {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(() => runCleanup(config), config.cleanupIntervalMs);
+  // Allow Node to exit even if the timer is still running
+  if (cleanupTimer && typeof cleanupTimer === 'object' && 'unref' in cleanupTimer) {
+    cleanupTimer.unref();
+  }
+}
+
+/**
+ * Stop the periodic cleanup interval.
+ */
+export function stopCleanup(): void {
+  if (cleanupTimer) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request augmentation
+// ---------------------------------------------------------------------------
+
+declare global {
+  namespace Express {
+    interface Request {
+      /** Velocity score result populated by the velocityScore middleware. */
+      velocityScore?: VelocityScoreResult;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an Express middleware that applies velocity-based fraud scoring
+ * to every request.
+ *
+ * The middleware:
+ * 1. Extracts the authenticated user ID and client IP from the request.
+ * 2. Updates per-user and per-IP sliding-window buckets.
+ * 3. Computes a combined velocity score.
+ * 4. Attaches the result to `req.velocityScore`.
+ * 5. Optionally blocks (HTTP 429) when the score meets or exceeds
+ *    `config.blockThreshold`.
+ *
+ * @param config - Partial configuration; merged with defaults.
+ * @returns Express middleware function.
+ *
+ * @example
+ * ```typescript
+ * import express from 'express';
+ * import { velocityScoreMiddleware } from './middleware/velocityScore.js';
+ *
+ * const app = express();
+ * app.use(velocityScoreMiddleware({ blockThreshold: 100 }));
+ *
+ * app.get('/api/data', (req, res) => {
+ *   console.log('Velocity score:', req.velocityScore?.score);
+ *   res.json({ ok: true });
+ * });
+ * ```
+ */
+export function velocityScoreMiddleware(
+  config: Partial<VelocityConfig> = {},
+): (req: Request, res: Response, next: NextFunction) => void {
+  const effectiveConfig: VelocityConfig = { ...DEFAULT_CONFIG, ...config };
+
+  // Ensure cleanup is running
+  startCleanup(effectiveConfig);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const now = Date.now();
+    const userKey = getUserKey(req);
+    const ipKey = getIpKey(req);
+
+    // Compute individual bucket scores
+    let userCount = 0;
+    let userScore = 0;
+    let ipCount = 0;
+    let ipScore = 0;
+
+    if (userKey) {
+      const timestamps = buckets.get(userKey) ?? [];
+      timestamps.push(now);
+      buckets.set(userKey, timestamps);
+      lastAccess.set(userKey, now);
+      const result = scoreBucket(timestamps, now, effectiveConfig);
+      userCount = result.count;
+      userScore = result.score;
+    }
+
+    if (ipKey) {
+      const timestamps = buckets.get(ipKey) ?? [];
+      timestamps.push(now);
+      buckets.set(ipKey, timestamps);
+      lastAccess.set(ipKey, now);
+      const result = scoreBucket(timestamps, now, effectiveConfig);
+      ipCount = result.count;
+      ipScore = result.score;
+    }
+
+    // Combined score: max of user and IP scores so one dimension can't hide
+    // the other when both are present. When only one dimension is available
+    // we use the single score plus a floor for the missing dimension.
+    const combinedScore = Math.max(userScore, ipScore);
+
+    // Build result
+    const result: VelocityScoreResult = {
+      score: combinedScore,
+      userCount,
+      ipCount,
+      computedAt: new Date(now).toISOString(),
+    };
+
+    // Auto-block check
+    if (
+      effectiveConfig.blockThreshold > 0 &&
+      combinedScore >= effectiveConfig.blockThreshold
+    ) {
+      result.blocked = true;
+      result.threshold = effectiveConfig.blockThreshold;
+
+      res.status(429).json({
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Request rate exceeded. Please slow down.',
+        },
+        velocityScore: result,
+      });
+      return;
+    }
+
+    // Attach to request for downstream handlers
+    req.velocityScore = result;
+
+    next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers — NOT for production use
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset all internal state. Intended for test teardown only.
+ */
+export function __resetBuckets(): void {
+  buckets.clear();
+  lastAccess.clear();
+  stopCleanup();
+}
+
+/**
+ * Directly inspect the raw bucket data. Intended for test assertions only.
+ */
+export function __getBuckets(): ReadonlyMap<string, readonly number[]> {
+  return buckets;
+}
+
+/**
+ * Return a frozen copy of the default config for test inspection.
+ */
+export function __getDefaultConfig(): Readonly<VelocityConfig> {
+  return Object.freeze({ ...DEFAULT_CONFIG });
+}

--- a/routes-d/tests/velocityScore.test.ts
+++ b/routes-d/tests/velocityScore.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Tests for velocity-based fraud scoring middleware.
+ *
+ * Covers: normal traffic, high request spikes, score increase, score decay,
+ * independent user/IP tracking, auto-block threshold, threshold disabled,
+ * missing user ID, missing IP, concurrent requests, and cleanup of expired
+ * windows.
+ */
+
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import {
+  velocityScoreMiddleware,
+  runCleanup,
+  stopCleanup,
+  __resetBuckets,
+  __getBuckets,
+  __getDefaultConfig,
+  type VelocityConfig,
+  type VelocityScoreResult,
+} from '../middleware/velocityScore.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a small Express app that uses the velocity middleware + a simple route. */
+function buildApp(config: Partial<VelocityConfig> = {}) {
+  const app = express();
+  app.use(express.json());
+  // Make req.ip work in tests by trusting the proxy
+  app.set('trust proxy', true);
+  app.use(velocityScoreMiddleware(config));
+  app.get('/test', (req: Request, res: Response) => {
+    res.json({ ok: true, velocityScore: req.velocityScore });
+  });
+  app.post('/test', (req: Request, res: Response) => {
+    res.json({ ok: true, velocityScore: req.velocityScore });
+  });
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+/** Helper to advance fake time by the given ms. Returns the new "now". */
+async function advanceTime(_app: ReturnType<typeof buildApp>, _ms: number): Promise<void> {
+  // supertest doesn't give us a way to mock Date.now(), so for most tests
+  // we use real time. For decay tests we sleep briefly.
+  await new Promise((r) => setTimeout(r, _ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('velocityScoreMiddleware', () => {
+  beforeEach(() => {
+    __resetBuckets();
+    // Restart cleanup (__resetBuckets stops it)
+  });
+
+  afterAll(() => {
+    stopCleanup();
+  });
+
+  // -----------------------------------------------------------------------
+  // Normal traffic
+  // -----------------------------------------------------------------------
+  describe('normal traffic', () => {
+    it('assigns a low score for a handful of requests spread over time', async () => {
+      const app = buildApp();
+
+      const res1 = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '192.168.1.10')
+        .send({ userId: 'user-normal' });
+
+      expect(res1.status).toBe(200);
+      const vs1: VelocityScoreResult = res1.body.velocityScore;
+      expect(vs1.score).toBeGreaterThanOrEqual(1);
+      expect(vs1.blocked).toBeUndefined();
+    });
+
+    it('returns score that includes both userCount and ipCount', async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.0.0.1')
+        .send({ userId: 'user-a' });
+
+      expect(res.status).toBe(200);
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      expect(vs.userCount).toBe(1);
+      expect(vs.ipCount).toBe(1);
+      expect(vs.score).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // High request spike (burst detection)
+  // -----------------------------------------------------------------------
+  describe('high request spike', () => {
+    it('amplifies the score when many requests arrive in rapid succession', async () => {
+      const app = buildApp({ burstWindowMs: 60_000 }); // large burst window for test
+
+      // Send 10 requests rapidly
+      let lastScore = 0;
+      for (let i = 0; i < 10; i++) {
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.1.1.1')
+          .send({ userId: 'user-burst' });
+
+        const vs = res.body.velocityScore as VelocityScoreResult;
+
+        if (i === 0) {
+          // First request: count=1, burstRatio=1 → score = 1 * burstMultiplier = 2
+          expect(vs.score).toBe(2);
+        } else {
+          // Score should grow non-linearly due to burst
+          expect(vs.score).toBeGreaterThan(lastScore);
+        }
+        lastScore = vs.score;
+      }
+
+      // Final score should be notably higher than the raw count (10)
+      // because burst multiplier is applied
+      expect(lastScore).toBeGreaterThan(10);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Score increases correctly
+  // -----------------------------------------------------------------------
+  describe('score increases correctly', () => {
+    it('increases the score monotonically as requests accumulate', async () => {
+      const app = buildApp();
+      const scores: number[] = [];
+
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.2.2.2')
+          .send({ userId: 'user-mono' });
+
+        const vs = res.body.velocityScore as VelocityScoreResult;
+        scores.push(vs.score);
+      }
+
+      // Scores should strictly increase (or at least never decrease)
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1]);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Score decays over time
+  // -----------------------------------------------------------------------
+  describe('score decays over time', () => {
+    it(
+      'returns a lower score after the window has partially elapsed',
+      async () => {
+        const windowMs = 500;
+        const app = buildApp({ windowSizeMs: windowMs });
+
+        // Send a burst
+        for (let i = 0; i < 5; i++) {
+          await request(app)
+            .get('/test')
+            .set('X-Forwarded-For', '10.3.3.3')
+            .send({ userId: 'user-decay' });
+        }
+
+        // Wait for window to expire (plus a small buffer)
+        await advanceTime(app, windowMs + 100);
+
+        // Now the score should be back to baseline (first request in new window)
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.3.3.3')
+          .send({ userId: 'user-decay' });
+
+        const vs = res.body.velocityScore as VelocityScoreResult;
+        // After all timestamps expired, only the current request should be in the window
+        expect(vs.score).toBeLessThanOrEqual(5);
+      },
+      10_000, // timeout for sleep
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // User and IP tracked independently
+  // -----------------------------------------------------------------------
+  describe('user/IP tracking independence', () => {
+    it('tracks user and IP separately in different buckets', async () => {
+      const app = buildApp();
+
+      // User A from IP X
+      await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.4.4.1')
+        .send({ userId: 'user-indie-1' });
+
+      // User B from the same IP X
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.4.4.1')
+        .send({ userId: 'user-indie-2' });
+
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      // IP count should be 2 (two requests from same IP)
+      expect(vs.ipCount).toBe(2);
+      // But user count should be 1 (first request for this user)
+      expect(vs.userCount).toBe(1);
+    });
+
+    it('assigns separate buckets for user and IP prefixes', () => {
+      const app = buildApp();
+      // Trigger to populate buckets
+      return request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.5.5.5')
+        .send({ userId: 'user-separate' })
+        .then(() => {
+          const buckets = __getBuckets();
+          const keys = Array.from(buckets.keys());
+          expect(keys).toContain('user:user-separate');
+          expect(keys).toContain('ip:10.5.5.5');
+        });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Auto-block threshold
+  // -----------------------------------------------------------------------
+  describe('auto-block threshold', () => {
+    it('blocks with 429 when score reaches the threshold', async () => {
+      const app = buildApp({ blockThreshold: 5 });
+
+      // Send 10 requests rapidly from the same user+IP
+      let blocked = false;
+      for (let i = 0; i < 15; i++) {
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.6.6.6')
+          .send({ userId: 'user-block' });
+
+        if (res.status === 429) {
+          blocked = true;
+          expect(res.body.error.code).toBe('RATE_LIMITED');
+          expect(res.body.velocityScore.blocked).toBe(true);
+          expect(res.body.velocityScore.threshold).toBe(5);
+          expect(res.body.velocityScore.score).toBeGreaterThanOrEqual(5);
+          break;
+        }
+      }
+      expect(blocked).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Threshold disabled
+  // -----------------------------------------------------------------------
+  describe('threshold disabled', () => {
+    it('never blocks when blockThreshold is 0', async () => {
+      const app = buildApp({ blockThreshold: 0 });
+
+      for (let i = 0; i < 20; i++) {
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.7.7.7')
+          .send({ userId: 'user-noblock' });
+
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('sets blocked to undefined when threshold is disabled', async () => {
+      const app = buildApp({ blockThreshold: 0 });
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.7.7.8')
+        .send({ userId: 'user-noblock2' });
+
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      expect(vs.blocked).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Missing user ID
+  // -----------------------------------------------------------------------
+  describe('missing user ID', () => {
+    it('still tracks IP when user ID is absent', async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.8.8.8')
+        .send({}); // no userId
+
+      expect(res.status).toBe(200);
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      expect(vs.userCount).toBe(0);
+      expect(vs.ipCount).toBe(1);
+      expect(vs.score).toBeGreaterThanOrEqual(1);
+    });
+
+    it('computes score solely from IP when user ID is missing', async () => {
+      const app = buildApp({ blockThreshold: 10 });
+
+      for (let i = 0; i < 12; i++) {
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.8.8.9')
+          .send({});
+
+        if (res.status === 429) {
+          // Blocked purely on IP velocity — that's correct
+          // With burst applied, blockThreshold=10 is reached around ipCount=5
+          expect(res.body.velocityScore.userCount).toBe(0);
+          expect(res.body.velocityScore.ipCount).toBeGreaterThanOrEqual(5);
+          return;
+        }
+      }
+      // Should have been blocked by now
+      throw new Error('Expected 429 was not returned');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Missing IP
+  // -----------------------------------------------------------------------
+  describe('missing IP', () => {
+    it('still tracks user when IP is absent', async () => {
+      const app = buildApp();
+
+      // Override the IP to simulate missing IP
+      const altApp = express();
+      altApp.use(express.json());
+      altApp.use((req: Request, _res: Response, next: NextFunction) => {
+        // Remove IP info
+        Object.defineProperty(req, 'ip', { value: undefined, writable: true });
+        (req as unknown as Record<string, unknown>).socket = {};
+        next();
+      });
+      altApp.use(velocityScoreMiddleware({}));
+      altApp.get('/test', (req: Request, res: Response) => {
+        res.json({ ok: true, velocityScore: req.velocityScore });
+      });
+
+      const res = await request(altApp)
+        .get('/test')
+        .send({ userId: 'user-noip' });
+
+      expect(res.status).toBe(200);
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      expect(vs.userCount).toBe(1);
+      expect(vs.ipCount).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Concurrent requests
+  // -----------------------------------------------------------------------
+  describe('concurrent requests', () => {
+    it('handles multiple concurrent requests without data corruption', async () => {
+      const app = buildApp();
+      const count = 20;
+
+      const promises = Array.from({ length: count }, (_, i) =>
+        request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.9.9.9')
+          .send({ userId: `user-concurrent-${i % 4}` }),
+      );
+
+      const results = await Promise.all(promises);
+
+      // All should succeed
+      for (const res of results) {
+        expect(res.status).toBe(200);
+        expect(res.body.velocityScore).toBeDefined();
+      }
+    });
+
+    it('produces consistent scores under concurrent load', async () => {
+      const app = buildApp();
+      const count = 10;
+
+      const promises = Array.from({ length: count }, () =>
+        request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.9.9.10')
+          .send({ userId: 'user-conc-single' }),
+      );
+
+      const results = await Promise.all(promises);
+      const scores = results.map((r) => (r.body.velocityScore as VelocityScoreResult).score);
+
+      // All scores should be > 0
+      for (const s of scores) {
+        expect(s).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cleanup of expired windows
+  // -----------------------------------------------------------------------
+  describe('cleanup of expired windows', () => {
+    it('removes expired buckets via runCleanup', async () => {
+      const windowMs = 300;
+      const app = buildApp({ windowSizeMs: windowMs });
+
+      // Send a request to populate buckets
+      await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.10.10.10')
+        .send({ userId: 'user-cleanup' });
+
+      let buckets = __getBuckets();
+      expect(buckets.size).toBeGreaterThan(0);
+
+      // Wait for window to expire
+      await advanceTime(app, windowMs + 100);
+
+      // Run cleanup — it should remove expired buckets
+      runCleanup({ ...__getDefaultConfig(), windowSizeMs: windowMs });
+
+      buckets = __getBuckets();
+      // All timestamps should be expired and buckets removed
+      expect(buckets.size).toBe(0);
+    }, 10_000);
+  });
+
+  // -----------------------------------------------------------------------
+  // Configuration validation
+  // -----------------------------------------------------------------------
+  describe('configuration', () => {
+    it('uses defaults when no config is provided', async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.11.11.11')
+        .send({ userId: 'user-defaults' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.velocityScore).toBeDefined();
+    });
+
+    it('respects a custom window size', async () => {
+      const windowMs = 300;
+      const app = buildApp({ windowSizeMs: windowMs });
+
+      // Send a request
+      await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.12.12.12')
+        .send({ userId: 'user-custom-window' });
+
+      // Wait for window to expire
+      await advanceTime(app, windowMs + 100);
+
+      // Next request should have count=1 (previous expired)
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.12.12.12')
+        .send({ userId: 'user-custom-window' });
+
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      expect(vs.userCount).toBe(1);
+    }, 10_000);
+  });
+
+  // -----------------------------------------------------------------------
+  // Multiple dimensions
+  // -----------------------------------------------------------------------
+  describe('combined scoring', () => {
+    it('uses the maximum of user and IP scores', async () => {
+      const app = buildApp({ blockThreshold: 20 });
+
+      // Saturate IP with many users but few requests per user
+      for (let i = 0; i < 25; i++) {
+        const res = await request(app)
+          .get('/test')
+          .set('X-Forwarded-For', '10.13.13.13')
+          .send({ userId: `user-combined-${i}` });
+
+        if (res.status === 429) {
+          // IP score exceeded threshold even though each user has only 1 request
+          const vs = res.body.velocityScore as VelocityScoreResult;
+          // Burst multiplier amplifies: blockThreshold=20 reached around ipCount=10
+          expect(vs.ipCount).toBeGreaterThanOrEqual(10);
+          expect(vs.userCount).toBeLessThanOrEqual(1);
+          return;
+        }
+      }
+      throw new Error('Expected 429 was not returned');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+  describe('edge cases', () => {
+    it('handles userId in headers instead of body', async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.14.14.14')
+        .set('x-user-id', 'user-header');
+
+      expect(res.status).toBe(200);
+      expect((res.body.velocityScore as VelocityScoreResult).userCount).toBe(1);
+    });
+
+    it('handles empty string userId gracefully', async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.15.15.15')
+        .send({ userId: '' });
+
+      expect(res.status).toBe(200);
+      // Empty userId should be treated as missing
+      expect((res.body.velocityScore as VelocityScoreResult).userCount).toBe(0);
+    });
+
+    it('returns a valid computedAt timestamp', async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get('/test')
+        .set('X-Forwarded-For', '10.16.16.16')
+        .send({ userId: 'user-timestamp' });
+
+      const vs = res.body.velocityScore as VelocityScoreResult;
+      expect(vs.computedAt).toBeDefined();
+      expect(() => new Date(vs.computedAt)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Implements a sliding-window velocity tracking middleware that computes fraud scores per user and IP, with configurable burst detection and optional auto-blocking. Includes comprehensive tests and documentation.

Closes #389