### PR TITLE
#384 Create recent transactions feed in routes-d

### DIFF
--- a/routes-d/docs/PR-385-top-assets-leaderboard.md
+++ b/routes-d/docs/PR-385-top-assets-leaderboard.md
@@ -1,0 +1,42 @@
+# Top Assets Leaderboard
+
+## Summary
+
+Add `GET /assets/top` endpoint that computes and serves a top-assets leaderboard ranked by volume over rolling time windows.
+
+## Changes
+
+- **`routes-d/lib/volumeRollup.ts`** — Volume computation module with in-memory trade store, configurable windows (24h, 7d, 30d), and result caching with 30s TTL. Exports `recordTrade`, `getTopAssets`, and test helpers (`__resetTrades`, `__seedTrade`, `__clearCache`, `__getCacheSize`).
+
+- **`routes-d/routes/assets.top.ts`** — `GET /assets/top` endpoint supporting `window` query param (`24h` default, `7d`, `30d`). Returns ranked assets with `volume`, `tradeCount`, and `lastPrice`.
+
+- **`routes-d/tests/unit/volumeRollup.test.ts`** — Unit tests covering:
+  - Empty trades returns empty assets
+  - Assets ranked by volume descending
+  - Window filtering for 24h, 7d, and 30d
+  - `lastPrice` set to most recent trade price per asset
+  - Multiple assets with varying trade counts
+  - Cache retains result within TTL
+  - Cache recomputes after `__clearCache`
+  - `recordTrade` clears all caches
+  - Each window cached independently
+  - `__resetTrades` clears caches
+
+- **`routes-d/tests/assets.top.test.ts`** — Route integration tests covering:
+  - Authentication (401 when `x-user-id` missing)
+  - Default window (24h)
+  - Invalid window validation (400)
+  - Each valid window (`24h`, `7d`, `30d`)
+  - Response shape (success, data, assets array)
+  - `generatedAt` timestamp
+  - Empty assets when no trades exist
+
+## Testing
+
+Tests follow the existing routes-d pattern (`supertest` + `express`, `buildApp()`, `beforeEach` reset, `__seed*` helpers).
+
+```bash
+npm test -- routes-d/tests/unit/volumeRollup.test.ts routes-d/tests/assets.top.test.ts
+```
+
+closes #385

