### PR TITLE
Add configurable maintenance mode route

### DIFF
--- a/routes-d/middleware/maintenance.ts
+++ b/routes-d/middleware/maintenance.ts
@@ -1,0 +1,91 @@
+import { NextFunction, Request, Response } from "express";
+
+export type MaintenanceConfig = {
+  enabled: boolean;
+  allowlist: string[];
+  retryAfterSeconds: number;
+};
+
+const DEFAULT_RETRY_AFTER_SECONDS = 60;
+
+let maintenanceConfig: MaintenanceConfig = {
+  enabled: false,
+  allowlist: [],
+  retryAfterSeconds: DEFAULT_RETRY_AFTER_SECONDS,
+};
+
+function normalizePath(path: string): string {
+  if (!path) {
+    return "/";
+  }
+
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return "/";
+  }
+
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function isAllowlisted(path: string): boolean {
+  const normalizedPath = normalizePath(path);
+  if (normalizedPath === "/admin/maintenance" || normalizedPath.startsWith("/admin/maintenance/")) {
+    return true;
+  }
+
+  return maintenanceConfig.allowlist.some((entry) => normalizePath(entry) === normalizedPath);
+}
+
+export function setMaintenanceMode(config: Partial<MaintenanceConfig> | MaintenanceConfig): void {
+  maintenanceConfig = {
+    enabled: config.enabled ?? maintenanceConfig.enabled,
+    allowlist: Array.isArray(config.allowlist) ? config.allowlist : maintenanceConfig.allowlist,
+    retryAfterSeconds:
+      typeof config.retryAfterSeconds === "number"
+        ? config.retryAfterSeconds
+        : maintenanceConfig.retryAfterSeconds,
+  };
+}
+
+export function getMaintenanceConfig(): MaintenanceConfig {
+  return {
+    enabled: maintenanceConfig.enabled,
+    allowlist: [...maintenanceConfig.allowlist],
+    retryAfterSeconds: maintenanceConfig.retryAfterSeconds,
+  };
+}
+
+export function __resetMaintenanceState(): void {
+  maintenanceConfig = {
+    enabled: false,
+    allowlist: [],
+    retryAfterSeconds: DEFAULT_RETRY_AFTER_SECONDS,
+  };
+}
+
+export function maintenanceMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (!maintenanceConfig.enabled) {
+    next();
+    return;
+  }
+
+  const requestPath = req.path || "/";
+  if (isAllowlisted(requestPath)) {
+    next();
+    return;
+  }
+
+  res.setHeader("Retry-After", String(maintenanceConfig.retryAfterSeconds));
+  res.status(503).json({
+    error: {
+      code: "MAINTENANCE_MODE",
+      message: "Service temporarily unavailable due to maintenance.",
+    },
+  });
+}
+
+export default maintenanceMiddleware;

