### PR TITLE
Add LancePay expense reimbursement route

### DIFF
--- a/routes-d/routes/lancepay.expenses.reimburse.ts
+++ b/routes-d/routes/lancepay.expenses.reimburse.ts
@@ -1,0 +1,94 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type ExpenseStatus = "pending" | "approved" | "reimbursed";
+
+type Expense = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  amount: number;
+  currency: string;
+  status: ExpenseStatus;
+};
+
+type Reimbursement = {
+  id: string;
+  expenseId: string;
+  workspaceId: string;
+  contractorId: string;
+  amount: number;
+  currency: string;
+  status: "reimbursed";
+  payment: {
+    fromWorkspaceId: string;
+    toContractorId: string;
+    currency: string;
+  };
+};
+
+const expenses = new Map<string, Expense>();
+const reimbursements = new Map<string, Reimbursement>();
+
+export function __seedExpense(expense: Expense): void {
+  expenses.set(expense.id, expense);
+}
+
+export function __resetExpenses(): void {
+  expenses.clear();
+}
+
+export function __resetReimbursements(): void {
+  reimbursements.clear();
+}
+
+router.post(
+  "/lancepay/expenses/:id/reimburse",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const expense = expenses.get(id);
+
+      if (!expense) {
+        sendError(res, "EXPENSE_NOT_FOUND", `Expense ${id} not found`, 404);
+        return;
+      }
+
+      if (expense.status !== "approved") {
+        sendError(res, "EXPENSE_NOT_APPROVED", "Expense must be approved before reimbursement", 409);
+        return;
+      }
+
+      const existing = reimbursements.get(id);
+      if (existing) {
+        return res.status(200).json({ success: true, data: existing, idempotent: true });
+      }
+
+      const reimbursement: Reimbursement = {
+        id: `reimb-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        expenseId: expense.id,
+        workspaceId: expense.workspaceId,
+        contractorId: expense.contractorId,
+        amount: expense.amount,
+        currency: expense.currency,
+        status: "reimbursed",
+        payment: {
+          fromWorkspaceId: expense.workspaceId,
+          toContractorId: expense.contractorId,
+          currency: expense.currency,
+        },
+      };
+
+      reimbursements.set(id, reimbursement);
+      expenses.set(id, { ...expense, status: "reimbursed" });
+
+      return res.status(200).json({ success: true, data: reimbursement });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/lancepay.expenses.reimburse.test.ts
+++ b/routes-d/tests/lancepay.expenses.reimburse.test.ts
@@ -1,0 +1,81 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __resetExpenses,
+  __resetReimbursements,
+  __seedExpense,
+} from "../routes/lancepay.expenses.reimburse.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/expenses/:id/reimburse", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetExpenses();
+    __resetReimbursements();
+  });
+
+  it("reimburses an approved expense from workspace funds", async () => {
+    __seedExpense({
+      id: "exp-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      amount: 125,
+      currency: "USD",
+      status: "approved",
+    });
+
+    const res = await request(app).post("/lancepay/expenses/exp-1/reimburse");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.expenseId).toBe("exp-1");
+    expect(res.body.data.status).toBe("reimbursed");
+    expect(res.body.data.payment.fromWorkspaceId).toBe("ws-1");
+    expect(res.body.data.payment.toContractorId).toBe("con-1");
+  });
+
+  it("returns an idempotent response for a duplicate reimbursement request", async () => {
+    __seedExpense({
+      id: "exp-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      amount: 250,
+      currency: "USD",
+      status: "approved",
+    });
+
+    const first = await request(app).post("/lancepay/expenses/exp-2/reimburse");
+    const second = await request(app).post("/lancepay/expenses/exp-2/reimburse");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.idempotent).toBe(true);
+    expect(second.body.data.id).toBe(first.body.data.id);
+  });
+
+  it("rejects reimbursement for an unapproved expense", async () => {
+    __seedExpense({
+      id: "exp-3",
+      workspaceId: "ws-1",
+      contractorId: "con-3",
+      amount: 90,
+      currency: "USD",
+      status: "pending",
+    });
+
+    const res = await request(app).post("/lancepay/expenses/exp-3/reimburse");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("EXPENSE_NOT_APPROVED");
+  });
+});


### PR DESCRIPTION
# Add LancePay expense reimbursement route in routes-d

## Summary
Add a new LancePay expense reimbursement route under routes-d/routes to support reimbursing approved expenses from workspace funds.

## What changed
- Added POST /lancepay/expenses/:id/reimburse in lancepay.expenses.reimburse.ts
- Implemented reimbursement creation from workspace funds to the contractor
- Added idempotent handling for duplicate reimbursement requests
- Added route tests covering:
  - successful reimbursement
  - duplicate reimbursement requests
  - rejection of unapproved expenses

## Notes
- The implementation is scoped to the routes-d folder as requested.

Closes: #591