--- a/routes-d/lib/volumeRollup.ts
+++ b/routes-d/lib/volumeRollup.ts
@@ -1,0 +1,116 @@
+export type WindowSize = "24h" | "7d" | "30d";
+
+export type Trade = {
+  id: string;
+  asset: string;
+  amount: number;
+  price: number;
+  timestamp: Date;
+};
+
+export type VolumeEntry = {
+  asset: string;
+  volume: number;
+  tradeCount: number;
+  lastPrice: number;
+};
+
+export type TopAssetsResult = {
+  window: WindowSize;
+  generatedAt: Date;
+  assets: VolumeEntry[];
+};
+
+const trades: Trade[] = [];
+const cache = new Map<string, { result: TopAssetsResult; expiresAt: number }>();
+const CACHE_TTL_MS = 30_000;
+
+function windowMs(window: WindowSize): number {
+  switch (window) {
+    case "24h":
+      return 24 * 60 * 60 * 1000;
+    case "7d":
+      return 7 * 24 * 60 * 60 * 1000;
+    case "30d":
+      return 30 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function cacheKey(window: WindowSize): string {
+  return `top:${window}`;
+}
+
+export function recordTrade(trade: Trade): void {
+  trades.push(trade);
+  cache.clear();
+}
+
+export function getTopAssets(window: WindowSize): TopAssetsResult {
+  const key = cacheKey(window);
+  const cached = cache.get(key);
+  if (cached && Date.now() < cached.expiresAt) {
+    return { ...cached.result, generatedAt: new Date(cached.result.generatedAt) };
+  }
+
+  const cutoff = new Date(Date.now() - windowMs(window));
+  const filtered = trades.filter((t) => t.timestamp >= cutoff);
+
+  const volumeMap = new Map<
+    string,
+    { volume: number; tradeCount: number; lastPrice: number; lastTimestamp: Date }
+  >();
+
+  for (const t of filtered) {
+    const prev = volumeMap.get(t.asset);
+    const lastPrice =
+      prev !== undefined && prev.lastTimestamp.getTime() >= t.timestamp.getTime()
+        ? prev.lastPrice
+        : t.price;
+    const lastTimestamp =
+      prev !== undefined && prev.lastTimestamp.getTime() >= t.timestamp.getTime()
+        ? prev.lastTimestamp
+        : t.timestamp;
+    volumeMap.set(t.asset, {
+      volume: (prev?.volume ?? 0) + t.amount * t.price,
+      tradeCount: (prev?.tradeCount ?? 0) + 1,
+      lastPrice,
+      lastTimestamp,
+    });
+  }
+
+  const assets: VolumeEntry[] = Array.from(volumeMap.entries())
+    .map(([asset, data]) => ({
+      asset,
+      volume: data.volume,
+      tradeCount: data.tradeCount,
+      lastPrice: data.lastPrice,
+    }))
+    .sort((a, b) => b.volume - a.volume);
+
+  const result: TopAssetsResult = {
+    window,
+    generatedAt: new Date(),
+    assets,
+  };
+
+  cache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+
+  return result;
+}
+
+export function __resetTrades(): void {
+  trades.length = 0;
+  cache.clear();
+}
+
+export function __seedTrade(trade: Trade): void {
+  trades.push(trade);
+}
+
+export function __clearCache(): void {
+  cache.clear();
+}
+
+export function __getCacheSize(): number {
+  return cache.size;
+}

--- a/routes-d/routes/account.tx.feed.ts
+++ b/routes-d/routes/account.tx.feed.ts
@@ -1,0 +1,135 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type Payment = {
+  hash: string;
+  amount: string;
+  asset: string;
+  source: string;
+  destination: string;
+  ledgerCloseTime: string;
+};
+
+type Trustline = {
+  hash: string;
+  assetCode: string;
+  assetIssuer: string;
+  limit: string;
+  ledgerCloseTime: string;
+};
+
+type ContractEvent = {
+  hash: string;
+  contractId: string;
+  topic: string;
+  value: string;
+  ledgerCloseTime: string;
+};
+
+type FeedItem =
+  | ({ type: "payment" } & Payment)
+  | ({ type: "trustline" } & Trustline)
+  | ({ type: "contract_event" } & ContractEvent);
+
+const paymentsStore = new Map<string, Payment[]>();
+const trustlinesStore = new Map<string, Trustline[]>();
+const contractEventsStore = new Map<string, ContractEvent[]>();
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function buildFeed(userId: string): FeedItem[] {
+  const payments: FeedItem[] = (paymentsStore.get(userId) ?? []).map((p) => ({ type: "payment", ...p }));
+  const trustlines: FeedItem[] = (trustlinesStore.get(userId) ?? []).map((t) => ({ type: "trustline", ...t }));
+  const events: FeedItem[] = (contractEventsStore.get(userId) ?? []).map((e) => ({ type: "contract_event", ...e }));
+
+  const feed = [...payments, ...trustlines, ...events];
+  feed.sort((a, b) => new Date(b.ledgerCloseTime).getTime() - new Date(a.ledgerCloseTime).getTime());
+  return feed;
+}
+
+router.get(
+  "/account/tx/feed",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "Authentication required", 401);
+        return;
+      }
+
+      const page =
+        req.query.page !== undefined
+          ? parseInt(req.query.page as string, 10)
+          : DEFAULT_PAGE;
+      const limit =
+        req.query.limit !== undefined
+          ? parseInt(req.query.limit as string, 10)
+          : DEFAULT_LIMIT;
+
+      if (
+        isNaN(page) ||
+        page < 1 ||
+        isNaN(limit) ||
+        limit < 1 ||
+        limit > MAX_LIMIT
+      ) {
+        sendError(
+          res,
+          "INVALID_PAGINATION",
+          "page must be >= 1 and limit must be between 1 and 100",
+          400,
+        );
+        return;
+      }
+
+      const feed = buildFeed(userId);
+      const total = feed.length;
+      const offset = (page - 1) * limit;
+      const paginated = feed.slice(offset, offset + limit);
+
+      return res.status(200).json({
+        success: true,
+        data: paginated,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit) || 1,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __resetFeed(): void {
+  paymentsStore.clear();
+  trustlinesStore.clear();
+  contractEventsStore.clear();
+}
+
+export function __seedPayment(userId: string, payment: Payment): void {
+  const existing = paymentsStore.get(userId) ?? [];
+  existing.push(payment);
+  paymentsStore.set(userId, existing);
+}
+
+export function __seedTrustline(userId: string, trustline: Trustline): void {
+  const existing = trustlinesStore.get(userId) ?? [];
+  existing.push(trustline);
+  trustlinesStore.set(userId, existing);
+}
+
+export function __seedContractEvent(userId: string, event: ContractEvent): void {
+  const existing = contractEventsStore.get(userId) ?? [];
+  existing.push(event);
+  contractEventsStore.set(userId, existing);
+}
+
+export default router;

--- a/routes-d/routes/assets.top.ts
+++ b/routes-d/routes/assets.top.ts
@@ -1,0 +1,41 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import { getTopAssets, type WindowSize } from "../lib/volumeRollup.js";
+
+const router = Router();
+
+const VALID_WINDOWS = new Set<WindowSize>(["24h", "7d", "30d"]);
+
+router.get(
+  "/assets/top",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "Authentication required", 401);
+        return;
+      }
+
+      const window = (req.query.window as string) ?? "24h";
+
+      if (!VALID_WINDOWS.has(window as WindowSize)) {
+        sendError(
+          res,
+          "INVALID_WINDOW",
+          "window must be one of: 24h, 7d, 30d",
+          400,
+        );
+        return;
+      }
+
+      const result = getTopAssets(window as WindowSize);
+
+      return res.status(200).json({ success: true, data: result });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/account.tx.feed.test.ts
+++ b/routes-d/tests/account.tx.feed.test.ts
@@ -1,0 +1,374 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import accountTxFeedRouter, {
+  __resetFeed,
+  __seedPayment,
+  __seedTrustline,
+  __seedContractEvent,
+} from "../routes/account.tx.feed.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(accountTxFeedRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER_ID = "user-feed-1";
+const BASE_TIME = "2025-06-01T12:00:00.000Z";
+
+describe("GET /account/tx/feed", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetFeed();
+  });
+
+  describe("empty feed", () => {
+    it("returns empty array with pagination metadata when user has no transactions", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 0,
+        totalPages: 1,
+      });
+    });
+
+    it("returns empty for a user with no feed even when other users have data", async () => {
+      __seedPayment("other-user", {
+        hash: "a".repeat(64),
+        amount: "100",
+        asset: "XLM",
+        source: "GSOURCE1",
+        destination: "GDEST1",
+        ledgerCloseTime: BASE_TIME,
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+  });
+
+  describe("mixed feed", () => {
+    it("returns payment items with correct type discriminator", async () => {
+      __seedPayment(USER_ID, {
+        hash: "a".repeat(64),
+        amount: "500",
+        asset: "XLM",
+        source: "GSOURCE1",
+        destination: "GDEST1",
+        ledgerCloseTime: BASE_TIME,
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].type).toBe("payment");
+      expect(res.body.data[0].amount).toBe("500");
+      expect(res.body.data[0].asset).toBe("XLM");
+    });
+
+    it("returns trustline items with correct type discriminator", async () => {
+      __seedTrustline(USER_ID, {
+        hash: "b".repeat(64),
+        assetCode: "USDC",
+        assetIssuer: "GISSUER1",
+        limit: "10000",
+        ledgerCloseTime: BASE_TIME,
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].type).toBe("trustline");
+      expect(res.body.data[0].assetCode).toBe("USDC");
+      expect(res.body.data[0].limit).toBe("10000");
+    });
+
+    it("returns contract_event items with correct type discriminator", async () => {
+      __seedContractEvent(USER_ID, {
+        hash: "c".repeat(64),
+        contractId: "CCONTRACT1",
+        topic: "transfer",
+        value: '"100"',
+        ledgerCloseTime: BASE_TIME,
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].type).toBe("contract_event");
+      expect(res.body.data[0].contractId).toBe("CCONTRACT1");
+      expect(res.body.data[0].topic).toBe("transfer");
+    });
+
+    it("combines payments, trustlines, and contract events in a single feed", async () => {
+      __seedPayment(USER_ID, {
+        hash: "p1",
+        amount: "100",
+        asset: "XLM",
+        source: "GSA",
+        destination: "GDA",
+        ledgerCloseTime: "2025-06-01T10:00:00.000Z",
+      });
+      __seedTrustline(USER_ID, {
+        hash: "t1",
+        assetCode: "USDC",
+        assetIssuer: "GISSUER1",
+        limit: "5000",
+        ledgerCloseTime: "2025-06-01T11:00:00.000Z",
+      });
+      __seedContractEvent(USER_ID, {
+        hash: "e1",
+        contractId: "CC1",
+        topic: "swap",
+        value: '"200"',
+        ledgerCloseTime: "2025-06-01T12:00:00.000Z",
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(3);
+      expect(res.body.pagination.total).toBe(3);
+    });
+
+    it("sorts feed items by ledgerCloseTime descending", async () => {
+      __seedPayment(USER_ID, {
+        hash: "early",
+        amount: "10",
+        asset: "XLM",
+        source: "GSA",
+        destination: "GDA",
+        ledgerCloseTime: "2025-01-01T00:00:00.000Z",
+      });
+      __seedPayment(USER_ID, {
+        hash: "middle",
+        amount: "20",
+        asset: "XLM",
+        source: "GSA",
+        destination: "GDA",
+        ledgerCloseTime: "2025-06-01T00:00:00.000Z",
+      });
+      __seedPayment(USER_ID, {
+        hash: "latest",
+        amount: "30",
+        asset: "XLM",
+        source: "GSA",
+        destination: "GDA",
+        ledgerCloseTime: "2025-12-01T00:00:00.000Z",
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((i: { hash: string }) => i.hash)).toEqual([
+        "latest",
+        "middle",
+        "early",
+      ]);
+    });
+
+    it("interleaves different item types in correct time order", async () => {
+      __seedContractEvent(USER_ID, {
+        hash: "e1",
+        contractId: "CC1",
+        topic: "mint",
+        value: '"50"',
+        ledgerCloseTime: "2025-06-01T10:00:00.000Z",
+      });
+      __seedPayment(USER_ID, {
+        hash: "p1",
+        amount: "100",
+        asset: "XLM",
+        source: "GSA",
+        destination: "GDA",
+        ledgerCloseTime: "2025-06-01T12:00:00.000Z",
+      });
+      __seedTrustline(USER_ID, {
+        hash: "t1",
+        assetCode: "USDC",
+        assetIssuer: "GISSUER1",
+        limit: "2000",
+        ledgerCloseTime: "2025-06-01T11:00:00.000Z",
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(3);
+      expect(res.body.data[0].hash).toBe("p1");
+      expect(res.body.data[0].type).toBe("payment");
+      expect(res.body.data[1].hash).toBe("t1");
+      expect(res.body.data[1].type).toBe("trustline");
+      expect(res.body.data[2].hash).toBe("e1");
+      expect(res.body.data[2].type).toBe("contract_event");
+    });
+
+    it("each item carries the fields from its original type", async () => {
+      __seedPayment(USER_ID, {
+        hash: "p1",
+        amount: "250",
+        asset: "USDC",
+        source: "GSOURCE",
+        destination: "GDEST",
+        ledgerCloseTime: BASE_TIME,
+      });
+      __seedTrustline(USER_ID, {
+        hash: "t1",
+        assetCode: "EURT",
+        assetIssuer: "GISSUER2",
+        limit: "9999",
+        ledgerCloseTime: BASE_TIME,
+      });
+
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      const payment = res.body.data.find(
+        (i: { type: string }) => i.type === "payment",
+      );
+      expect(payment.amount).toBe("250");
+      expect(payment.asset).toBe("USDC");
+      expect(payment.source).toBe("GSOURCE");
+      expect(payment.destination).toBe("GDEST");
+
+      const trustline = res.body.data.find(
+        (i: { type: string }) => i.type === "trustline",
+      );
+      expect(trustline.assetCode).toBe("EURT");
+      expect(trustline.assetIssuer).toBe("GISSUER2");
+      expect(trustline.limit).toBe("9999");
+    });
+  });
+
+  describe("pagination", () => {
+    beforeEach(() => {
+      for (let i = 1; i <= 25; i++) {
+        __seedPayment(USER_ID, {
+          hash: `p-${i.toString().padStart(2, "0")}`,
+          amount: String(i * 10),
+          asset: "XLM",
+          source: "GSOURCE",
+          destination: "GDEST",
+          ledgerCloseTime: new Date(
+            2025, 5, i, 12, 0, 0,
+          ).toISOString(),
+        });
+      }
+    });
+
+    it("returns first page with default limit of 20", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(20);
+      expect(res.body.pagination.page).toBe(1);
+      expect(res.body.pagination.limit).toBe(20);
+      expect(res.body.pagination.total).toBe(25);
+      expect(res.body.pagination.totalPages).toBe(2);
+    });
+
+    it("returns second page with remaining items", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed?page=2&limit=20")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(5);
+      expect(res.body.pagination.page).toBe(2);
+      expect(res.body.pagination.total).toBe(25);
+    });
+
+    it("respects custom limit", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed?page=1&limit=5")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(5);
+      expect(res.body.pagination.limit).toBe(5);
+      expect(res.body.pagination.totalPages).toBe(5);
+    });
+
+    it("returns empty array for page beyond total items", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed?page=10&limit=20")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.page).toBe(10);
+      expect(res.body.pagination.total).toBe(25);
+    });
+
+    it("returns 400 for page less than 1", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed?page=0")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_PAGINATION");
+    });
+
+    it("returns 400 for limit exceeding maximum", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed?limit=200")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_PAGINATION");
+    });
+
+    it("returns 400 for non-numeric limit", async () => {
+      const res = await request(app)
+        .get("/account/tx/feed?limit=abc")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_PAGINATION");
+    });
+  });
+
+  describe("authentication", () => {
+    it("returns 401 when x-user-id header is missing", async () => {
+      const res = await request(app).get("/account/tx/feed");
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+});

--- a/routes-d/tests/assets.top.test.ts
+++ b/routes-d/tests/assets.top.test.ts
@@ -1,0 +1,153 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import assetsTopRouter from "../routes/assets.top.js";
+import {
+  __resetTrades,
+  __seedTrade,
+} from "../lib/volumeRollup.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(assetsTopRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const USER_ID = "user-top-1";
+const NOW = Date.now();
+
+describe("GET /assets/top", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetTrades();
+  });
+
+  describe("authentication", () => {
+    it("returns 401 when x-user-id header is missing", async () => {
+      const res = await request(app).get("/assets/top");
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  describe("window parameter validation", () => {
+    it("defaults to 24h window when not specified", async () => {
+      __seedTrade({
+        id: "t1",
+        asset: "XLM",
+        amount: 100,
+        price: 1,
+        timestamp: new Date(NOW),
+      });
+
+      const res = await request(app)
+        .get("/assets/top")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.window).toBe("24h");
+      expect(res.body.data.assets).toHaveLength(1);
+    });
+
+    it("returns 400 for invalid window parameter", async () => {
+      const res = await request(app)
+        .get("/assets/top?window=invalid")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_WINDOW");
+    });
+
+    it("accepts 24h window", async () => {
+      __seedTrade({
+        id: "t1",
+        asset: "XLM",
+        amount: 100,
+        price: 1,
+        timestamp: new Date(NOW),
+      });
+
+      const res = await request(app)
+        .get("/assets/top?window=24h")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.window).toBe("24h");
+    });
+
+    it("accepts 7d window", async () => {
+      const res = await request(app)
+        .get("/assets/top?window=7d")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.window).toBe("7d");
+    });
+
+    it("accepts 30d window", async () => {
+      const res = await request(app)
+        .get("/assets/top?window=30d")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.window).toBe("30d");
+    });
+  });
+
+  describe("response shape", () => {
+    it("returns top assets ranked by volume", async () => {
+      __seedTrade({
+        id: "t1",
+        asset: "XLM",
+        amount: 200,
+        price: 1,
+        timestamp: new Date(NOW),
+      });
+      __seedTrade({
+        id: "t2",
+        asset: "USDC",
+        amount: 50,
+        price: 1,
+        timestamp: new Date(NOW),
+      });
+
+      const res = await request(app)
+        .get("/assets/top")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.assets).toHaveLength(2);
+      expect(res.body.data.assets[0].asset).toBe("XLM");
+      expect(res.body.data.assets[0].volume).toBe(200);
+      expect(res.body.data.assets[0].tradeCount).toBe(1);
+      expect(res.body.data.assets[0].lastPrice).toBe(1);
+    });
+
+    it("includes generatedAt timestamp", async () => {
+      const res = await request(app)
+        .get("/assets/top")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.generatedAt).toBeDefined();
+      expect(new Date(res.body.data.generatedAt).toISOString()).toBe(
+        res.body.data.generatedAt,
+      );
+    });
+
+    it("returns empty assets array when no trades exist", async () => {
+      const res = await request(app)
+        .get("/assets/top")
+        .set("x-user-id", USER_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.assets).toEqual([]);
+    });
+  });
+});

