### PR TITLE
feat(routes-d): add feature flag service and notification preferences…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "^1.11.1",
         "commander": "^14.0.0",
         "execa": "^9.6.0",
-        "express": "^5.2.1",
         "fs-extra": "^11.3.0",
         "gradient-string": "^3.0.0",
         "jsonwebtoken": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@unrs/resolver-binding-win32-x64-msvc": "^1.11.1",
     "commander": "^14.0.0",
     "execa": "^9.6.0",
-    "express": "^5.2.1",
     "fs-extra": "^11.3.0",
     "gradient-string": "^3.0.0",
     "jsonwebtoken": "^9.0.3",

--- a/routes-d/lib/featureFlags.ts
+++ b/routes-d/lib/featureFlags.ts
@@ -1,0 +1,277 @@
+/**
+ * Feature Flag Service – routes-d/lib/featureFlags.ts
+ *
+ * Provides stable per-user bucketing and hot-reload of flag definitions from
+ * environment variables.
+ *
+ * Flag values are sourced from process.env:
+ *
+ *   FEATURE_FLAGS_JSON  – JSON string: { "flag-name": { "enabled": true, "rollout": 0.5 } }
+ *
+ * When FEATURE_FLAGS_JSON is absent or unparseable the service falls back to
+ * DEFAULT_FLAG_DEFINITIONS, so tests and local dev work with zero config.
+ *
+ * Bucketing algorithm
+ * -------------------
+ * A user is "in" a flag when:
+ *
+ *   hash(userId + flagName) % 100  <  rollout * 100
+ *
+ * where hash() is a stable, deterministic 32-bit integer derived from the string.
+ * The same userId + flagName pair always produces the same bucket, regardless of
+ * how many times the service is reloaded.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FlagDefinition {
+  /** Whether the flag exists and is active at all. */
+  enabled: boolean;
+  /**
+   * Fraction of users that should see this flag (0.0 – 1.0).
+   * 1.0 = everyone, 0.0 = nobody.  Defaults to 1.0 when omitted.
+   */
+  rollout?: number;
+  /** Optional human-readable description for the /flags/status endpoint. */
+  description?: string;
+}
+
+export interface FlagMap {
+  [flagName: string]: FlagDefinition;
+}
+
+export interface FlagStatus {
+  flags: Record<
+    string,
+    {
+      enabled: boolean;
+      rollout: number;
+      description: string;
+    }
+  >;
+  loadedAt: string;
+  source: 'env' | 'default';
+}
+
+// ---------------------------------------------------------------------------
+// Default flag definitions (used when no env is present)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FLAG_DEFINITIONS: FlagMap = {
+  'stellar-soroban-v2': {
+    enabled: true,
+    rollout: 1.0,
+    description: 'Enable Soroban v2 contract interactions',
+  },
+  'wallet-backup-prompt': {
+    enabled: true,
+    rollout: 0.5,
+    description: 'Show wallet backup reminder prompt to 50 % of users',
+  },
+  'defi-yield-farming': {
+    enabled: false,
+    rollout: 0.0,
+    description: 'DeFi yield farming – currently disabled',
+  },
+  'notification-prefs-v2': {
+    enabled: true,
+    rollout: 1.0,
+    description: 'Notification preferences v2 UI',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+let _flags: FlagMap = { ...DEFAULT_FLAG_DEFINITIONS };
+let _loadedAt: Date = new Date();
+let _source: 'env' | 'default' = 'default';
+
+// ---------------------------------------------------------------------------
+// Deterministic hash helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * djb2-style 32-bit hash of an arbitrary string.
+ * Always returns a non-negative integer.
+ */
+function hashString(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    // (h << 5) + h  =  h * 33
+    h = ((h << 5) + h + s.charCodeAt(i)) >>> 0; // keep unsigned 32-bit
+  }
+  return h;
+}
+
+/**
+ * Maps a userId + flagName to a bucket in [0, 100).
+ * This value is stable as long as the inputs don't change.
+ */
+export function getBucket(userId: string, flagName: string): number {
+  return hashString(`${userId}:${flagName}`) % 100;
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate a raw FlagMap-shaped value.
+ * Returns null if the value cannot be coerced into a valid FlagMap.
+ */
+function parseFlagMap(raw: unknown): FlagMap | null {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return null;
+  }
+
+  const result: FlagMap = {};
+
+  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof val !== 'object' || val === null) continue;
+    const v = val as Record<string, unknown>;
+
+    if (typeof v.enabled !== 'boolean') continue;
+
+    const rollout =
+      typeof v.rollout === 'number'
+        ? Math.max(0, Math.min(1, v.rollout))
+        : 1.0;
+
+    result[key] = {
+      enabled: v.enabled,
+      rollout,
+      description: typeof v.description === 'string' ? v.description : '',
+    };
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * (Re)load flag definitions from FEATURE_FLAGS_JSON environment variable.
+ *
+ * This is the "hot reload" entry-point – call it whenever you want the service
+ * to pick up a new config (e.g. on SIGHUP, periodically, or in a test).
+ *
+ * @returns `true` when env-provided flags were loaded, `false` when falling
+ *          back to defaults.
+ */
+export function reloadFlags(): boolean {
+  const raw = process.env['FEATURE_FLAGS_JSON'];
+
+  if (raw) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      const flags = parseFlagMap(parsed);
+
+      if (flags) {
+        _flags = flags;
+        _loadedAt = new Date();
+        _source = 'env';
+        return true;
+      }
+    } catch {
+      // fall through to defaults
+    }
+  }
+
+  _flags = { ...DEFAULT_FLAG_DEFINITIONS };
+  _loadedAt = new Date();
+  _source = 'default';
+  return false;
+}
+
+// Perform initial load at module initialisation time.
+reloadFlags();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a named flag is enabled for a specific user.
+ *
+ * A flag is enabled for a user when:
+ *   1. The flag definition exists and its `enabled` property is `true`.
+ *   2. The user falls within the flag's rollout percentage (stable bucketing).
+ *
+ * Unknown flags are treated as disabled (returns `false`).
+ */
+export function isFlagEnabled(flagName: string, userId: string): boolean {
+  const def = _flags[flagName];
+  if (!def || !def.enabled) return false;
+
+  const rollout = def.rollout ?? 1.0;
+  if (rollout >= 1.0) return true;
+  if (rollout <= 0.0) return false;
+
+  const bucket = getBucket(userId, flagName);
+  return bucket < rollout * 100;
+}
+
+/**
+ * Return all flags and their evaluated state for a specific user.
+ * Useful for the /flags/status endpoint when an authenticated user is present.
+ */
+export function getFlagsForUser(userId: string): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  for (const flagName of Object.keys(_flags)) {
+    result[flagName] = isFlagEnabled(flagName, userId);
+  }
+  return result;
+}
+
+/**
+ * Return a snapshot of all current flag definitions and metadata.
+ * This is the raw config view – no user bucketing applied.
+ */
+export function getFlagStatus(): FlagStatus {
+  const flags: FlagStatus['flags'] = {};
+
+  for (const [name, def] of Object.entries(_flags)) {
+    flags[name] = {
+      enabled: def.enabled,
+      rollout: def.rollout ?? 1.0,
+      description: def.description ?? '',
+    };
+  }
+
+  return {
+    flags,
+    loadedAt: _loadedAt.toISOString(),
+    source: _source,
+  };
+}
+
+/**
+ * Return the raw flag definition map (for testing / introspection).
+ */
+export function getRawFlags(): Readonly<FlagMap> {
+  return { ..._flags };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers  (prefixed with __ by convention in this codebase)
+// ---------------------------------------------------------------------------
+
+/**
+ * Override the entire flag map.  Useful in tests to inject known state.
+ */
+export function __setFlags(flags: FlagMap): void {
+  _flags = { ...flags };
+  _loadedAt = new Date();
+  _source = 'default';
+}
+
+/**
+ * Reset to the module defaults (DEFAULT_FLAG_DEFINITIONS).
+ */
+export function __resetFlags(): void {
+  _flags = { ...DEFAULT_FLAG_DEFINITIONS };
+  _loadedAt = new Date();
+  _source = 'default';
+}

--- a/routes-d/routes/flags.ts
+++ b/routes-d/routes/flags.ts
@@ -1,0 +1,96 @@
+/**
+ * routes-d/routes/flags.ts
+ *
+ * Exposes flag status information via HTTP.
+ *
+ *   GET  /flags/status          – raw config snapshot (no user bucketing)
+ *   GET  /flags/user            – per-user flag evaluation (requires x-user-id header)
+ *   POST /flags/reload          – hot-reload flags from FEATURE_FLAGS_JSON env var
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  getFlagStatus,
+  getFlagsForUser,
+  reloadFlags,
+} from '../lib/featureFlags.js';
+import { sendError } from '../lib/response.js';
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// GET /flags/status
+// Returns a raw snapshot of all current flag definitions and metadata.
+// ---------------------------------------------------------------------------
+router.get(
+  '/flags/status',
+  (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const status = getFlagStatus();
+      return res.status(200).json({
+        success: true,
+        data: status,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// GET /flags/user
+// Returns per-user evaluated flags (true/false per flag).
+// Requires x-user-id header.
+// ---------------------------------------------------------------------------
+router.get(
+  '/flags/user',
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers['x-user-id'] as string | undefined;
+
+      if (!userId || userId.trim() === '') {
+        sendError(res, 'UNAUTHORIZED', 'x-user-id header is required', 401);
+        return;
+      }
+
+      const flags = getFlagsForUser(userId.trim());
+
+      return res.status(200).json({
+        success: true,
+        data: { userId: userId.trim(), flags },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /flags/reload
+// Triggers a hot-reload of flag definitions from FEATURE_FLAGS_JSON.
+// Returns whether new env-based flags were loaded or defaults were used.
+// ---------------------------------------------------------------------------
+router.post(
+  '/flags/reload',
+  (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const loaded = reloadFlags();
+      const status = getFlagStatus();
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          reloaded: true,
+          source: status.source,
+          loadedAt: status.loadedAt,
+          flagCount: Object.keys(status.flags).length,
+          envProvided: loaded,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/routes/notifications.prefs.ts
+++ b/routes-d/routes/notifications.prefs.ts
@@ -1,0 +1,272 @@
+/**
+ * routes-d/routes/notifications.prefs.ts
+ *
+ * Notification preference management endpoints.
+ *
+ *   GET   /notifications/preferences     – return current prefs for the user
+ *   PATCH /notifications/preferences     – update one or more event-class channels
+ *
+ * Supported event classes and channels
+ * -------------------------------------
+ *
+ *   Event classes: payment | transfer | security | marketing | system
+ *   Channels per class: email | sms | push | in_app
+ *
+ * Default baseline (all users start here unless they have saved prefs):
+ *
+ *   payment:   email, in_app
+ *   transfer:  email, in_app
+ *   security:  email, sms, push, in_app  (all channels – security is critical)
+ *   marketing: email
+ *   system:    email, in_app
+ *
+ * Validation rules
+ * ----------------
+ * - Unknown event classes are rejected (400 UNKNOWN_EVENT_CLASS).
+ * - Unknown channels within a known class are rejected (400 UNSUPPORTED_CHANNEL).
+ * - The value must be an array; non-array values are rejected (400 INVALID_CHANNEL_LIST).
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { sendError } from '../lib/response.js';
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Channel = 'email' | 'sms' | 'push' | 'in_app';
+export type EventClass =
+  | 'payment'
+  | 'transfer'
+  | 'security'
+  | 'marketing'
+  | 'system';
+
+export type NotificationPreferences = Record<EventClass, Channel[]>;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SUPPORTED_CHANNELS: ReadonlySet<Channel> = new Set([
+  'email',
+  'sms',
+  'push',
+  'in_app',
+]);
+
+export const SUPPORTED_EVENT_CLASSES: ReadonlySet<EventClass> = new Set([
+  'payment',
+  'transfer',
+  'security',
+  'marketing',
+  'system',
+]);
+
+/**
+ * Documented default baseline: new users start with these preferences.
+ */
+export const DEFAULT_NOTIFICATION_PREFS: Readonly<NotificationPreferences> = {
+  payment: ['email', 'in_app'],
+  transfer: ['email', 'in_app'],
+  security: ['email', 'sms', 'push', 'in_app'],
+  marketing: ['email'],
+  system: ['email', 'in_app'],
+};
+
+// ---------------------------------------------------------------------------
+// In-memory store (per-user, keyed by userId)
+// ---------------------------------------------------------------------------
+
+const prefsStore = new Map<string, NotificationPreferences>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getPrefsForUser(userId: string): NotificationPreferences {
+  const stored = prefsStore.get(userId);
+  if (stored) return stored;
+
+  // Return a deep copy of defaults so mutations don't affect the constant.
+  return {
+    payment: [...DEFAULT_NOTIFICATION_PREFS.payment],
+    transfer: [...DEFAULT_NOTIFICATION_PREFS.transfer],
+    security: [...DEFAULT_NOTIFICATION_PREFS.security],
+    marketing: [...DEFAULT_NOTIFICATION_PREFS.marketing],
+    system: [...DEFAULT_NOTIFICATION_PREFS.system],
+  };
+}
+
+function deduplicateChannels(channels: Channel[]): Channel[] {
+  return [...new Set(channels)];
+}
+
+type UpdatePayload = Partial<Record<EventClass, unknown>>;
+
+interface ValidationError {
+  field: string;
+  code: string;
+  message: string;
+}
+
+function validateUpdate(body: UpdatePayload): ValidationError | null {
+  for (const [key, value] of Object.entries(body)) {
+    // Reject unknown event classes.
+    if (!SUPPORTED_EVENT_CLASSES.has(key as EventClass)) {
+      return {
+        field: key,
+        code: 'UNKNOWN_EVENT_CLASS',
+        message: `Unknown event class: "${key}". Supported classes: ${[...SUPPORTED_EVENT_CLASSES].join(', ')}`,
+      };
+    }
+
+    // Value must be an array.
+    if (!Array.isArray(value)) {
+      return {
+        field: key,
+        code: 'INVALID_CHANNEL_LIST',
+        message: `Channels for "${key}" must be an array`,
+      };
+    }
+
+    // Each item must be a known channel.
+    for (const ch of value) {
+      if (!SUPPORTED_CHANNELS.has(ch as Channel)) {
+        return {
+          field: key,
+          code: 'UNSUPPORTED_CHANNEL',
+          message: `Unsupported channel "${ch}" for event class "${key}". Supported channels: ${[...SUPPORTED_CHANNELS].join(', ')}`,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// GET /notifications/preferences
+// ---------------------------------------------------------------------------
+router.get(
+  '/notifications/preferences',
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers['x-user-id'] as string | undefined;
+
+      if (!userId || userId.trim() === '') {
+        sendError(res, 'UNAUTHORIZED', 'x-user-id header is required', 401);
+        return;
+      }
+
+      const prefs = getPrefsForUser(userId.trim());
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          userId: userId.trim(),
+          preferences: prefs,
+          isDefault: !prefsStore.has(userId.trim()),
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// PATCH /notifications/preferences
+// ---------------------------------------------------------------------------
+router.patch(
+  '/notifications/preferences',
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers['x-user-id'] as string | undefined;
+
+      if (!userId || userId.trim() === '') {
+        sendError(res, 'UNAUTHORIZED', 'x-user-id header is required', 401);
+        return;
+      }
+
+      const uid = userId.trim();
+      const body = req.body as UpdatePayload;
+
+      if (
+        typeof body !== 'object' ||
+        body === null ||
+        Array.isArray(body)
+      ) {
+        sendError(res, 'INVALID_BODY', 'Request body must be a JSON object', 400);
+        return;
+      }
+
+      const keys = Object.keys(body);
+
+      if (keys.length === 0) {
+        // No-op: return current prefs unchanged.
+        const prefs = getPrefsForUser(uid);
+        return res.status(200).json({
+          success: true,
+          data: {
+            userId: uid,
+            preferences: prefs,
+            updated: false,
+          },
+        });
+      }
+
+      const validationError = validateUpdate(body);
+      if (validationError) {
+        sendError(res, validationError.code, validationError.message, 400);
+        return;
+      }
+
+      // Apply the update.
+      const current = getPrefsForUser(uid);
+      const updated: NotificationPreferences = { ...current };
+
+      for (const [key, value] of Object.entries(body)) {
+        updated[key as EventClass] = deduplicateChannels(value as Channel[]);
+      }
+
+      prefsStore.set(uid, updated);
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          userId: uid,
+          preferences: updated,
+          updated: true,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export function __resetNotificationPrefs(): void {
+  prefsStore.clear();
+}
+
+export function __seedNotificationPrefs(
+  userId: string,
+  prefs: NotificationPreferences,
+): void {
+  prefsStore.set(userId, { ...prefs });
+}
+
+export function __getNotificationPrefs(
+  userId: string,
+): NotificationPreferences | undefined {
+  return prefsStore.get(userId);
+}

--- a/routes-d/tests/flags.test.ts
+++ b/routes-d/tests/flags.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Route tests for routes-d/routes/flags.ts
+ *
+ * Covers:
+ *  - GET /flags/status returns flag definitions
+ *  - GET /flags/user requires x-user-id header
+ *  - GET /flags/user returns per-user evaluated flags
+ *  - POST /flags/reload triggers hot reload and returns metadata
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import flagsRouter from '../routes/flags.js';
+import {
+  __resetFlags,
+  __setFlags,
+  type FlagMap,
+} from '../lib/featureFlags.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(flagsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe('GET /flags/status', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetFlags();
+  });
+
+  it('returns 200 with success: true', async () => {
+    const res = await request(app).get('/flags/status');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns flags, loadedAt, and source in data', async () => {
+    const res = await request(app).get('/flags/status');
+    const { data } = res.body;
+    expect(data).toBeDefined();
+    expect(data.flags).toBeDefined();
+    expect(data.loadedAt).toBeDefined();
+    expect(data.source).toBeDefined();
+  });
+
+  it('returns the injected flags', async () => {
+    const custom: FlagMap = {
+      'my-test-flag': { enabled: true, rollout: 0.5, description: 'test' },
+    };
+    __setFlags(custom);
+
+    const res = await request(app).get('/flags/status');
+    const { flags } = res.body.data;
+    expect(flags['my-test-flag']).toBeDefined();
+    expect(flags['my-test-flag'].enabled).toBe(true);
+    expect(flags['my-test-flag'].rollout).toBe(0.5);
+    expect(flags['my-test-flag'].description).toBe('test');
+  });
+
+  it('includes all default flags', async () => {
+    __resetFlags();
+    const res = await request(app).get('/flags/status');
+    const { flags } = res.body.data;
+    expect(flags['stellar-soroban-v2']).toBeDefined();
+    expect(flags['notification-prefs-v2']).toBeDefined();
+  });
+});
+
+describe('GET /flags/user', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetFlags();
+  });
+
+  it('returns 401 UNAUTHORIZED when x-user-id header is missing', async () => {
+    const res = await request(app).get('/flags/user');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 UNAUTHORIZED when x-user-id is an empty string', async () => {
+    const res = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', '  ');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 200 with userId and flags for a valid user', async () => {
+    __setFlags({
+      'flag-on': { enabled: true, rollout: 1.0 },
+      'flag-off': { enabled: false, rollout: 1.0 },
+    });
+
+    const res = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', 'user-123');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.userId).toBe('user-123');
+    expect(typeof res.body.data.flags).toBe('object');
+  });
+
+  it('enabled flag with rollout 1.0 is true for the user', async () => {
+    __setFlags({ 'always-on': { enabled: true, rollout: 1.0 } });
+
+    const res = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', 'any-user');
+
+    expect(res.body.data.flags['always-on']).toBe(true);
+  });
+
+  it('disabled flag is false for the user', async () => {
+    __setFlags({ 'always-off': { enabled: false, rollout: 1.0 } });
+
+    const res = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', 'any-user');
+
+    expect(res.body.data.flags['always-off']).toBe(false);
+  });
+
+  it('returns consistent results on repeated calls for the same user', async () => {
+    __setFlags({ 'stable': { enabled: true, rollout: 0.5 } });
+
+    const uid = 'stable-user-abc';
+    const res1 = await request(app).get('/flags/user').set('x-user-id', uid);
+    const res2 = await request(app).get('/flags/user').set('x-user-id', uid);
+
+    expect(res1.body.data.flags['stable']).toBe(
+      res2.body.data.flags['stable'],
+    );
+  });
+});
+
+describe('POST /flags/reload', () => {
+  afterEach(() => {
+    delete process.env['FEATURE_FLAGS_JSON'];
+    __resetFlags();
+  });
+
+  it('returns 200 with reloaded: true', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/flags/reload');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.reloaded).toBe(true);
+  });
+
+  it('returns envProvided: false when FEATURE_FLAGS_JSON is not set', async () => {
+    delete process.env['FEATURE_FLAGS_JSON'];
+    __resetFlags();
+    const app = buildApp();
+    const res = await request(app).post('/flags/reload');
+    expect(res.body.data.envProvided).toBe(false);
+    expect(res.body.data.source).toBe('default');
+  });
+
+  it('returns envProvided: true when FEATURE_FLAGS_JSON is valid', async () => {
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({
+      'env-test': { enabled: true, rollout: 1.0 },
+    });
+    const app = buildApp();
+    const res = await request(app).post('/flags/reload');
+    expect(res.body.data.envProvided).toBe(true);
+    expect(res.body.data.source).toBe('env');
+  });
+
+  it('includes flagCount in the response', async () => {
+    __setFlags({ 'a': { enabled: true }, 'b': { enabled: false } });
+    const app = buildApp();
+    const res = await request(app).post('/flags/reload');
+    expect(typeof res.body.data.flagCount).toBe('number');
+    expect(res.body.data.flagCount).toBeGreaterThan(0);
+  });
+
+  it('includes loadedAt as an ISO date string', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/flags/reload');
+    expect(res.body.data.loadedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('picks up new flags from env after reload', async () => {
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({
+      'hot-reloaded-flag': { enabled: true, rollout: 1.0 },
+    });
+    const app = buildApp();
+    await request(app).post('/flags/reload');
+
+    const statusRes = await request(app).get('/flags/status');
+    expect(statusRes.body.data.flags['hot-reloaded-flag']).toBeDefined();
+  });
+});

--- a/routes-d/tests/integration/featureFlags.notificationPrefs.integration.test.ts
+++ b/routes-d/tests/integration/featureFlags.notificationPrefs.integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Integration tests for #375 Feature Flag Service + #380 Notification Prefs
+ *
+ * Exercises the two features end-to-end via their HTTP routes:
+ *  - Flags hot-reload via POST /flags/reload
+ *  - Per-user flag evaluation via GET /flags/user
+ *  - Notification prefs CRUD round-trip
+ *  - Both features share a user and work independently
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import flagsRouter from '../../routes/flags.js';
+import notificationPrefsRouter from '../../routes/notifications.prefs.js';
+import {
+  __resetFlags,
+  __setFlags,
+} from '../../lib/featureFlags.js';
+import {
+  __resetNotificationPrefs,
+} from '../../routes/notifications.prefs.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(flagsRouter);
+  app.use(notificationPrefsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe('Feature flags + notification prefs integration', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    __resetFlags();
+    __resetNotificationPrefs();
+    app = buildApp();
+  });
+
+  afterEach(() => {
+    delete process.env['FEATURE_FLAGS_JSON'];
+    __resetFlags();
+    __resetNotificationPrefs();
+  });
+
+  it('flag status and notification prefs both respond on the same app', async () => {
+    const flagRes = await request(app).get('/flags/status');
+    const prefRes = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-integ');
+
+    expect(flagRes.status).toBe(200);
+    expect(prefRes.status).toBe(200);
+  });
+
+  it('hot-reload adds a notification-gate flag and user prefs remain independent', async () => {
+    // Set a flag that gates access to notification prefs v2
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({
+      'notification-prefs-v2': { enabled: true, rollout: 1.0, description: 'v2' },
+    });
+
+    await request(app).post('/flags/reload');
+
+    // Flag should be on for the user
+    const flagRes = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', 'user-gate');
+    expect(flagRes.body.data.flags['notification-prefs-v2']).toBe(true);
+
+    // The user can still update prefs
+    const patchRes = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-gate')
+      .send({ payment: ['push', 'email'] });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.data.preferences.payment).toContain('push');
+  });
+
+  it('flag bucketing is stable across flag reloads', async () => {
+    __setFlags({ 'stable-gate': { enabled: true, rollout: 0.5 } });
+
+    const uid = 'user-stable-integ-001';
+
+    const res1 = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', uid);
+
+    // Trigger a reload with the same flags
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({
+      'stable-gate': { enabled: true, rollout: 0.5 },
+    });
+    await request(app).post('/flags/reload');
+
+    const res2 = await request(app)
+      .get('/flags/user')
+      .set('x-user-id', uid);
+
+    expect(res1.body.data.flags['stable-gate']).toBe(
+      res2.body.data.flags['stable-gate'],
+    );
+  });
+
+  it('complete flow: get defaults → patch prefs → get updated → flags unaffected', async () => {
+    const uid = 'integ-full-flow';
+
+    // 1. Get defaults
+    const defaults = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', uid);
+    expect(defaults.body.data.isDefault).toBe(true);
+
+    // 2. Patch preferences
+    await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', uid)
+      .send({ security: ['email', 'push'], marketing: [] });
+
+    // 3. Verify update
+    const updated = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', uid);
+    expect(updated.body.data.preferences.security).toEqual(
+      expect.arrayContaining(['email', 'push']),
+    );
+    expect(updated.body.data.preferences.marketing).toEqual([]);
+
+    // 4. Flag status is unaffected by prefs changes
+    const flagStatus = await request(app).get('/flags/status');
+    expect(flagStatus.status).toBe(200);
+    expect(flagStatus.body.data.flags).toBeDefined();
+  });
+
+  it('rejects bad channel and bad event class with correct codes', async () => {
+    const badChannel = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-bad')
+      .send({ payment: ['carrier-pigeon'] });
+    expect(badChannel.status).toBe(400);
+    expect(badChannel.body.error.code).toBe('UNSUPPORTED_CHANNEL');
+
+    const badClass = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-bad')
+      .send({ unknown_class: ['email'] });
+    expect(badClass.status).toBe(400);
+    expect(badClass.body.error.code).toBe('UNKNOWN_EVENT_CLASS');
+  });
+});

