### PR TITLE
fix: fail fast on --javascript + --template minimal|defi before banner and prompts (#672)

### DIFF
--- a/bin/nextellar.ts
+++ b/bin/nextellar.ts
@@ -262,6 +262,16 @@ program.action(async (projectName, options) => {
     return await exitWithTelemetry(1);
   }
 
+  if (!useTs && template !== "default") {
+    console.error(
+      pc.red(
+        `--javascript (or --no-typescript) currently only supports the default template. ` +
+          `Use --template default or omit --javascript/--no-typescript.`,
+      ),
+    );
+    return await exitWithTelemetry(1);
+  }
+
   // Clear console and show welcome banner
   if (process.stdout.isTTY) {
     process.stdout.write("\x1Bc");

--- a/tests/cli-entry.test.ts
+++ b/tests/cli-entry.test.ts
@@ -7,16 +7,17 @@ import { dirname } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('nextellar CLI', () => {
-  const tmpDir = path.join(__dirname, 'tmp-test-app');
+const cli = path.resolve(__dirname, '../dist/bin/nextellar.js');
+const tmpDir = path.join(__dirname, 'tmp-test-app');
 
+describe('nextellar CLI', () => {
   beforeEach(async () => {
     await fs.remove(tmpDir);
   }, 10000);
 
   it('should scaffold a new project and exit cleanly', async () => {
     const { exitCode, stdout } = await execa('node', [
-      path.resolve(__dirname, '../dist/bin/nextellar.js'),
+      cli,
       tmpDir,
       '--typescript',
       '--defaults',
@@ -25,5 +26,41 @@ describe('nextellar CLI', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain('✔ Nextellar scaffold complete!');
     expect(await fs.pathExists(tmpDir)).toBe(true);
+  }, 30000);
+
+  it('should fail fast on --javascript --template minimal before banner and prompts', async () => {
+    const { exitCode, stderr, stdout } = await execa('node', [
+      cli,
+      tmpDir,
+      '--javascript',
+      '--template',
+      'minimal',
+      '--defaults'
+    ], { reject: false });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--javascript');
+    expect(stderr).toContain('default template');
+    // Should fail before banner clears console
+    expect(stdout).not.toContain('Nextellar CLI');
+    expect(stdout).not.toContain('Nextellar scaffold complete');
+    expect(await fs.pathExists(tmpDir)).toBe(false);
+  }, 30000);
+
+  it('should fail fast on --javascript --template defi before banner and prompts', async () => {
+    const { exitCode, stderr, stdout } = await execa('node', [
+      cli,
+      tmpDir,
+      '--javascript',
+      '--template',
+      'defi',
+      '--defaults'
+    ], { reject: false });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('--javascript');
+    expect(stderr).toContain('default template');
+    // Should fail before banner clears console
+    expect(stdout).not.toContain('Nextellar CLI');
+    expect(stdout).not.toContain('Nextellar scaffold complete');
+    expect(await fs.pathExists(tmpDir)).toBe(false);
   }, 30000);
 });


### PR DESCRIPTION
## Summary

Move the JS/template-compatibility check next to the existing template-name validation in  so it fails **before** the banner clears the console and interactive prompts run.

## Changes

- **bin/nextellar.ts**: Added validation at line 255-263 that checks if  (or ) is used with a non-default template (, ). Exits with code 1 and clear error message immediately.
- **src/lib/scaffold.ts**: Kept defensive check (lines 56-60) for programmatic callers.
- **tests/cli-entry.test.ts**: Added two test cases verifying fast-fail behavior for both  and  with .

## Verification

- All 3 CLI tests pass
- Manual testing:
  -  → exits 1 immediately with clear message
  -  → exits 1 immediately with clear message
  -  → works (default template)
  -  → works (TypeScript)

## Acceptance Criteria

- [x]  exits 1 immediately with clear message; no banner-clear, no prompts
- [x] Covered in tests/cli-entry.test.ts
- [ ] Behavior documented (coordinate with nextellar-docs flags page - separate repo)

Closes #672