### PR TITLE
Add LancePay expense approval route

### DIFF
--- a/routes-d/routes/lancepay.expenses.approve.ts
+++ b/routes-d/routes/lancepay.expenses.approve.ts
@@ -1,0 +1,114 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type ExpenseStatus = "submitted" | "approved" | "rejected";
+
+type Expense = {
+  id: string;
+  workspaceId: string;
+  amount: number;
+  status: ExpenseStatus;
+  approverId?: string;
+};
+
+type PayoutDraft = {
+  id: string;
+  expenseId: string;
+  workspaceId: string;
+  amount: number;
+  status: "draft";
+  createdAt: string;
+};
+
+type ApproveBody = {
+  approverId?: string;
+  approverRole?: string;
+};
+
+const expenses = new Map<string, Expense>();
+const payoutDrafts: PayoutDraft[] = [];
+
+/**
+ * POST /lancepay/expenses/:id/approve
+ * Approve a submitted LancePay expense and queue a reimbursement draft.
+ */
+router.post(
+  "/lancepay/expenses/:id/approve",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const expenseId = req.params.id?.trim();
+      if (!expenseId) {
+        sendError(res, "INVALID_EXPENSE_ID", "expenseId is required", 400);
+        return;
+      }
+
+      const body = req.body as ApproveBody;
+      const approverId = typeof body.approverId === "string" ? body.approverId.trim() : "";
+      const approverRole = typeof body.approverRole === "string" ? body.approverRole.trim() : "";
+
+      if (!approverId || approverRole !== "workspace-approver") {
+        sendError(res, "FORBIDDEN", "workspace approver role required", 403);
+        return;
+      }
+
+      const expense = expenses.get(expenseId);
+      if (!expense) {
+        sendError(res, "NOT_FOUND", "Expense not found", 404);
+        return;
+      }
+
+      if (expense.status === "approved") {
+        sendError(res, "ALREADY_APPROVED", "Expense is already approved", 409);
+        return;
+      }
+
+      expense.status = "approved";
+      expense.approverId = approverId;
+
+      const payoutDraft: PayoutDraft = {
+        id: `payout-${expense.id}-${Date.now()}`,
+        expenseId: expense.id,
+        workspaceId: expense.workspaceId,
+        amount: expense.amount,
+        status: "draft",
+        createdAt: new Date().toISOString(),
+      };
+      payoutDrafts.push(payoutDraft);
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          expenseId: expense.id,
+          status: expense.status,
+          approverId: expense.approverId,
+          payoutDraftQueued: true,
+          payoutDraftId: payoutDraft.id,
+        },
+        message: "Expense approved and reimbursement payout draft queued",
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedExpense(expense: Expense): void {
+  expenses.set(expense.id, { ...expense });
+}
+
+export function __getExpense(id: string): Expense | undefined {
+  return expenses.get(id);
+}
+
+export function __getPayoutDrafts(): PayoutDraft[] {
+  return payoutDrafts.slice();
+}
+
+export function __resetExpenses(): void {
+  expenses.clear();
+  payoutDrafts.length = 0;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.expenses.approve.test.ts
+++ b/routes-d/tests/lancepay.expenses.approve.test.ts
@@ -1,0 +1,92 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedExpense,
+  __getExpense,
+  __getPayoutDrafts,
+  __resetExpenses,
+} from "../routes/lancepay.expenses.approve.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/expenses/:id/approve", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetExpenses();
+  });
+
+  it("approves an expense and queues a reimbursement payout draft", async () => {
+    __seedExpense({
+      id: "exp-1",
+      workspaceId: "ws-1",
+      amount: 125,
+      status: "submitted",
+      approverId: undefined,
+    });
+
+    const res = await request(app)
+      .post("/lancepay/expenses/exp-1/approve")
+      .send({ approverId: "approver-1", approverRole: "workspace-approver" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.payoutDraftQueued).toBe(true);
+
+    const expense = __getExpense("exp-1");
+    expect(expense?.status).toBe("approved");
+    expect(expense?.approverId).toBe("approver-1");
+
+    const payoutDrafts = __getPayoutDrafts();
+    expect(payoutDrafts).toHaveLength(1);
+    expect(payoutDrafts[0]).toMatchObject({
+      expenseId: "exp-1",
+      workspaceId: "ws-1",
+      amount: 125,
+      status: "draft",
+    });
+  });
+
+  it("rejects an expense that is already approved", async () => {
+    __seedExpense({
+      id: "exp-2",
+      workspaceId: "ws-1",
+      amount: 75,
+      status: "approved",
+      approverId: "approver-1",
+    });
+
+    const res = await request(app)
+      .post("/lancepay/expenses/exp-2/approve")
+      .send({ approverId: "approver-2", approverRole: "workspace-approver" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_APPROVED");
+  });
+
+  it("rejects a non-approver", async () => {
+    __seedExpense({
+      id: "exp-3",
+      workspaceId: "ws-2",
+      amount: 50,
+      status: "submitted",
+      approverId: undefined,
+    });
+
+    const res = await request(app)
+      .post("/lancepay/expenses/exp-3/approve")
+      .send({ approverId: "user-1", approverRole: "contractor" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+});


### PR DESCRIPTION
# Add LancePay expense approval route


The new LancePay expense approval route is implemented


### What was added
- Route: lancepay.expenses.approve.ts
- Tests: lancepay.expenses.approve.test.ts

### Behavior implemented
- Accepts POST to /lancepay/expenses/:id/approve
- Requires a workspace approver role
- Approves the expense and queues a reimbursement payout draft
- Rejects already approved expenses with 409
- Rejects unauthorized approvers with 403

### Verification
I verified it with:
- npm test -- --runInBand lancepay.expenses.approve.test.ts

Result:
- 1 test suite passed
- 3 tests passed

### Branch and remote
- Branch: task/lancepay-expense-approval-routes-d
- Pushed to: https://github.com/chiemezie1/nextellar

Closes: #590 