### PR TITLE
feat(currency): implement currency display formatting endpoint and logic

### DIFF
--- a/routes-d/docs/currency-formatting.md
+++ b/routes-d/docs/currency-formatting.md
@@ -1,0 +1,94 @@
+# Currency Display Formatting Endpoint (`routes-d`)
+
+This endpoint formats amounts for display per locale and currency in a deterministic manner. It supports ISO-4217 currency codes, Stellar native Lumens (`XLM` / `native`), custom Stellar crypto tokens, and handles edge precision scenarios.
+
+## Endpoints
+
+- `GET /format/currency`
+- `POST /format/currency`
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `amount` | `number` \| `string` | **Yes** | - | Numeric amount to format |
+| `currency` | `string` | **Yes** | - | ISO-4217 code (e.g. `USD`, `EUR`, `JPY`) or Stellar token (`XLM`, `native`, `USDC`) |
+| `locale` | `string` | No | `"en-US"` | BCP 47 locale string (e.g. `"en-US"`, `"de-DE"`, `"fr-FR"`, `"ja-JP"`) |
+| `decimals` | `number` | No | - | Override fixed number of fraction digits |
+| `minDecimals` | `number` | No | - | Minimum fraction digits |
+| `maxDecimals` | `number` | No | - | Maximum fraction digits |
+
+## Example Requests
+
+### 1. ISO 4217 Currency (USD in en-US)
+```http
+POST /format/currency
+Content-Type: application/json
+
+{
+  "amount": 1234.56,
+  "currency": "USD",
+  "locale": "en-US"
+}
+```
+
+**Response (200 OK)**:
+```json
+{
+  "success": true,
+  "data": {
+    "formatted": "$1,234.56",
+    "amount": 1234.56,
+    "currency": "USD",
+    "locale": "en-US",
+    "isNative": false
+  }
+}
+```
+
+### 2. Stellar Native Lumens (XLM with 7 decimal precision)
+```http
+POST /format/currency
+Content-Type: application/json
+
+{
+  "amount": 0.0000001,
+  "currency": "XLM",
+  "locale": "en-US"
+}
+```
+
+**Response (200 OK)**:
+```json
+{
+  "success": true,
+  "data": {
+    "formatted": "0.0000001 XLM",
+    "amount": 0.0000001,
+    "currency": "XLM",
+    "locale": "en-US",
+    "isNative": true
+  }
+}
+```
+
+### 3. Unknown Currency Code Error
+```http
+POST /format/currency
+Content-Type: application/json
+
+{
+  "amount": 100,
+  "currency": "INVALID_XYZ"
+}
+```
+
+**Response (400 Bad Request)**:
+```json
+{
+  "error": {
+    "code": "UNKNOWN_CURRENCY",
+    "message": "Unknown or unsupported currency code: 'INVALID_XYZ'"
+  }
+}
+```