--- a/routes-d/tests/notifications.prefs.test.ts
+++ b/routes-d/tests/notifications.prefs.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for routes-d/routes/notifications.prefs.ts
+ *
+ * Covers:
+ *  - GET  /notifications/preferences – auth, defaults, per-user isolation
+ *  - PATCH /notifications/preferences – update, validation, no-op, channel dedup
+ *  - Unsupported channel rejection
+ *  - Unknown event class rejection
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import notificationPrefsRouter, {
+  __resetNotificationPrefs,
+  __seedNotificationPrefs,
+  __getNotificationPrefs,
+  DEFAULT_NOTIFICATION_PREFS,
+  SUPPORTED_CHANNELS,
+  SUPPORTED_EVENT_CLASSES,
+  type NotificationPreferences,
+} from '../routes/notifications.prefs.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(notificationPrefsRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// GET /notifications/preferences
+// ---------------------------------------------------------------------------
+describe('GET /notifications/preferences', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetNotificationPrefs();
+  });
+
+  it('returns 401 UNAUTHORIZED when x-user-id header is missing', async () => {
+    const res = await request(app).get('/notifications/preferences');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 UNAUTHORIZED when x-user-id is blank', async () => {
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', '   ');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 200 with success: true for a valid user', async () => {
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns documented default preferences for a new user', async () => {
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'new-user');
+
+    expect(res.status).toBe(200);
+    const { preferences, isDefault } = res.body.data;
+
+    expect(isDefault).toBe(true);
+
+    // Verify each default event class and its channels
+    for (const [cls, channels] of Object.entries(DEFAULT_NOTIFICATION_PREFS)) {
+      expect(preferences[cls]).toBeDefined();
+      for (const ch of channels) {
+        expect(preferences[cls]).toContain(ch);
+      }
+    }
+  });
+
+  it('security event class defaults to all four channels', async () => {
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-security');
+
+    expect(res.body.data.preferences.security).toEqual(
+      expect.arrayContaining(['email', 'sms', 'push', 'in_app']),
+    );
+  });
+
+  it('returns persisted preferences when they exist for the user', async () => {
+    const custom: NotificationPreferences = {
+      payment: ['push'],
+      transfer: ['sms'],
+      security: ['email'],
+      marketing: [],
+      system: ['in_app'],
+    };
+    __seedNotificationPrefs('user-seeded', custom);
+
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-seeded');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isDefault).toBe(false);
+    expect(res.body.data.preferences.payment).toEqual(['push']);
+    expect(res.body.data.preferences.transfer).toEqual(['sms']);
+    expect(res.body.data.preferences.marketing).toEqual([]);
+  });
+
+  it('isolates preferences between users', async () => {
+    __seedNotificationPrefs('user-a', {
+      payment: ['push'],
+      transfer: ['sms'],
+      security: ['email'],
+      marketing: [],
+      system: [],
+    });
+
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-b');
+
+    expect(res.body.data.preferences.payment).toEqual(
+      expect.arrayContaining(DEFAULT_NOTIFICATION_PREFS.payment),
+    );
+  });
+
+  it('returns userId in response body', async () => {
+    const res = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-xyz');
+    expect(res.body.data.userId).toBe('user-xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /notifications/preferences
+// ---------------------------------------------------------------------------
+describe('PATCH /notifications/preferences', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetNotificationPrefs();
+  });
+
+  it('returns 401 UNAUTHORIZED when x-user-id header is missing', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .send({ payment: ['email'] });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('updates a single event class channel list', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-1')
+      .send({ payment: ['push', 'sms'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.updated).toBe(true);
+    expect(res.body.data.preferences.payment).toEqual(
+      expect.arrayContaining(['push', 'sms']),
+    );
+  });
+
+  it('persists the update and GET reflects the new value', async () => {
+    await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-2')
+      .send({ marketing: ['sms', 'push'] });
+
+    const get = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'user-2');
+
+    expect(get.body.data.preferences.marketing).toEqual(
+      expect.arrayContaining(['sms', 'push']),
+    );
+    expect(get.body.data.isDefault).toBe(false);
+  });
+
+  it('can set a channel list to empty array (opt out of all channels)', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-3')
+      .send({ marketing: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.preferences.marketing).toEqual([]);
+  });
+
+  it('deduplicates channels in the update', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-4')
+      .send({ payment: ['email', 'email', 'sms', 'sms'] });
+
+    expect(res.status).toBe(200);
+    const channels: string[] = res.body.data.preferences.payment;
+    const unique = new Set(channels);
+    expect(channels.length).toBe(unique.size);
+  });
+
+  it('updates multiple event classes atomically', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-5')
+      .send({ payment: ['push'], transfer: ['sms'], marketing: [] });
+
+    expect(res.status).toBe(200);
+    const { preferences } = res.body.data;
+    expect(preferences.payment).toEqual(expect.arrayContaining(['push']));
+    expect(preferences.transfer).toEqual(expect.arrayContaining(['sms']));
+    expect(preferences.marketing).toEqual([]);
+  });
+
+  it('unaffected event classes keep their previous values', async () => {
+    __seedNotificationPrefs('user-6', {
+      payment: ['email'],
+      transfer: ['in_app'],
+      security: ['email', 'sms'],
+      marketing: ['email'],
+      system: ['push'],
+    });
+
+    await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-6')
+      .send({ payment: ['push'] });
+
+    const stored = __getNotificationPrefs('user-6');
+    expect(stored?.transfer).toEqual(['in_app']);
+    expect(stored?.security).toEqual(['email', 'sms']);
+    expect(stored?.marketing).toEqual(['email']);
+    expect(stored?.system).toEqual(['push']);
+  });
+
+  it('returns updated: false and current prefs for an empty body', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-7')
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.updated).toBe(false);
+    expect(res.body.data.preferences).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation – unsupported channels
+  // -------------------------------------------------------------------------
+
+  it('returns 400 UNSUPPORTED_CHANNEL for an unknown channel', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-8')
+      .send({ payment: ['email', 'telegram'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('UNSUPPORTED_CHANNEL');
+  });
+
+  it('includes the unsupported channel name in the error message', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-9')
+      .send({ payment: ['slack'] });
+
+    expect(res.body.error.message).toMatch(/slack/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation – unknown event classes
+  // -------------------------------------------------------------------------
+
+  it('returns 400 UNKNOWN_EVENT_CLASS for an unrecognised event class', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-10')
+      .send({ foobar: ['email'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('UNKNOWN_EVENT_CLASS');
+  });
+
+  it('includes the unknown class name in the error message', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-11')
+      .send({ custom_alerts: ['push'] });
+
+    expect(res.body.error.message).toMatch(/custom_alerts/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation – non-array channel value
+  // -------------------------------------------------------------------------
+
+  it('returns 400 INVALID_CHANNEL_LIST when channel value is a string', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-12')
+      .send({ payment: 'email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_CHANNEL_LIST');
+  });
+
+  it('returns 400 INVALID_CHANNEL_LIST when channel value is a boolean', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-13')
+      .send({ payment: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_CHANNEL_LIST');
+  });
+
+  it('returns 400 INVALID_CHANNEL_LIST when channel value is null', async () => {
+    const res = await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'user-14')
+      .send({ payment: null });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_CHANNEL_LIST');
+  });
+
+  // -------------------------------------------------------------------------
+  // All supported channels are accepted
+  // -------------------------------------------------------------------------
+
+  it.each([...SUPPORTED_CHANNELS])(
+    'accepts "%s" as a valid channel',
+    async (channel) => {
+      const res = await request(app)
+        .patch('/notifications/preferences')
+        .set('x-user-id', `user-ch-${channel}`)
+        .send({ payment: [channel] });
+
+      expect(res.status).toBe(200);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // All supported event classes are accepted
+  // -------------------------------------------------------------------------
+
+  it.each([...SUPPORTED_EVENT_CLASSES])(
+    'accepts "%s" as a valid event class',
+    async (cls) => {
+      const res = await request(app)
+        .patch('/notifications/preferences')
+        .set('x-user-id', `user-cls-${cls}`)
+        .send({ [cls]: ['email'] });
+
+      expect(res.status).toBe(200);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Integration: GET → PATCH → GET round-trip
+// ---------------------------------------------------------------------------
+describe('notifications.prefs integration round-trip', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetNotificationPrefs();
+  });
+
+  it('GET returns defaults → PATCH updates → GET reflects changes', async () => {
+    const uid = 'integration-user-1';
+
+    const initial = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', uid);
+
+    expect(initial.body.data.isDefault).toBe(true);
+    expect(initial.body.data.preferences.payment).toEqual(
+      expect.arrayContaining(DEFAULT_NOTIFICATION_PREFS.payment),
+    );
+
+    await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', uid)
+      .send({ payment: ['push'], marketing: [] });
+
+    const updated = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', uid);
+
+    expect(updated.body.data.isDefault).toBe(false);
+    expect(updated.body.data.preferences.payment).toEqual(
+      expect.arrayContaining(['push']),
+    );
+    expect(updated.body.data.preferences.marketing).toEqual([]);
+    // Other classes unchanged from defaults
+    expect(updated.body.data.preferences.security).toEqual(
+      expect.arrayContaining(DEFAULT_NOTIFICATION_PREFS.security),
+    );
+  });
+
+  it('multiple users can have independent preferences', async () => {
+    await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'multi-user-a')
+      .send({ payment: ['sms'] });
+
+    await request(app)
+      .patch('/notifications/preferences')
+      .set('x-user-id', 'multi-user-b')
+      .send({ payment: ['push'] });
+
+    const aRes = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'multi-user-a');
+
+    const bRes = await request(app)
+      .get('/notifications/preferences')
+      .set('x-user-id', 'multi-user-b');
+
+    expect(aRes.body.data.preferences.payment).toContain('sms');
+    expect(bRes.body.data.preferences.payment).toContain('push');
+    expect(aRes.body.data.preferences.payment).not.toContain('push');
+    expect(bRes.body.data.preferences.payment).not.toContain('sms');
+  });
+});

--- a/routes-d/tests/unit/featureFlags.test.ts
+++ b/routes-d/tests/unit/featureFlags.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Unit tests for routes-d/lib/featureFlags.ts
+ *
+ * Covers:
+ *  - Stable user bucketing (same userId+flag → same result every call)
+ *  - Rollout boundaries (0 %, 100 %, partial cohorts)
+ *  - Defaults (enabled flags default to true for all users)
+ *  - Hot reload via reloadFlags() + FEATURE_FLAGS_JSON env variable
+ *  - getFlagStatus() returns correct metadata
+ *  - getFlagsForUser() returns per-user evaluated values
+ *  - Unknown flags return false
+ *  - __setFlags / __resetFlags test helpers
+ */
+
+import {
+  isFlagEnabled,
+  getFlagsForUser,
+  getFlagStatus,
+  getRawFlags,
+  reloadFlags,
+  getBucket,
+  __setFlags,
+  __resetFlags,
+  type FlagMap,
+} from '../../lib/featureFlags.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Save and restore process.env.FEATURE_FLAGS_JSON around a block. */
+function withEnv(value: string | undefined, fn: () => void): void {
+  const original = process.env['FEATURE_FLAGS_JSON'];
+  if (value === undefined) {
+    delete process.env['FEATURE_FLAGS_JSON'];
+  } else {
+    process.env['FEATURE_FLAGS_JSON'] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env['FEATURE_FLAGS_JSON'];
+    } else {
+      process.env['FEATURE_FLAGS_JSON'] = original;
+    }
+    // Restore module state to defaults after env manipulation.
+    __resetFlags();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('featureFlags – getBucket', () => {
+  it('returns a number in [0, 100)', () => {
+    for (const userId of ['alice', 'bob', 'carol', 'user-99', '']) {
+      const b = getBucket(userId, 'some-flag');
+      expect(b).toBeGreaterThanOrEqual(0);
+      expect(b).toBeLessThan(100);
+    }
+  });
+
+  it('is deterministic – same inputs always yield the same bucket', () => {
+    const ids = ['user-1', 'user-2', 'user-abc', 'user-xyz'];
+    const flag = 'wallet-backup-prompt';
+
+    for (const id of ids) {
+      const first = getBucket(id, flag);
+      const second = getBucket(id, flag);
+      const third = getBucket(id, flag);
+      expect(first).toBe(second);
+      expect(second).toBe(third);
+    }
+  });
+
+  it('produces different buckets for different flags on the same user', () => {
+    const buckets = [
+      getBucket('user-1', 'flag-a'),
+      getBucket('user-1', 'flag-b'),
+      getBucket('user-1', 'flag-c'),
+    ];
+    // They should not all be the same
+    const unique = new Set(buckets);
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  it('produces different buckets for different users on the same flag', () => {
+    const flag = 'stellar-soroban-v2';
+    const buckets = new Set([
+      getBucket('user-1', flag),
+      getBucket('user-2', flag),
+      getBucket('user-3', flag),
+      getBucket('user-4', flag),
+      getBucket('user-5', flag),
+    ]);
+    expect(buckets.size).toBeGreaterThan(1);
+  });
+});
+
+describe('featureFlags – isFlagEnabled', () => {
+  beforeEach(() => {
+    __resetFlags();
+  });
+
+  it('returns false for an unknown flag', () => {
+    expect(isFlagEnabled('no-such-flag', 'user-1')).toBe(false);
+  });
+
+  it('returns false when flag.enabled is false regardless of rollout', () => {
+    __setFlags({
+      'disabled-flag': { enabled: false, rollout: 1.0 },
+    });
+    expect(isFlagEnabled('disabled-flag', 'user-1')).toBe(false);
+    expect(isFlagEnabled('disabled-flag', 'user-2')).toBe(false);
+  });
+
+  it('returns true for all users when rollout is 1.0', () => {
+    __setFlags({
+      'full-rollout': { enabled: true, rollout: 1.0 },
+    });
+    const ids = ['user-1', 'user-2', 'user-3', 'alice', 'bob'];
+    for (const id of ids) {
+      expect(isFlagEnabled('full-rollout', id)).toBe(true);
+    }
+  });
+
+  it('returns false for all users when rollout is 0.0', () => {
+    __setFlags({
+      'zero-rollout': { enabled: true, rollout: 0.0 },
+    });
+    const ids = ['user-1', 'user-2', 'user-3', 'alice', 'bob'];
+    for (const id of ids) {
+      expect(isFlagEnabled('zero-rollout', id)).toBe(false);
+    }
+  });
+
+  it('uses bucket < rollout * 100 to determine inclusion', () => {
+    // For 'test-flag' find a user whose bucket is in [0,49] and one in [50,99]
+    const flag = 'test-flag';
+    __setFlags({ [flag]: { enabled: true, rollout: 0.5 } });
+
+    // Scan a range of userIds to find one in each partition
+    let inUser: string | null = null;
+    let outUser: string | null = null;
+
+    for (let i = 0; i < 200; i++) {
+      const uid = `test-user-${i}`;
+      const bucket = getBucket(uid, flag);
+      if (bucket < 50 && inUser === null) inUser = uid;
+      if (bucket >= 50 && outUser === null) outUser = uid;
+      if (inUser && outUser) break;
+    }
+
+    expect(inUser).not.toBeNull();
+    expect(outUser).not.toBeNull();
+
+    expect(isFlagEnabled(flag, inUser!)).toBe(true);
+    expect(isFlagEnabled(flag, outUser!)).toBe(false);
+  });
+
+  it('is stable across repeated calls for the same user', () => {
+    __setFlags({
+      'stable-flag': { enabled: true, rollout: 0.5 },
+    });
+    const uid = 'user-stability-test';
+    const first = isFlagEnabled('stable-flag', uid);
+    for (let i = 0; i < 10; i++) {
+      expect(isFlagEnabled('stable-flag', uid)).toBe(first);
+    }
+  });
+
+  it('defaults to rollout 1.0 when rollout is omitted', () => {
+    __setFlags({ 'no-rollout-field': { enabled: true } });
+    expect(isFlagEnabled('no-rollout-field', 'any-user')).toBe(true);
+    expect(isFlagEnabled('no-rollout-field', 'another-user')).toBe(true);
+  });
+});
+
+describe('featureFlags – getFlagsForUser', () => {
+  beforeEach(() => {
+    __resetFlags();
+  });
+
+  it('returns an object keyed by all flag names', () => {
+    __setFlags({
+      'flag-a': { enabled: true, rollout: 1.0 },
+      'flag-b': { enabled: false, rollout: 1.0 },
+    });
+    const result = getFlagsForUser('user-x');
+    expect(Object.keys(result)).toEqual(['flag-a', 'flag-b']);
+  });
+
+  it('returns correct boolean values per flag', () => {
+    __setFlags({
+      'on-flag': { enabled: true, rollout: 1.0 },
+      'off-flag': { enabled: false, rollout: 1.0 },
+    });
+    const result = getFlagsForUser('user-x');
+    expect(result['on-flag']).toBe(true);
+    expect(result['off-flag']).toBe(false);
+  });
+
+  it('is stable for the same user across calls', () => {
+    __setFlags({
+      'partial': { enabled: true, rollout: 0.5 },
+    });
+    const uid = 'user-stable-check';
+    const first = getFlagsForUser(uid);
+    const second = getFlagsForUser(uid);
+    expect(first).toEqual(second);
+  });
+});
+
+describe('featureFlags – getFlagStatus', () => {
+  beforeEach(() => {
+    __resetFlags();
+  });
+
+  it('returns all flags in the flags property', () => {
+    __setFlags({
+      'flag-1': { enabled: true, rollout: 0.25, description: 'desc' },
+      'flag-2': { enabled: false, rollout: 0.0 },
+    });
+    const status = getFlagStatus();
+    expect(Object.keys(status.flags)).toContain('flag-1');
+    expect(Object.keys(status.flags)).toContain('flag-2');
+  });
+
+  it('returns correct metadata for each flag', () => {
+    __setFlags({
+      'my-flag': { enabled: true, rollout: 0.75, description: 'test flag' },
+    });
+    const status = getFlagStatus();
+    expect(status.flags['my-flag'].enabled).toBe(true);
+    expect(status.flags['my-flag'].rollout).toBe(0.75);
+    expect(status.flags['my-flag'].description).toBe('test flag');
+  });
+
+  it('includes loadedAt as an ISO string', () => {
+    const status = getFlagStatus();
+    expect(() => new Date(status.loadedAt)).not.toThrow();
+    expect(status.loadedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('reports source as "default" after __resetFlags', () => {
+    __resetFlags();
+    const status = getFlagStatus();
+    expect(status.source).toBe('default');
+  });
+});
+
+describe('featureFlags – reloadFlags (hot reload)', () => {
+  afterEach(() => {
+    delete process.env['FEATURE_FLAGS_JSON'];
+    __resetFlags();
+  });
+
+  it('loads flags from FEATURE_FLAGS_JSON when set', () => {
+    const envFlags: FlagMap = {
+      'env-flag': { enabled: true, rollout: 1.0, description: 'from env' },
+    };
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify(envFlags);
+
+    const loaded = reloadFlags();
+    expect(loaded).toBe(true);
+
+    const raw = getRawFlags();
+    expect(raw['env-flag']).toBeDefined();
+    expect(raw['env-flag'].enabled).toBe(true);
+  });
+
+  it('returns true and sets source to "env" when env flags are valid', () => {
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({
+      'x': { enabled: true },
+    });
+    const loaded = reloadFlags();
+    expect(loaded).toBe(true);
+    expect(getFlagStatus().source).toBe('env');
+  });
+
+  it('falls back to defaults when FEATURE_FLAGS_JSON is invalid JSON', () => {
+    process.env['FEATURE_FLAGS_JSON'] = 'not-valid-json{{';
+    const loaded = reloadFlags();
+    expect(loaded).toBe(false);
+    expect(getFlagStatus().source).toBe('default');
+  });
+
+  it('falls back to defaults when FEATURE_FLAGS_JSON is an empty object', () => {
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({});
+    const loaded = reloadFlags();
+    expect(loaded).toBe(false);
+    expect(getFlagStatus().source).toBe('default');
+  });
+
+  it('falls back to defaults when FEATURE_FLAGS_JSON is not set', () => {
+    delete process.env['FEATURE_FLAGS_JSON'];
+    const loaded = reloadFlags();
+    expect(loaded).toBe(false);
+    expect(getFlagStatus().source).toBe('default');
+  });
+
+  it('reflects new flags immediately after reload', () => {
+    __setFlags({ 'old-flag': { enabled: true } });
+    expect(isFlagEnabled('old-flag', 'user-1')).toBe(true);
+
+    process.env['FEATURE_FLAGS_JSON'] = JSON.stringify({
+      'new-flag': { enabled: true, rollout: 1.0 },
+    });
+    reloadFlags();
+
+    // Old flag should be gone, new flag should be present.
+    expect(isFlagEnabled('old-flag', 'user-1')).toBe(false);
+    expect(isFlagEnabled('new-flag', 'user-1')).toBe(true);
+  });
+
+  it('multiple consecutive reloads are each independent', () => {
+    withEnv(
+      JSON.stringify({ 'reload-a': { enabled: true, rollout: 1.0 } }),
+      () => {
+        reloadFlags();
+        expect(isFlagEnabled('reload-a', 'u1')).toBe(true);
+      },
+    );
+
+    withEnv(
+      JSON.stringify({ 'reload-b': { enabled: true, rollout: 1.0 } }),
+      () => {
+        reloadFlags();
+        expect(isFlagEnabled('reload-b', 'u1')).toBe(true);
+        expect(isFlagEnabled('reload-a', 'u1')).toBe(false);
+      },
+    );
+  });
+});
+
+describe('featureFlags – default flag definitions', () => {
+  beforeEach(() => {
+    __resetFlags();
+  });
+
+  it('stellar-soroban-v2 is enabled for all users by default', () => {
+    expect(isFlagEnabled('stellar-soroban-v2', 'alice')).toBe(true);
+    expect(isFlagEnabled('stellar-soroban-v2', 'bob')).toBe(true);
+  });
+
+  it('defi-yield-farming is disabled for all users by default', () => {
+    expect(isFlagEnabled('defi-yield-farming', 'alice')).toBe(false);
+    expect(isFlagEnabled('defi-yield-farming', 'bob')).toBe(false);
+  });
+
+  it('notification-prefs-v2 is enabled for all users by default', () => {
+    expect(isFlagEnabled('notification-prefs-v2', 'alice')).toBe(true);
+  });
+});


### PR DESCRIPTION
… endpoint

#375 – Feature Flag Service
- Add routes-d/lib/featureFlags.ts with stable per-user bucketing (djb2 hash), hot reload from FEATURE_FLAGS_JSON env var, and default flag definitions
- Add routes-d/routes/flags.ts exposing GET /flags/status, GET /flags/user, and POST /flags/reload
- Add unit and route tests covering bucketing stability, rollout boundaries, defaults, hot reload, and all three endpoints

#380 – Notification Preferences Endpoint
- Add routes-d/routes/notifications.prefs.ts with GET and PATCH handlers for /notifications/preferences, per-user storage, and documented default baseline
- Validate event classes (payment, transfer, security, marketing, system) and channels (email, sms, push, in_app); reject unknown values with specific codes
- Add route and integration tests covering get, update, unsupported channel rejection, unknown event class rejection, and multi-user isolation

All 83 new tests pass; no regressions in existing test suites

closes #375 
closes #380 