### PR TITLE
feat: add GET /lancepay/timesheets route with filtering and pagination

### DIFF
--- a/routes-d/routes/lancepay.timesheets.list.ts
+++ b/routes-d/routes/lancepay.timesheets.list.ts
@@ -1,0 +1,144 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type TimesheetStatus = "draft" | "submitted" | "approved" | "rejected" | "paid";
+
+type TimesheetRecord = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  status: TimesheetStatus;
+  payPeriodStart: string;
+  payPeriodEnd: string;
+  hoursWorked: number;
+  amountDue: number;
+  currency: string;
+  submittedAt: string;
+  createdAt: string;
+};
+
+const timesheets = new Map<string, TimesheetRecord>();
+
+/**
+ * GET /lancepay/timesheets
+ * List timesheets visible to the caller through their workspace.
+ * Query params: contractorId, status, payPeriodStart, payPeriodEnd, page, limit
+ * Paginated and sorted by submission time (submittedAt) descending.
+ */
+router.get(
+  "/lancepay/timesheets",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const workspaceId = req.headers["x-workspace-id"] as string | undefined;
+      
+      if (!workspaceId) {
+        sendError(res, "UNAUTHORIZED", "x-workspace-id header is required", 401);
+        return;
+      }
+
+      const { 
+        contractorId, 
+        status, 
+        payPeriodStart,
+        payPeriodEnd,
+        page = "1", 
+        limit = "20" 
+      } = req.query;
+
+      const pageNum = parseInt(String(page), 10);
+      const limitNum = parseInt(String(limit), 10);
+
+      if (isNaN(pageNum) || pageNum < 1) {
+        sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+        return;
+      }
+
+      if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+        sendError(res, "INVALID_LIMIT", "limit must be between 1 and 100", 400);
+        return;
+      }
+
+      // Start with timesheets for this workspace
+      let filtered = Array.from(timesheets.values()).filter(
+        (t) => t.workspaceId === workspaceId
+      );
+
+      // Filter by contractorId
+      if (contractorId && typeof contractorId === "string") {
+        filtered = filtered.filter((t) => t.contractorId === contractorId.trim());
+      }
+
+      // Filter by status
+      if (status && typeof status === "string") {
+        filtered = filtered.filter((t) => t.status === status.trim());
+      }
+
+      // Filter by pay period start date
+      if (payPeriodStart && typeof payPeriodStart === "string") {
+        const startDate = new Date(payPeriodStart);
+        if (isNaN(startDate.getTime())) {
+          sendError(res, "INVALID_DATE", "payPeriodStart must be a valid ISO 8601 date", 400);
+          return;
+        }
+        filtered = filtered.filter((t) => {
+          const tStart = new Date(t.payPeriodStart);
+          return tStart >= startDate;
+        });
+      }
+
+      // Filter by pay period end date
+      if (payPeriodEnd && typeof payPeriodEnd === "string") {
+        const endDate = new Date(payPeriodEnd);
+        if (isNaN(endDate.getTime())) {
+          sendError(res, "INVALID_DATE", "payPeriodEnd must be a valid ISO 8601 date", 400);
+          return;
+        }
+        filtered = filtered.filter((t) => {
+          const tEnd = new Date(t.payPeriodEnd);
+          return tEnd <= endDate;
+        });
+      }
+
+      // Sort by submission time descending (most recent first)
+      filtered.sort((a, b) => {
+        const aTime = new Date(a.submittedAt).getTime();
+        const bTime = new Date(b.submittedAt).getTime();
+        return bTime - aTime;
+      });
+
+      // Paginate
+      const offset = (pageNum - 1) * limitNum;
+      const paged = filtered.slice(offset, offset + limitNum);
+
+      return res.status(200).json({
+        success: true,
+        data: paged,
+        pagination: {
+          page: pageNum,
+          limit: limitNum,
+          total: filtered.length,
+          hasNext: offset + limitNum < filtered.length,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  }
+);
+
+// Test helpers
+export function __seedTimesheet(t: TimesheetRecord): void {
+  timesheets.set(t.id, { ...t });
+}
+
+export function __resetTimesheets(): void {
+  timesheets.clear();
+}
+
+export function __getTimesheets(): Map<string, TimesheetRecord> {
+  return timesheets;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.timesheets.list.test.ts
+++ b/routes-d/tests/lancepay.timesheets.list.test.ts
@@ -1,0 +1,475 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedTimesheet,
+  __resetTimesheets,
+  __getTimesheets,
+} from "../routes/lancepay.timesheets.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /lancepay/timesheets", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetTimesheets();
+  });
+
+  it("returns empty list when no timesheets exist", async () => {
+    const res = await request(app)
+      .get("/lancepay/timesheets")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("returns 401 when x-workspace-id header is missing", async () => {
+    const res = await request(app).get("/lancepay/timesheets");
+    
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns all timesheets for workspace when no filters applied", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date(Date.now() - 1000).toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "approved",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date(Date.now() - 2000).toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.pagination.total).toBe(2);
+  });
+
+  it("filters timesheets by workspace (does not leak across workspaces)", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-2",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("ts-1");
+  });
+
+  it("filters by contractorId", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets?contractorId=con-1")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].contractorId).toBe("con-1");
+  });
+
+  it("filters by status", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "approved",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets?status=approved")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].status).toBe("approved");
+  });
+
+  it("filters by pay period start date", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "submitted",
+      payPeriodStart: "2026-02-01T00:00:00Z",
+      payPeriodEnd: "2026-02-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets?payPeriodStart=2026-01-15T00:00:00Z")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("ts-2");
+  });
+
+  it("filters by pay period end date", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "submitted",
+      payPeriodStart: "2026-02-01T00:00:00Z",
+      payPeriodEnd: "2026-02-28T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets?payPeriodEnd=2026-01-31T23:59:59Z")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("ts-1");
+  });
+
+  it("returns 400 for invalid payPeriodStart date", async () => {
+    const res = await request(app)
+      .get("/lancepay/timesheets?payPeriodStart=invalid-date")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DATE");
+  });
+
+  it("returns 400 for invalid payPeriodEnd date", async () => {
+    const res = await request(app)
+      .get("/lancepay/timesheets?payPeriodEnd=not-a-date")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DATE");
+  });
+
+  it("sorts by submission time descending (most recent first)", async () => {
+    const now = Date.now();
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date(now - 5000).toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date(now - 1000).toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-3",
+      workspaceId: "ws-1",
+      contractorId: "con-3",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 70,
+      amountDue: 3500,
+      currency: "USD",
+      submittedAt: new Date(now - 3000).toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].id).toBe("ts-2"); // most recent
+    expect(res.body.data[1].id).toBe("ts-3"); // middle
+    expect(res.body.data[2].id).toBe("ts-1"); // oldest
+  });
+
+  it("paginates results", async () => {
+    for (let i = 1; i <= 25; i++) {
+      __seedTimesheet({
+        id: `ts-${i}`,
+        workspaceId: "ws-1",
+        contractorId: `con-${i}`,
+        status: "submitted",
+        payPeriodStart: "2026-01-01T00:00:00Z",
+        payPeriodEnd: "2026-01-15T23:59:59Z",
+        hoursWorked: 80,
+        amountDue: 4000,
+        currency: "USD",
+        submittedAt: new Date(Date.now() - i * 1000).toISOString(),
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    const page1 = await request(app)
+      .get("/lancepay/timesheets?page=1&limit=10")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(page1.status).toBe(200);
+    expect(page1.body.data.length).toBe(10);
+    expect(page1.body.pagination.page).toBe(1);
+    expect(page1.body.pagination.limit).toBe(10);
+    expect(page1.body.pagination.total).toBe(25);
+    expect(page1.body.pagination.hasNext).toBe(true);
+
+    const page2 = await request(app)
+      .get("/lancepay/timesheets?page=2&limit=10")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(page2.status).toBe(200);
+    expect(page2.body.data.length).toBe(10);
+    expect(page2.body.pagination.page).toBe(2);
+    expect(page2.body.pagination.hasNext).toBe(true);
+
+    const page3 = await request(app)
+      .get("/lancepay/timesheets?page=3&limit=10")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(page3.status).toBe(200);
+    expect(page3.body.data.length).toBe(5);
+    expect(page3.body.pagination.hasNext).toBe(false);
+  });
+
+  it("returns 400 for invalid page", async () => {
+    const res = await request(app)
+      .get("/lancepay/timesheets?page=0")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGE");
+  });
+
+  it("returns 400 for invalid limit", async () => {
+    const res = await request(app)
+      .get("/lancepay/timesheets?limit=101")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LIMIT");
+  });
+
+  it("combines multiple filters", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "approved",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-2",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 60,
+      amountDue: 3000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    __seedTimesheet({
+      id: "ts-3",
+      workspaceId: "ws-1",
+      contractorId: "con-2",
+      status: "approved",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 70,
+      amountDue: 3500,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets?contractorId=con-1&status=approved")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("ts-1");
+    expect(res.body.data[0].contractorId).toBe("con-1");
+    expect(res.body.data[0].status).toBe("approved");
+  });
+
+  it("returns empty list when filters match nothing", async () => {
+    __seedTimesheet({
+      id: "ts-1",
+      workspaceId: "ws-1",
+      contractorId: "con-1",
+      status: "submitted",
+      payPeriodStart: "2026-01-01T00:00:00Z",
+      payPeriodEnd: "2026-01-15T23:59:59Z",
+      hoursWorked: 80,
+      amountDue: 4000,
+      currency: "USD",
+      submittedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get("/lancepay/timesheets?contractorId=non-existent")
+      .set("x-workspace-id", "ws-1");
+    
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+});


### PR DESCRIPTION
- Implement lancepay.timesheets.list.ts route handler
- Add filtering by contractorId, status, and pay period dates
- Add pagination with page/limit (limit 1-100)
- Sort by submittedAt descending
- Include comprehensive test suite covering:
  - Empty list scenario
  - Authorization and workspace isolation
  - Individual and combined filters
  - Pagination with hasNext indicator
  - Date validation and error handling
- Follow existing LancePay route patterns and conventions


closes   #585