--- a/routes-d/routes/admin.maintenance.ts
+++ b/routes-d/routes/admin.maintenance.ts
@@ -1,0 +1,59 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { getMaintenanceConfig, setMaintenanceMode } from "../middleware/maintenance.js";
+
+const router = Router();
+
+type MaintenancePayload = {
+  enabled?: boolean;
+  allowlist?: string[];
+  retryAfterSeconds?: number;
+};
+
+function parsePayload(body: unknown): MaintenancePayload {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+
+  const candidate = body as Record<string, unknown>;
+  return {
+    enabled: typeof candidate.enabled === "boolean" ? candidate.enabled : undefined,
+    allowlist: Array.isArray(candidate.allowlist)
+      ? candidate.allowlist.filter((item): item is string => typeof item === "string")
+      : undefined,
+    retryAfterSeconds:
+      typeof candidate.retryAfterSeconds === "number"
+        ? candidate.retryAfterSeconds
+        : undefined,
+  };
+}
+
+router.post(
+  "/admin/maintenance",
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const payload = parsePayload(req.body);
+      const nextConfig = {
+        enabled: payload.enabled ?? getMaintenanceConfig().enabled,
+        allowlist: payload.allowlist ?? getMaintenanceConfig().allowlist,
+        retryAfterSeconds:
+          payload.retryAfterSeconds ?? getMaintenanceConfig().retryAfterSeconds,
+      };
+
+      setMaintenanceMode(nextConfig);
+
+      return res.status(200).json({
+        success: true,
+        data: getMaintenanceConfig(),
+      });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export { parsePayload };
+export function __resetMaintenanceState(): void {
+  setMaintenanceMode({ enabled: false, allowlist: [], retryAfterSeconds: 60 });
+}
+
+export default router;

--- a/routes-d/tests/admin.maintenance.test.ts
+++ b/routes-d/tests/admin.maintenance.test.ts
@@ -1,0 +1,68 @@
+import express, { NextFunction, Request, Response } from "express";
+import request from "supertest";
+import router, { __resetMaintenanceState } from "../routes/admin.maintenance.js";
+import { maintenanceMiddleware } from "../middleware/maintenance.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(maintenanceMiddleware);
+  app.use(router);
+  app.get("/health", (_req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  });
+  app.get("/api/status", (_req: Request, res: Response) => {
+    res.status(200).json({ status: "ok" });
+  });
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /admin/maintenance", () => {
+  beforeEach(() => {
+    __resetMaintenanceState();
+  });
+
+  it("toggles maintenance mode and allows whitelisted routes", async () => {
+    const app = buildApp();
+
+    const enableRes = await request(app).post("/admin/maintenance").send({
+      enabled: true,
+      allowlist: ["/health"],
+      retryAfterSeconds: 60,
+    });
+
+    expect(enableRes.status).toBe(200);
+    expect(enableRes.body.data.enabled).toBe(true);
+    expect(enableRes.body.data.allowlist).toEqual(["/health"]);
+
+    const healthRes = await request(app).get("/health");
+    expect(healthRes.status).toBe(200);
+
+    const blockedRes = await request(app).get("/api/status");
+    expect(blockedRes.status).toBe(503);
+    expect(blockedRes.headers["retry-after"]).toBe("60");
+  });
+
+  it("disables maintenance mode when requested", async () => {
+    const app = buildApp();
+
+    await request(app).post("/admin/maintenance").send({
+      enabled: true,
+      allowlist: [],
+      retryAfterSeconds: 30,
+    });
+
+    const disableRes = await request(app).post("/admin/maintenance").send({
+      enabled: false,
+      allowlist: [],
+      retryAfterSeconds: 30,
+    });
+
+    expect(disableRes.status).toBe(200);
+    const healthyRes = await request(app).get("/api/status");
+    expect(healthyRes.status).toBe(200);
+  });
+});

--- a/routes-d/tests/unit/maintenance.middleware.test.ts
+++ b/routes-d/tests/unit/maintenance.middleware.test.ts
@@ -1,0 +1,48 @@
+import express, { NextFunction, Request, Response } from "express";
+import request from "supertest";
+import { maintenanceMiddleware, __resetMaintenanceState } from "../../middleware/maintenance.js";
+import adminMaintenanceRouter from "../../routes/admin.maintenance.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(maintenanceMiddleware);
+  app.use(adminMaintenanceRouter);
+  app.get("/health", (_req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  });
+  app.get("/api/status", (_req: Request, res: Response) => {
+    res.status(200).json({ status: "ok" });
+  });
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("maintenance middleware", () => {
+  beforeEach(() => {
+    __resetMaintenanceState();
+  });
+
+  it("blocks non-allowlisted routes with 503 and a Retry-After header", async () => {
+    const app = buildApp();
+
+    const res = await request(app).get("/api/status");
+
+    expect(res.status).toBe(200);
+
+    const enabledRes = await request(app).post("/admin/maintenance").send({
+      enabled: true,
+      allowlist: ["/health"],
+      retryAfterSeconds: 120,
+    });
+
+    expect(enabledRes.status).toBe(200);
+
+    const blockedRes = await request(app).get("/api/status");
+    expect(blockedRes.status).toBe(503);
+    expect(blockedRes.headers["retry-after"]).toBe("120");
+    expect(blockedRes.body.error.code).toBe("MAINTENANCE_MODE");
+  });
+});


### PR DESCRIPTION
# Add configurable maintenance mode endpoint under routes-d

## Summary
Add a configurable maintenance mode flow under routes-d that allows operators to temporarily block non-essential traffic while keeping selected routes available.

## What changed
- Added a maintenance middleware that returns HTTP 503 with a Retry-After header when maintenance is enabled
- Added an allowlist mechanism so selected routes remain accessible during maintenance
- Added an admin route to toggle maintenance mode, allowlist entries, and retry delay
- Added unit and integration tests covering enable/disable behavior, allowlist handling, and Retry-After responses

## Testing
- Verified the new maintenance-mode tests locally with Jest

Closes: #404