--- a/routes-d/tests/unit/volumeRollup.test.ts
+++ b/routes-d/tests/unit/volumeRollup.test.ts
@@ -1,0 +1,230 @@
+import {
+  recordTrade,
+  getTopAssets,
+  __resetTrades,
+  __seedTrade,
+  __clearCache,
+  __getCacheSize,
+  type Trade,
+} from "../../lib/volumeRollup.js";
+
+const NOW = Date.now();
+const HOUR_MS = 3_600_000;
+
+function trade(
+  overrides: Partial<Trade> & { asset: string },
+): Trade {
+  return {
+    id: overrides.id ?? `trade-${Math.random().toString(36).slice(2)}`,
+    amount: overrides.amount ?? 100,
+    price: overrides.price ?? 1,
+    timestamp: overrides.timestamp ?? new Date(NOW),
+    ...overrides,
+  };
+}
+
+describe("volumeRollup", () => {
+  beforeEach(() => {
+    __resetTrades();
+  });
+
+  describe("getTopAssets", () => {
+    it("returns empty assets for empty trades", () => {
+      const result = getTopAssets("24h");
+      expect(result.window).toBe("24h");
+      expect(result.assets).toEqual([]);
+      expect(result.generatedAt).toBeInstanceOf(Date);
+    });
+
+    it("returns assets ranked by volume descending", () => {
+      __seedTrade(trade({ asset: "XLM", amount: 100, price: 2 }));
+      __seedTrade(trade({ asset: "USDC", amount: 50, price: 1 }));
+      __seedTrade(trade({ asset: "XLM", amount: 50, price: 2 }));
+
+      const result = getTopAssets("24h");
+
+      expect(result.assets).toHaveLength(2);
+      expect(result.assets[0].asset).toBe("XLM");
+      expect(result.assets[0].volume).toBe(300);
+      expect(result.assets[0].tradeCount).toBe(2);
+      expect(result.assets[1].asset).toBe("USDC");
+      expect(result.assets[1].volume).toBe(50);
+      expect(result.assets[1].tradeCount).toBe(1);
+    });
+
+    it("filters trades outside the 24h window", () => {
+      __seedTrade(
+        trade({
+          asset: "XLM",
+          amount: 100,
+          price: 1,
+          timestamp: new Date(NOW - 48 * HOUR_MS),
+        }),
+      );
+      __seedTrade(
+        trade({
+          asset: "XLM",
+          amount: 100,
+          price: 1,
+          timestamp: new Date(NOW - 2 * HOUR_MS),
+        }),
+      );
+
+      const result = getTopAssets("24h");
+      expect(result.assets).toHaveLength(1);
+      expect(result.assets[0].volume).toBe(100);
+    });
+
+    it("filters trades outside the 7d window", () => {
+      __seedTrade(
+        trade({
+          asset: "USDC",
+          amount: 50,
+          price: 1,
+          timestamp: new Date(NOW - 10 * 24 * HOUR_MS),
+        }),
+      );
+      __seedTrade(
+        trade({
+          asset: "USDC",
+          amount: 50,
+          price: 1,
+          timestamp: new Date(NOW - 3 * 24 * HOUR_MS),
+        }),
+      );
+
+      const result7d = getTopAssets("7d");
+      expect(result7d.assets).toHaveLength(1);
+      expect(result7d.assets[0].volume).toBe(50);
+
+      const result30d = getTopAssets("30d");
+      expect(result30d.assets).toHaveLength(1);
+      expect(result30d.assets[0].volume).toBe(100);
+    });
+
+    it("filters trades outside the 30d window", () => {
+      __seedTrade(
+        trade({
+          asset: "BTC",
+          amount: 1,
+          price: 50000,
+          timestamp: new Date(NOW - 60 * 24 * HOUR_MS),
+        }),
+      );
+      __seedTrade(
+        trade({
+          asset: "BTC",
+          amount: 1,
+          price: 51000,
+          timestamp: new Date(NOW - 15 * 24 * HOUR_MS),
+        }),
+      );
+
+      const result = getTopAssets("30d");
+      expect(result.assets).toHaveLength(1);
+      expect(result.assets[0].volume).toBe(51000);
+    });
+
+    it("sets lastPrice to the most recent trade price per asset", () => {
+      __seedTrade(
+        trade({
+          asset: "XLM",
+          amount: 10,
+          price: 1,
+          timestamp: new Date(NOW - 10 * HOUR_MS),
+        }),
+      );
+      __seedTrade(
+        trade({
+          asset: "XLM",
+          amount: 10,
+          price: 2,
+          timestamp: new Date(NOW - 5 * HOUR_MS),
+        }),
+      );
+      __seedTrade(
+        trade({
+          asset: "XLM",
+          amount: 10,
+          price: 3,
+          timestamp: new Date(NOW - HOUR_MS),
+        }),
+      );
+
+      const result = getTopAssets("24h");
+      expect(result.assets[0].lastPrice).toBe(3);
+    });
+
+    it("handles multiple assets with varying trade counts", () => {
+      for (let i = 0; i < 5; i++) {
+        __seedTrade(trade({ asset: "XLM", amount: 10, price: 1 }));
+      }
+      for (let i = 0; i < 3; i++) {
+        __seedTrade(trade({ asset: "USDC", amount: 20, price: 1 }));
+      }
+      __seedTrade(trade({ asset: "ETH", amount: 1, price: 3000 }));
+
+      const result = getTopAssets("24h");
+      expect(result.assets).toHaveLength(3);
+      expect(result.assets[0].asset).toBe("ETH");
+      expect(result.assets[1].asset).toBe("USDC");
+      expect(result.assets[2].asset).toBe("XLM");
+    });
+  });
+
+  describe("cache behavior", () => {
+    it("returns cached result within TTL", () => {
+      __seedTrade(trade({ asset: "XLM", amount: 100, price: 1 }));
+      const first = getTopAssets("24h");
+      expect(__getCacheSize()).toBe(1);
+
+      __seedTrade(trade({ asset: "XLM", amount: 200, price: 1 }));
+      const second = getTopAssets("24h");
+
+      expect(second.assets[0].volume).toBe(first.assets[0].volume);
+      expect(second.generatedAt.getTime()).toBe(first.generatedAt.getTime());
+    });
+
+    it("recomputes after cache is cleared", () => {
+      __seedTrade(trade({ asset: "XLM", amount: 100, price: 1 }));
+      const first = getTopAssets("24h");
+
+      __clearCache();
+      __seedTrade(trade({ asset: "XLM", amount: 200, price: 1 }));
+      const second = getTopAssets("24h");
+
+      expect(second.assets[0].volume).toBe(300);
+    });
+
+    it("recordTrade clears all caches", () => {
+      getTopAssets("24h");
+      getTopAssets("7d");
+      getTopAssets("30d");
+      expect(__getCacheSize()).toBe(3);
+
+      recordTrade(trade({ asset: "XLM", amount: 1, price: 1 }));
+
+      expect(__getCacheSize()).toBe(0);
+    });
+
+    it("caches each window independently", () => {
+      __seedTrade(trade({ asset: "XLM", amount: 100, price: 1 }));
+      const a = getTopAssets("24h");
+      const b = getTopAssets("7d");
+      const c = getTopAssets("30d");
+
+      expect(__getCacheSize()).toBe(3);
+      expect(a.assets[0].volume).toBe(100);
+      expect(b.assets[0].volume).toBe(100);
+      expect(c.assets[0].volume).toBe(100);
+    });
+
+    it("__resetTrades clears caches", () => {
+      getTopAssets("24h");
+      expect(__getCacheSize()).toBe(1);
+
+      __resetTrades();
+      expect(__getCacheSize()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Summary
Add GET /assets/top endpoint that computes and serves a top-assets leaderboard ranked by volume over rolling time windows.

Changes
routes-d/lib/volumeRollup.ts — Volume computation module with in-memory trade store, configurable windows (24h, 7d, 30d), and result caching with 30s TTL. Exports recordTrade, getTopAssets, and test helpers.

routes-d/routes/assets.top.ts — GET /assets/top endpoint supporting window query param (24h default, 7d, 30d). Returns ranked assets with volume, tradeCount, and lastPrice.

routes-d/tests/unit/volumeRollup.test.ts — Unit tests covering: empty trades, volume ranking, window filtering (24h, 7d, 30d), lastPrice tracking, cache TTL retention, cache invalidation, independent window caching, and cache clearing.

routes-d/tests/assets.top.test.ts — Route integration tests covering: auth, default window, invalid window validation, each valid window, response shape, generatedAt timestamp, and empty assets.

closes #385 