--- a/routes-d/lib/currencyFormatter.ts
+++ b/routes-d/lib/currencyFormatter.ts
@@ -1,0 +1,141 @@
+/**
+ * Deterministic Currency Display Formatter
+ * Supports ISO-4217 currency codes, Stellar native Lumens (XLM), custom locales, and edge precision.
+ */
+
+// Supported ISO 4217 currency codes set
+const VALID_ISO_CURRENCIES = new Set([
+  'USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'CHF', 'CNY', 'INR', 'BRL',
+  'SGD', 'HKD', 'SEK', 'NOK', 'NZD', 'MXN', 'ZAR', 'KRW', 'TRY', 'RUB',
+  'AED', 'SAR', 'PLN', 'THB', 'IDR', 'HUF', 'CZK', 'ILS', 'CLP', 'PHP',
+  'COP', 'MYR', 'RON', 'EGP', 'DKK', 'TWD', 'ARS', 'VND', 'PKR', 'NGN',
+  'KES', 'GHS', 'UAH', 'PEN', 'MAD'
+]);
+
+// Known Crypto / Stellar tokens
+const KNOWN_CRYPTO_TOKENS = new Set([
+  'XLM', 'NATIVE', 'USDC', 'AQUA', 'YXLM', 'SHX', 'BTC', 'ETH'
+]);
+
+export interface CurrencyFormatOptions {
+  decimals?: number;
+  minDecimals?: number;
+  maxDecimals?: number;
+  useSymbol?: boolean;
+}
+
+export interface FormattedCurrencyResult {
+  formatted: string;
+  amount: number;
+  currency: string;
+  locale: string;
+  isNative: boolean;
+}
+
+/**
+ * Validates whether a currency code is a valid ISO-4217 or recognized Stellar/Crypto code.
+ */
+export function isValidCurrencyCode(currency: string): boolean {
+  if (!currency || typeof currency !== 'string') return false;
+  const upper = currency.trim().toUpperCase();
+  if (upper === 'NATIVE') return true;
+  if (KNOWN_CRYPTO_TOKENS.has(upper)) return true;
+  if (VALID_ISO_CURRENCIES.has(upper)) return true;
+
+  // Check if Intl recognizes it as a valid ISO currency
+  try {
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: upper });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Format an amount per locale and currency in a deterministic manner.
+ */
+export function formatCurrency(
+  amountInput: number | string,
+  currencyInput: string,
+  localeInput: string = 'en-US',
+  options: CurrencyFormatOptions = {}
+): FormattedCurrencyResult {
+  if (amountInput === null || amountInput === undefined || amountInput === '') {
+    throw new Error('Amount is required');
+  }
+
+  const numericAmount = typeof amountInput === 'number' ? amountInput : Number(amountInput);
+  if (isNaN(numericAmount) || !isFinite(numericAmount)) {
+    throw new Error('Invalid numeric amount');
+  }
+
+  if (!currencyInput || typeof currencyInput !== 'string') {
+    throw new Error('Currency code is required');
+  }
+
+  const rawCurrency = currencyInput.trim();
+  const upperCurrency = rawCurrency.toUpperCase();
+  const locale = (localeInput || 'en-US').trim();
+
+  if (!isValidCurrencyCode(upperCurrency)) {
+    throw new Error(`Unsupported or unknown currency code: ${currencyInput}`);
+  }
+
+  const isNative = upperCurrency === 'XLM' || upperCurrency === 'NATIVE';
+  const targetCurrency = isNative ? 'XLM' : upperCurrency;
+
+  let formattedResult: string;
+
+  if (isNative || KNOWN_CRYPTO_TOKENS.has(targetCurrency) && !VALID_ISO_CURRENCIES.has(targetCurrency)) {
+    // Stellar native or custom crypto token precision handling
+    const maxDec = options.maxDecimals ?? 7;
+    const minDec = options.minDecimals ?? 0;
+
+    const formatter = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: minDec,
+      maximumFractionDigits: maxDec,
+    });
+
+    const numStr = formatter.format(numericAmount);
+    // Deterministic placement of token symbol
+    formattedResult = `${numStr} ${targetCurrency}`;
+  } else {
+    // Standard ISO 4217 Currency formatting
+    const isZeroDecimalCurrency = ['JPY', 'KRW', 'VND', 'CLP', 'HUF'].includes(targetCurrency);
+    const defaultDecimals = isZeroDecimalCurrency ? 0 : 2;
+
+    const formatterOptions: Intl.NumberFormatOptions = {
+      style: 'currency',
+      currency: targetCurrency,
+      currencyDisplay: options.useSymbol === false ? 'code' : 'symbol',
+    };
+
+    if (options.decimals !== undefined) {
+      formatterOptions.minimumFractionDigits = options.decimals;
+      formatterOptions.maximumFractionDigits = options.decimals;
+    } else {
+      if (options.minDecimals !== undefined) formatterOptions.minimumFractionDigits = options.minDecimals;
+      if (options.maxDecimals !== undefined) formatterOptions.maximumFractionDigits = options.maxDecimals;
+    }
+
+    try {
+      const formatter = new Intl.NumberFormat(locale, formatterOptions);
+      formattedResult = formatter.format(numericAmount);
+    } catch {
+      // Fallback formatting if locale parameter is invalid
+      const fallbackFormatter = new Intl.NumberFormat('en-US', formatterOptions);
+      formattedResult = fallbackFormatter.format(numericAmount);
+    }
+  }
+
+  // Normalize whitespace (convert non-breaking spaces \u00a0 and \u202f to standard space)
+  const normalizedFormatted = formattedResult.replace(/\u00a0|\u202f/g, ' ').trim();
+
+  return {
+    formatted: normalizedFormatted,
+    amount: numericAmount,
+    currency: targetCurrency,
+    locale,
+    isNative,
+  };
+}

