### PR TITLE
feat(routes-d): add LancePay FX quote, org list, member invite, and role update routes

### DIFF
--- a/routes-d/routes/lancepay.fx.quote.ts
+++ b/routes-d/routes/lancepay.fx.quote.ts
@@ -1,0 +1,90 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type QuoteData = {
+  pair: string;
+  fromAsset: string;
+  toAsset: string;
+  inputAmount: number;
+  expectedOutput: number;
+  effectiveRate: number;
+  spread: number;
+  priceImpact: number;
+  liquidity: "deep" | "thin";
+};
+
+const quoteCache = new Map<string, { data: QuoteData; expiresAt: number }>();
+
+const RATES: Record<string, number> = {
+  "USDC-NGN": 1500,
+  "NGN-USDC": 1 / 1500,
+  "USDC-EUR": 0.92,
+  "EUR-USDC": 1 / 0.92,
+  "XLM-USDC": 0.12,
+  "USDC-XLM": 1 / 0.12,
+};
+
+router.post("/lancepay/fx/quote", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { fromAsset, toAsset, amount } = req.body ?? {};
+
+    if (!fromAsset || !toAsset || typeof amount !== "number" || amount <= 0) {
+      sendError(res, "INVALID_INPUT", "fromAsset, toAsset, and positive amount are required", 400);
+      return;
+    }
+
+    const pair = `${fromAsset.toUpperCase()}-${toAsset.toUpperCase()}`;
+    const baseRate = RATES[pair];
+
+    if (!baseRate) {
+      sendError(res, "UNKNOWN_PAIR", `Unsupported currency pair: ${pair}`, 404);
+      return;
+    }
+
+    const cacheKey = `${pair}:${amount}`;
+    const cached = quoteCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return res.status(200).json({ success: true, data: cached.data, cached: true });
+    }
+
+    let spread = 0.005;
+    let priceImpact = 0.001;
+
+    if (amount >= 100000) {
+      spread = 0.03;
+      priceImpact = 0.05;
+    } else if (amount >= 10000) {
+      spread = 0.015;
+      priceImpact = 0.01;
+    }
+
+    const effectiveRate = baseRate * (1 - spread - priceImpact);
+    const expectedOutput = Number((amount * effectiveRate).toFixed(6));
+
+    const quoteData: QuoteData = {
+      pair,
+      fromAsset: fromAsset.toUpperCase(),
+      toAsset: toAsset.toUpperCase(),
+      inputAmount: amount,
+      expectedOutput,
+      effectiveRate,
+      spread,
+      priceImpact,
+      liquidity: amount >= 100000 ? "thin" : "deep",
+    };
+
+    quoteCache.set(cacheKey, { data: quoteData, expiresAt: Date.now() + 10000 });
+
+    return res.status(200).json({ success: true, data: quoteData, cached: false });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __clearFxQuoteCache() {
+  quoteCache.clear();
+}
+
+export default router;