--- a/routes-d/routes/format.currency.ts
+++ b/routes-d/routes/format.currency.ts
@@ -1,0 +1,91 @@
+import { Router, Request, Response } from "express";
+import { sendError } from "../lib/response.js";
+import {
+  formatCurrency,
+  isValidCurrencyCode,
+  CurrencyFormatOptions,
+} from "../lib/currencyFormatter.js";
+
+const router = Router();
+
+/**
+ * Currency formatting request handler helper.
+ */
+function handleFormatCurrency(req: Request, res: Response) {
+  try {
+    const params = { ...(req.query || {}), ...(req.body || {}) };
+    const { amount, currency, locale, decimals, minDecimals, maxDecimals, useSymbol } = params;
+
+    if (amount === undefined || amount === null || amount === "") {
+      sendError(res, "VALIDATION_ERROR", "Field 'amount' is required", 400);
+      return;
+    }
+
+    if (!currency) {
+      sendError(res, "VALIDATION_ERROR", "Field 'currency' is required", 400);
+      return;
+    }
+
+    const numAmount = Number(amount);
+    if (isNaN(numAmount) || !isFinite(numAmount)) {
+      sendError(res, "INVALID_AMOUNT", "Field 'amount' must be a valid number", 400);
+      return;
+    }
+
+    if (!isValidCurrencyCode(String(currency))) {
+      sendError(
+        res,
+        "UNKNOWN_CURRENCY",
+        `Unknown or unsupported currency code: '${currency}'`,
+        400
+      );
+      return;
+    }
+
+    const options: CurrencyFormatOptions = {};
+    if (decimals !== undefined && decimals !== "") {
+      const parsed = parseInt(String(decimals), 10);
+      if (!isNaN(parsed) && parsed >= 0) options.decimals = parsed;
+    }
+    if (minDecimals !== undefined && minDecimals !== "") {
+      const parsed = parseInt(String(minDecimals), 10);
+      if (!isNaN(parsed) && parsed >= 0) options.minDecimals = parsed;
+    }
+    if (maxDecimals !== undefined && maxDecimals !== "") {
+      const parsed = parseInt(String(maxDecimals), 10);
+      if (!isNaN(parsed) && parsed >= 0) options.maxDecimals = parsed;
+    }
+    if (useSymbol !== undefined) {
+      options.useSymbol = useSymbol === "true" || useSymbol === true;
+    }
+
+    const result = formatCurrency(
+      numAmount,
+      String(currency),
+      locale ? String(locale) : "en-US",
+      options
+    );
+
+    return res.status(200).json({
+      success: true,
+      data: result,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Formatting error";
+    if (message.includes("currency code")) {
+      sendError(res, "UNKNOWN_CURRENCY", message, 400);
+      return;
+    }
+    sendError(res, "FORMAT_ERROR", message, 400);
+  }
+}
+
+/**
+ * GET /format/currency
+ * POST /format/currency
+ * Format amounts for display per locale and currency.
+ */
+router.get("/format/currency", handleFormatCurrency);
+router.post("/format/currency", handleFormatCurrency);
+
+export default router;

--- a/routes-d/tests/format.currency.test.ts
+++ b/routes-d/tests/format.currency.test.ts
@@ -1,0 +1,106 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import formatCurrencyRouter from "../routes/format.currency.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(formatCurrencyRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, error: { message: err.message } });
+  });
+  return app;
+}
+
+describe("Currency Display Formatting Route Handlers", () => {
+  const app = buildApp();
+
+  describe("POST /format/currency", () => {
+    it("formats USD currency successfully", async () => {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          amount: 2500.5,
+          currency: "USD",
+          locale: "en-US",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.formatted).toBe("$2,500.50");
+      expect(res.body.data.amount).toBe(2500.5);
+      expect(res.body.data.currency).toBe("USD");
+    });
+
+    it("formats Stellar native XLM successfully", async () => {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          amount: 0.0000001,
+          currency: "XLM",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.formatted).toBe("0.0000001 XLM");
+      expect(res.body.data.isNative).toBe(true);
+    });
+
+    it("rejects unknown currency code with 400 Bad Request", async () => {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          amount: 100,
+          currency: "NON_EXISTENT_CODE",
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("UNKNOWN_CURRENCY");
+    });
+
+    it("returns 400 when missing amount field", async () => {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          currency: "USD",
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 when missing currency field", async () => {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          amount: 100,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for invalid amount parameter", async () => {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          amount: "invalid-number",
+          currency: "USD",
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_AMOUNT");
+    });
+  });
+
+  describe("GET /format/currency", () => {
+    it("formats currency via query parameters", async () => {
+      const res = await request(app)
+        .get("/format/currency?amount=500&currency=EUR&locale=de-DE");
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.formatted).toContain("500,00");
+    });
+  });
+});

--- a/routes-d/tests/integration/format.currency.integration.test.ts
+++ b/routes-d/tests/integration/format.currency.integration.test.ts
@@ -1,0 +1,41 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import formatCurrencyRouter from "../../routes/format.currency.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(formatCurrencyRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, error: { message: err.message } });
+  });
+  return app;
+}
+
+describe("Currency Display Formatting Integration", () => {
+  const app = buildApp();
+
+  it("handles multi-currency and locale formatting across well-known pairs and Stellar assets", async () => {
+    const testCases = [
+      { amount: 1000, currency: "USD", locale: "en-US", expectedSub: "$1,000.00" },
+      { amount: 1000, currency: "EUR", locale: "fr-FR", expectedSub: "1 000,00" },
+      { amount: 5000, currency: "JPY", locale: "ja-JP", expectedSub: "5,000" },
+      { amount: 10.5, currency: "XLM", locale: "en-US", expectedSub: "10.5 XLM" },
+      { amount: 0.0000001, currency: "native", locale: "en-US", expectedSub: "0.0000001 XLM" },
+    ];
+
+    for (const tc of testCases) {
+      const res = await request(app)
+        .post("/format/currency")
+        .send({
+          amount: tc.amount,
+          currency: tc.currency,
+          locale: tc.locale,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.formatted).toContain(tc.expectedSub);
+    }
+  });
+});

--- a/routes-d/tests/unit/format.currency.store.test.ts
+++ b/routes-d/tests/unit/format.currency.store.test.ts
@@ -1,0 +1,100 @@
+import {
+  formatCurrency,
+  isValidCurrencyCode,
+} from "../../lib/currencyFormatter.js";
+
+describe("currencyFormatter Unit Tests", () => {
+  describe("isValidCurrencyCode", () => {
+    it("recognizes standard ISO-4217 currencies", () => {
+      expect(isValidCurrencyCode("USD")).toBe(true);
+      expect(isValidCurrencyCode("EUR")).toBe(true);
+      expect(isValidCurrencyCode("GBP")).toBe(true);
+      expect(isValidCurrencyCode("JPY")).toBe(true);
+      expect(isValidCurrencyCode("BRL")).toBe(true);
+    });
+
+    it("recognizes Stellar native and crypto tokens", () => {
+      expect(isValidCurrencyCode("XLM")).toBe(true);
+      expect(isValidCurrencyCode("native")).toBe(true);
+      expect(isValidCurrencyCode("NATIVE")).toBe(true);
+      expect(isValidCurrencyCode("USDC")).toBe(true);
+    });
+
+    it("rejects unknown or invalid currency codes", () => {
+      expect(isValidCurrencyCode("INVALID_XYZ")).toBe(false);
+      expect(isValidCurrencyCode("FOOBAR123")).toBe(false);
+      expect(isValidCurrencyCode("")).toBe(false);
+    });
+  });
+
+  describe("formatCurrency well-known pairs", () => {
+    it("formats USD in en-US locale", () => {
+      const res = formatCurrency(1234.56, "USD", "en-US");
+      expect(res.formatted).toContain("$1,234.56");
+      expect(res.currency).toBe("USD");
+      expect(res.amount).toBe(1234.56);
+    });
+
+    it("formats EUR in de-DE locale", () => {
+      const res = formatCurrency(1234.56, "EUR", "de-DE");
+      expect(res.formatted).toContain("1.234,56");
+      expect(res.formatted).toContain("€");
+    });
+
+    it("formats JPY with 0 decimal places", () => {
+      const res = formatCurrency(1500, "JPY", "ja-JP");
+      expect(res.formatted).toContain("1,500");
+      expect(res.formatted).toMatch(/[¥￥]/);
+    });
+
+    it("formats GBP in en-GB locale", () => {
+      const res = formatCurrency(99.99, "GBP", "en-GB");
+      expect(res.formatted).toContain("£99.99");
+    });
+  });
+
+  describe("Stellar Native (XLM) & Crypto formatting", () => {
+    it("formats XLM with default 7-decimal stroop precision", () => {
+      const res = formatCurrency(12.3456789, "XLM", "en-US");
+      expect(res.formatted).toBe("12.3456789 XLM");
+      expect(res.isNative).toBe(true);
+    });
+
+    it("formats 'native' as XLM", () => {
+      const res = formatCurrency(100, "native", "en-US");
+      expect(res.formatted).toBe("100 XLM");
+      expect(res.currency).toBe("XLM");
+      expect(res.isNative).toBe(true);
+    });
+
+    it("handles 1 stroop edge precision (0.0000001)", () => {
+      const res = formatCurrency(0.0000001, "XLM", "en-US");
+      expect(res.formatted).toBe("0.0000001 XLM");
+    });
+  });
+
+  describe("Edge cases & Error handling", () => {
+    it("handles zero amount", () => {
+      const res = formatCurrency(0, "USD", "en-US");
+      expect(res.formatted).toBe("$0.00");
+    });
+
+    it("handles negative amounts", () => {
+      const res = formatCurrency(-50.25, "USD", "en-US");
+      expect(res.formatted).toBe("-$50.25");
+    });
+
+    it("handles string amount input", () => {
+      const res = formatCurrency("999.99", "USD", "en-US");
+      expect(res.formatted).toBe("$999.99");
+    });
+
+    it("throws error for non-numeric amounts", () => {
+      expect(() => formatCurrency("not-a-number", "USD")).toThrow("Invalid numeric amount");
+    });
+
+    it("throws error for unknown currency code", () => {
+      expect(() => formatCurrency(100, "UNKNOWN_CODE")).toThrow("Unsupported or unknown currency code");
+    });
+  });
+});


### PR DESCRIPTION
### **Create currency display formatting endpoint in routes-d**

Closes #395 

<img width="468" height="282" alt="image" src="https://github.com/user-attachments/assets/155ba938-c281-43cd-9cd0-4e0a29684afd" />