--- a/routes-d/routes/lancepay.org.list.ts
+++ b/routes-d/routes/lancepay.org.list.ts
@@ -1,0 +1,54 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+export type UserOrganization = {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+  isActive: boolean;
+};
+
+const userOrgsStore = new Map<string, UserOrganization[]>();
+
+router.get("/lancepay/organizations", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = (req.headers["x-user-id"] as string) || (req.query.userId as string);
+    const activeOrgId = (req.headers["x-active-org-id"] as string) || (req.query.activeOrgId as string);
+
+    if (!userId || typeof userId !== "string" || !userId.trim()) {
+      sendError(res, "UNAUTHORIZED", "User identity required (x-user-id header or query)", 401);
+      return;
+    }
+
+    const orgs = userOrgsStore.get(userId.trim()) ?? [];
+
+    const formattedOrgs = orgs.map((org, index) => ({
+      ...org,
+      isActive: activeOrgId ? org.id === activeOrgId : index === 0,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        organizations: formattedOrgs,
+        total: formattedOrgs.length,
+        activeOrgId: formattedOrgs.find((o) => o.isActive)?.id ?? null,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __seedUserOrganizations(userId: string, orgs: UserOrganization[]) {
+  userOrgsStore.set(userId, orgs);
+}
+
+export function __resetUserOrganizations() {
+  userOrgsStore.clear();
+}
+
+export default router;

--- a/routes-d/routes/lancepay.org.members.invite.ts
+++ b/routes-d/routes/lancepay.org.members.invite.ts
@@ -1,0 +1,115 @@
+import { Router, Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+export type Invite = {
+  id: string;
+  orgId: string;
+  email: string;
+  role: string;
+  token: string;
+  inviteUrl: string;
+  expiresAt: number;
+  used: boolean;
+  invitedBy: string;
+};
+
+const invitesStore = new Map<string, Invite>();
+
+router.post("/lancepay/organizations/:id/members/invite", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const orgId = req.params.id?.trim();
+    if (!orgId) {
+      sendError(res, "INVALID_ORG_ID", "Organization ID is required", 400);
+      return;
+    }
+
+    const callerRole = (req.headers["x-caller-role"] as string) || req.body?.callerRole;
+    const callerId = (req.headers["x-caller-id"] as string) || req.body?.callerId;
+
+    if (!callerId || !callerRole || (callerRole !== "owner" && callerRole !== "admin")) {
+      sendError(res, "UNAUTHORIZED", "Only owner or admin can issue member invites", 403);
+      return;
+    }
+
+    const { email, role = "member", ttlSeconds = 86400 } = req.body ?? {};
+
+    if (!email || typeof email !== "string" || !email.includes("@")) {
+      sendError(res, "INVALID_EMAIL", "Valid email is required", 400);
+      return;
+    }
+
+    const token = crypto.randomBytes(24).toString("hex");
+    const expiresAt = Date.now() + ttlSeconds * 1000;
+    const inviteId = `inv_${Date.now()}_${crypto.randomBytes(4).toString("hex")}`;
+    const inviteUrl = `https://lancepay.app/invite/accept?token=${token}&org=${orgId}`;
+
+    const invite: Invite = {
+      id: inviteId,
+      orgId,
+      email: email.trim().toLowerCase(),
+      role,
+      token,
+      inviteUrl,
+      expiresAt,
+      used: false,
+      invitedBy: callerId,
+    };
+
+    invitesStore.set(token, invite);
+
+    return res.status(201).json({
+      success: true,
+      data: invite,
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// Helper route to verify/accept invite token
+router.get("/lancepay/organizations/invites/verify", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const token = req.query.token as string | undefined;
+    if (!token) {
+      sendError(res, "INVALID_TOKEN", "Invite token is required", 400);
+      return;
+    }
+
+    const invite = invitesStore.get(token);
+    if (!invite) {
+      sendError(res, "NOT_FOUND", "Invite token not found", 404);
+      return;
+    }
+
+    if (invite.used) {
+      sendError(res, "ALREADY_USED", "Invite token has already been used", 400);
+      return;
+    }
+
+    if (Date.now() > invite.expiresAt) {
+      sendError(res, "EXPIRED", "Invite link has expired", 400);
+      return;
+    }
+
+    return res.status(200).json({ success: true, data: invite });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __seedInvite(invite: Invite) {
+  invitesStore.set(invite.token, invite);
+}
+
+export function __getInvite(token: string): Invite | undefined {
+  return invitesStore.get(token);
+}
+
+export function __resetInviteStore() {
+  invitesStore.clear();
+}
+
+export default router;

--- a/routes-d/routes/lancepay.org.members.role.ts
+++ b/routes-d/routes/lancepay.org.members.role.ts
@@ -1,0 +1,114 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+export type MemberRole = "owner" | "admin" | "member" | "viewer";
+
+export type Member = {
+  memberId: string;
+  orgId: string;
+  role: MemberRole;
+};
+
+export type AuditEvent = {
+  id: string;
+  orgId: string;
+  memberId: string;
+  previousRole: MemberRole;
+  newRole: MemberRole;
+  updatedBy: string;
+  timestamp: string;
+};
+
+const membersStore = new Map<string, Member>();
+const auditEvents: AuditEvent[] = [];
+
+const VALID_ROLES: MemberRole[] = ["owner", "admin", "member", "viewer"];
+
+router.post("/lancepay/organizations/:id/members/role", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const orgId = req.params.id?.trim();
+    if (!orgId) {
+      sendError(res, "INVALID_ORG_ID", "Organization ID is required", 400);
+      return;
+    }
+
+    const callerRole = (req.headers["x-caller-role"] as string) || req.body?.callerRole;
+    const callerId = (req.headers["x-caller-id"] as string) || req.body?.callerId;
+
+    if (!callerId || !callerRole || (callerRole !== "owner" && callerRole !== "admin")) {
+      sendError(res, "UNAUTHORIZED", "Caller must be an owner or admin", 403);
+      return;
+    }
+
+    const { memberId, newRole } = req.body ?? {};
+
+    if (!memberId || typeof memberId !== "string" || !newRole || !VALID_ROLES.includes(newRole)) {
+      sendError(res, "INVALID_ROLE", "Valid memberId and newRole are required", 400);
+      return;
+    }
+
+    const key = `${orgId}:${memberId}`;
+    let member = membersStore.get(key);
+
+    if (!member) {
+      member = { memberId, orgId, role: "member" };
+    }
+
+    const previousRole = member.role;
+    if (previousRole === newRole) {
+      return res.status(200).json({
+        success: true,
+        data: { memberId, orgId, role: newRole },
+        message: "Role is already set to target role",
+      });
+    }
+
+    member.role = newRole;
+    membersStore.set(key, member);
+
+    const auditEvent: AuditEvent = {
+      id: `audit_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
+      orgId,
+      memberId,
+      previousRole,
+      newRole,
+      updatedBy: callerId,
+      timestamp: new Date().toISOString(),
+    };
+    auditEvents.push(auditEvent);
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        memberId,
+        orgId,
+        previousRole,
+        newRole,
+      },
+      auditEvent,
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export function __seedMember(m: Member) {
+  membersStore.set(`${m.orgId}:${m.memberId}`, m);
+}
+
+export function __getMember(orgId: string, memberId: string): Member | undefined {
+  return membersStore.get(`${orgId}:${memberId}`);
+}
+
+export function __getAuditEvents(): AuditEvent[] {
+  return auditEvents;
+}
+
+export function __resetRoleStore() {
+  membersStore.clear();
+  auditEvents.length = 0;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.fx.quote.test.ts
+++ b/routes-d/tests/lancepay.fx.quote.test.ts
@@ -1,0 +1,61 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, { __clearFxQuoteCache } from "../routes/lancepay.fx.quote.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/fx/quote", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __clearFxQuoteCache();
+  });
+
+  it("returns quote for deep liquidity request", async () => {
+    const res = await request(app)
+      .post("/lancepay/fx/quote")
+      .send({ fromAsset: "USDC", toAsset: "NGN", amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.expectedOutput).toBeGreaterThan(0);
+    expect(res.body.data.liquidity).toBe("deep");
+    expect(res.body.data.spread).toBe(0.005);
+  });
+
+  it("returns quote with higher spread/priceImpact for thin liquidity", async () => {
+    const res = await request(app)
+      .post("/lancepay/fx/quote")
+      .send({ fromAsset: "USDC", toAsset: "NGN", amount: 150000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.liquidity).toBe("thin");
+    expect(res.body.data.priceImpact).toBe(0.05);
+  });
+
+  it("returns 404 for unknown currency pair", async () => {
+    const res = await request(app)
+      .post("/lancepay/fx/quote")
+      .send({ fromAsset: "BTC", toAsset: "XYZ", amount: 10 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("UNKNOWN_PAIR");
+  });
+
+  it("serves cached quote for identical recent requests", async () => {
+    const payload = { fromAsset: "USDC", toAsset: "EUR", amount: 500 };
+    const res1 = await request(app).post("/lancepay/fx/quote").send(payload);
+    expect(res1.body.cached).toBe(false);
+
+    const res2 = await request(app).post("/lancepay/fx/quote").send(payload);
+    expect(res2.body.cached).toBe(true);
+  });
+});

--- a/routes-d/tests/lancepay.org.list.test.ts
+++ b/routes-d/tests/lancepay.org.list.test.ts
@@ -1,0 +1,73 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, { __seedUserOrganizations, __resetUserOrganizations } from "../routes/lancepay.org.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /lancepay/organizations", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetUserOrganizations();
+  });
+
+  it("returns 401 when user identity is missing", async () => {
+    const res = await request(app).get("/lancepay/organizations");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns empty organization list for user with no orgs", async () => {
+    const res = await request(app)
+      .get("/lancepay/organizations")
+      .set("x-user-id", "user_none");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.organizations).toEqual([]);
+    expect(res.body.data.total).toBe(0);
+  });
+
+  it("returns single organization with active mark for user with one org", async () => {
+    __seedUserOrganizations("user_one", [
+      { id: "org_1", name: "Acme Corp", slug: "acme", role: "owner", isActive: false },
+    ]);
+
+    const res = await request(app)
+      .get("/lancepay/organizations")
+      .set("x-user-id", "user_one");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.organizations).toHaveLength(1);
+    expect(res.body.data.organizations[0].isActive).toBe(true);
+    expect(res.body.data.organizations[0].role).toBe("owner");
+  });
+
+  it("returns multiple organizations marking specified activeOrgId", async () => {
+    __seedUserOrganizations("user_many", [
+      { id: "org_1", name: "Alpha", slug: "alpha", role: "owner", isActive: false },
+      { id: "org_2", name: "Beta", slug: "beta", role: "member", isActive: false },
+      { id: "org_3", name: "Gamma", slug: "gamma", role: "admin", isActive: false },
+    ]);
+
+    const res = await request(app)
+      .get("/lancepay/organizations")
+      .set("x-user-id", "user_many")
+      .set("x-active-org-id", "org_2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.organizations).toHaveLength(3);
+    expect(res.body.data.organizations[1].id).toBe("org_2");
+    expect(res.body.data.organizations[1].isActive).toBe(true);
+    expect(res.body.data.organizations[0].isActive).toBe(false);
+    expect(res.body.data.activeOrgId).toBe("org_2");
+  });
+});

--- a/routes-d/tests/lancepay.org.members.invite.test.ts
+++ b/routes-d/tests/lancepay.org.members.invite.test.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, { __seedInvite, __getInvite, __resetInviteStore } from "../routes/lancepay.org.members.invite.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/organizations/:id/members/invite", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetInviteStore();
+  });
+
+  it("creates a single-use signed invite link", async () => {
+    const res = await request(app)
+      .post("/lancepay/organizations/org1/members/invite")
+      .set("x-caller-id", "admin1")
+      .set("x-caller-role", "admin")
+      .send({ email: "dev@example.com", role: "member" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.inviteUrl).toContain("https://lancepay.app/invite/accept?token=");
+    expect(res.body.data.email).toBe("dev@example.com");
+
+    const invite = __getInvite(res.body.data.token);
+    expect(invite).toBeDefined();
+    expect(invite?.invitedBy).toBe("admin1");
+  });
+
+  it("returns 403 when caller is not owner or admin", async () => {
+    const res = await request(app)
+      .post("/lancepay/organizations/org1/members/invite")
+      .set("x-caller-id", "user1")
+      .set("x-caller-role", "member")
+      .send({ email: "dev@example.com" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("detects expired invite link during verification", async () => {
+    __seedInvite({
+      id: "inv1",
+      orgId: "org1",
+      email: "old@example.com",
+      role: "member",
+      token: "exp_token",
+      inviteUrl: "http://...",
+      expiresAt: Date.now() - 1000,
+      used: false,
+      invitedBy: "admin1",
+    });
+
+    const res = await request(app)
+      .get("/lancepay/organizations/invites/verify")
+      .query({ token: "exp_token" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("EXPIRED");
+  });
+});

--- a/routes-d/tests/lancepay.org.members.role.test.ts
+++ b/routes-d/tests/lancepay.org.members.role.test.ts
@@ -1,0 +1,67 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, { __seedMember, __getMember, __getAuditEvents, __resetRoleStore } from "../routes/lancepay.org.members.role.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /lancepay/organizations/:id/members/role", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetRoleStore();
+  });
+
+  it("promotes member role and records audit event", async () => {
+    __seedMember({ orgId: "org1", memberId: "mem1", role: "member" });
+
+    const res = await request(app)
+      .post("/lancepay/organizations/org1/members/role")
+      .set("x-caller-id", "owner1")
+      .set("x-caller-role", "owner")
+      .send({ memberId: "mem1", newRole: "admin" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.previousRole).toBe("member");
+    expect(res.body.data.newRole).toBe("admin");
+
+    const updated = __getMember("org1", "mem1");
+    expect(updated?.role).toBe("admin");
+
+    const audits = __getAuditEvents();
+    expect(audits).toHaveLength(1);
+    expect(audits[0].newRole).toBe("admin");
+  });
+
+  it("demotes member role successfully", async () => {
+    __seedMember({ orgId: "org1", memberId: "mem1", role: "admin" });
+
+    const res = await request(app)
+      .post("/lancepay/organizations/org1/members/role")
+      .set("x-caller-id", "admin1")
+      .set("x-caller-role", "admin")
+      .send({ memberId: "mem1", newRole: "viewer" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.newRole).toBe("viewer");
+  });
+
+  it("rejects unauthorized caller without admin/owner role", async () => {
+    const res = await request(app)
+      .post("/lancepay/organizations/org1/members/role")
+      .set("x-caller-id", "user1")
+      .set("x-caller-role", "member")
+      .send({ memberId: "mem1", newRole: "admin" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+});


### PR DESCRIPTION
## Description
Implemented four route handlers and unit test suites under routes-d/ for LancePay FX quotes, organization list, member invite, and member role management.

Closes #600
Closes #599
Closes #598
Closes #597

## Changes proposed

### What were you told to do?
Create routes under routes-d/routes/ with lancepay.* prefix and tests under routes-d/tests/ for FX quote, member role update, member invite, and organizations list.

### What did I do?
#### Routes-D Route Handlers & Unit Tests
- Created routes-d/routes/lancepay.fx.quote.ts and routes-d/tests/lancepay.fx.quote.test.ts
- Created routes-d/routes/lancepay.org.members.role.ts and routes-d/tests/lancepay.org.members.role.test.ts
- Created routes-d/routes/lancepay.org.members.invite.ts and routes-d/tests/lancepay.org.members.invite.test.ts
- Created routes-d/routes/lancepay.org.list.ts and routes-d/tests/lancepay.org.list.test.ts

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
All handlers created strictly inside routes-d/ with unit test coverage using Supertest and Express.