### PR TITLE
feat: add KYC document upload endpoint with multipart handling

### DIFF
--- a/routes-d/docs/PR-386-kyc-document-upload.md
+++ b/routes-d/docs/PR-386-kyc-document-upload.md
@@ -1,0 +1,39 @@
+# KYC Document Upload Endpoint
+
+## Summary
+
+Add `POST /kyc/upload` endpoint that accepts KYC document uploads through multipart form data for partners that require identity verification.
+
+## Changes
+
+- **`routes-d/lib/uploadHelper.ts`** — Pre-signed upload helper with in-memory file store. Provides `generatePresignedUrl` for mock URL generation, `storeFile` for persisting uploaded file metadata, and test helpers (`__resetUploads`, `__getUploads`, `__getUpload`).
+
+- **`routes-d/routes/kyc.upload.ts`** — `POST /kyc/upload` endpoint with:
+  - Multipart file upload via `multer` (memory storage)
+  - Authentication via `x-user-id` header
+  - File size validation (configurable via `KYC_MAX_FILE_SIZE` env var, default 10MB)
+  - MIME type validation via multer `fileFilter` (PDF, PNG, JPEG, GIF, WebP)
+  - Magic byte content verification as defense-in-depth
+  - Mock virus scan step
+  - Pre-signed URL generation and file metadata storage
+  - Returns `201` with `id`, `fileName`, `mimeType`, `size`, `presignedUrl`, `uploadedAt`
+
+- **`routes-d/tests/kyc.upload.test.ts`** — Route integration tests covering:
+  - Successful upload returns 201 with correct metadata
+  - Oversized file rejection (413 `FILE_TOO_LARGE`)
+  - Unsupported MIME type rejection (415 `UNSUPPORTED_FILE_TYPE`)
+  - Missing authentication (401 `UNAUTHORIZED`)
+  - Missing file (400 `NO_FILE`)
+  - Invalid file content / magic byte mismatch (415 `INVALID_FILE_CONTENT`)
+  - Unique file IDs per upload
+  - Concurrent upload isolation
+
+## Testing
+
+Tests follow the existing routes-d pattern (`supertest` + `express`, `buildApp()`, `beforeEach` reset, `__seed*` helpers).
+
+```bash
+npm test -- routes-d/tests/kyc.upload.test.ts
+```
+
+closes #386

--- a/routes-d/lib/uploadHelper.ts
+++ b/routes-d/lib/uploadHelper.ts
@@ -1,0 +1,51 @@
+import crypto from "crypto";
+
+export type StoredFile = {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  presignedUrl: string;
+  uploadedAt: string;
+};
+
+const fileStore = new Map<string, StoredFile>();
+
+export function generatePresignedUrl(fileName: string, contentType: string): string {
+  const expires = Date.now() + 3600000;
+  const encodedName = encodeURIComponent(fileName);
+  return `https://storage.nextellar.dev/kyc/${crypto.randomUUID()}?filename=${encodedName}&contentType=${encodeURIComponent(contentType)}&expires=${expires}&signature=mock-sig`;
+}
+
+export async function storeFile(
+  fileName: string,
+  buffer: Buffer,
+  mimeType: string,
+): Promise<StoredFile> {
+  const id = crypto.randomUUID();
+  const presignedUrl = generatePresignedUrl(fileName, mimeType);
+
+  const record: StoredFile = {
+    id,
+    fileName,
+    mimeType,
+    size: buffer.length,
+    presignedUrl,
+    uploadedAt: new Date().toISOString(),
+  };
+
+  fileStore.set(id, record);
+  return record;
+}
+
+export function __resetUploads(): void {
+  fileStore.clear();
+}
+
+export function __getUploads(): Map<string, StoredFile> {
+  return fileStore;
+}
+
+export function __getUpload(id: string): StoredFile | undefined {
+  return fileStore.get(id);
+}

--- a/routes-d/routes/kyc.upload.ts
+++ b/routes-d/routes/kyc.upload.ts
@@ -1,0 +1,120 @@
+import { Router, Request, Response, NextFunction } from "express";
+import multer from "multer";
+import { sendError } from "../lib/response.js";
+import { storeFile } from "../lib/uploadHelper.js";
+
+const router = Router();
+
+const ALLOWED_MIME_TYPES = new Set([
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+const MAGIC_SIGNATURES: Array<{ mime: string; bytes: number[] }> = [
+  { mime: "application/pdf", bytes: [0x25, 0x50, 0x44, 0x46] },
+  { mime: "image/png", bytes: [0x89, 0x50, 0x4e, 0x47] },
+  { mime: "image/jpeg", bytes: [0xff, 0xd8, 0xff] },
+  { mime: "image/gif", bytes: [0x47, 0x49, 0x46, 0x38] },
+  { mime: "image/webp", bytes: [0x52, 0x49, 0x46, 0x46] },
+];
+
+const MAX_FILE_SIZE = parseInt(process.env.KYC_MAX_FILE_SIZE || "10485760", 10);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("UNSUPPORTED_FILE_TYPE"));
+    }
+  },
+});
+
+function detectMimeType(buffer: Buffer): string | null {
+  for (const sig of MAGIC_SIGNATURES) {
+    if (buffer.length < sig.bytes.length) continue;
+    const matches = sig.bytes.every((byte, i) => buffer[i] === byte);
+    if (matches) return sig.mime;
+  }
+  return null;
+}
+
+async function virusScan(_buffer: Buffer): Promise<{ clean: boolean }> {
+  return { clean: true };
+}
+
+router.post(
+  "/kyc/upload",
+  (req: Request, res: Response, next: NextFunction) => {
+    upload.single("file")(req, res, async (err: unknown) => {
+      if (err) {
+        if (err instanceof multer.MulterError) {
+          if (err.code === "LIMIT_FILE_SIZE") {
+            sendError(res, "FILE_TOO_LARGE", `File exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`, 413);
+            return;
+          }
+          sendError(res, "UPLOAD_ERROR", err.message, 400);
+          return;
+        }
+        if (err instanceof Error && err.message === "UNSUPPORTED_FILE_TYPE") {
+          sendError(res, "UNSUPPORTED_FILE_TYPE", "File type is not supported. Allowed: PDF, PNG, JPEG, GIF, WebP", 415);
+          return;
+        }
+        return next(err);
+      }
+
+      try {
+        const file = (req as any).file;
+        if (!file) {
+          sendError(res, "NO_FILE", "No file was uploaded", 400);
+          return;
+        }
+
+        const userId = req.headers["x-user-id"] as string | undefined;
+        if (!userId) {
+          sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+          return;
+        }
+
+        const detectedMime = detectMimeType(file.buffer);
+        if (!detectedMime || !ALLOWED_MIME_TYPES.has(detectedMime)) {
+          sendError(res, "INVALID_FILE_CONTENT", "File content does not match its declared type", 415);
+          return;
+        }
+
+        const scanResult = await virusScan(file.buffer);
+        if (!scanResult.clean) {
+          sendError(res, "VIRUS_DETECTED", "File failed virus scan", 422);
+          return;
+        }
+
+        const stored = await storeFile(file.originalname, file.buffer, detectedMime);
+
+        res.status(201).json({
+          success: true,
+          data: {
+            id: stored.id,
+            fileName: stored.fileName,
+            mimeType: stored.mimeType,
+            size: stored.size,
+            presignedUrl: stored.presignedUrl,
+            uploadedAt: stored.uploadedAt,
+          },
+        });
+      } catch (innerErr) {
+        return next(innerErr);
+      }
+    });
+  },
+);
+
+export function __getMaxFileSize(): number {
+  return MAX_FILE_SIZE;
+}
+
+export default router;

--- a/routes-d/tests/kyc.upload.test.ts
+++ b/routes-d/tests/kyc.upload.test.ts
@@ -1,0 +1,123 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import kycUploadRouter, { __getMaxFileSize } from "../routes/kyc.upload.js";
+import { __resetUploads } from "../lib/uploadHelper.js";
+
+function buildApp() {
+  const app = express();
+  app.use(kycUploadRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("POST /kyc/upload", () => {
+  const app = buildApp();
+  const authHeader = { "x-user-id": "user-001" };
+
+  const validPdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x01, 0x02, 0x03]);
+
+  beforeEach(() => {
+    __resetUploads();
+  });
+
+  it("accepts a valid PDF file and returns upload metadata", async () => {
+    const res = await request(app)
+      .post("/kyc/upload")
+      .set(authHeader)
+      .attach("file", validPdfBytes, "document.pdf");
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data.fileName).toBe("document.pdf");
+    expect(res.body.data.mimeType).toBe("application/pdf");
+    expect(res.body.data.size).toBe(validPdfBytes.length);
+    expect(res.body.data).toHaveProperty("presignedUrl");
+    expect(res.body.data).toHaveProperty("uploadedAt");
+    expect(res.body.data.presignedUrl).toContain("storage.nextellar.dev");
+  });
+
+  it("rejects an oversized file", async () => {
+    const oversized = Buffer.alloc(__getMaxFileSize() + 1, 0x00);
+
+    const res = await request(app)
+      .post("/kyc/upload")
+      .set(authHeader)
+      .attach("file", oversized, {
+        filename: "large.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(413);
+    expect(res.body.error.code).toBe("FILE_TOO_LARGE");
+  });
+
+  it("rejects an unsupported file type via MIME check", async () => {
+    const res = await request(app)
+      .post("/kyc/upload")
+      .set(authHeader)
+      .attach("file", Buffer.from("binary-data"), "malware.exe");
+
+    expect(res.status).toBe(415);
+    expect(res.body.error.code).toBe("UNSUPPORTED_FILE_TYPE");
+  });
+
+  it("rejects requests without authentication", async () => {
+    const res = await request(app)
+      .post("/kyc/upload")
+      .attach("file", validPdfBytes, "document.pdf");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects requests without a file", async () => {
+    const res = await request(app)
+      .post("/kyc/upload")
+      .set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("NO_FILE");
+  });
+
+  it("rejects a file with mismatched content (invalid magic bytes)", async () => {
+    const res = await request(app)
+      .post("/kyc/upload")
+      .set(authHeader)
+      .attach("file", Buffer.from("fake-png-content"), {
+        filename: "image.png",
+        contentType: "image/png",
+      });
+
+    expect(res.status).toBe(415);
+    expect(res.body.error.code).toBe("INVALID_FILE_CONTENT");
+  });
+
+  it("stores the file record and returns the presigned URL", async () => {
+    const res = await request(app)
+      .post("/kyc/upload")
+      .set(authHeader)
+      .attach("file", validPdfBytes, "document.pdf");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toBeDefined();
+    expect(res.body.data.presignedUrl).toMatch(
+      /^https:\/\/storage\.nextellar\.dev\/kyc\//,
+    );
+  });
+
+  it("handles concurrent uploads with unique IDs", async () => {
+    const [r1, r2] = await Promise.all([
+      request(app).post("/kyc/upload").set(authHeader).attach("file", validPdfBytes, "doc1.pdf"),
+      request(app).post("/kyc/upload").set(authHeader).attach("file", validPdfBytes, "doc2.pdf"),
+    ]);
+
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
+    expect(r1.body.data.id).not.toBe(r2.body.data.id);
+    expect(r1.body.data.fileName).toBe("doc1.pdf");
+    expect(r2.body.data.fileName).toBe("doc2.pdf");
+  });
+});


### PR DESCRIPTION
KYC Document Upload Endpoint
Summary
Add POST /kyc/upload endpoint that accepts KYC document uploads through multipart form data for partners that require identity verification.

Changes
routes-d/lib/uploadHelper.ts — Pre-signed upload helper with in-memory file store. Provides generatePresignedUrl for mock URL generation, storeFile for persisting uploaded file metadata, and test helpers (__resetUploads, __getUploads, __getUpload).

routes-d/routes/kyc.upload.ts — POST /kyc/upload endpoint with:

Multipart file upload via multer (memory storage)
Authentication via x-user-id header
File size validation (configurable via KYC_MAX_FILE_SIZE env var, default 10MB)
MIME type validation via multer fileFilter (PDF, PNG, JPEG, GIF, WebP)
Magic byte content verification as defense-in-depth
Mock virus scan step
Pre-signed URL generation and file metadata storage
Returns 201 with id, fileName, mimeType, size, presignedUrl, uploadedAt
routes-d/tests/kyc.upload.test.ts — Route integration tests covering:

Successful upload returns 201 with correct metadata
Oversized file rejection (413 FILE_TOO_LARGE)
Unsupported MIME type rejection (415 UNSUPPORTED_FILE_TYPE)
Missing authentication (401 UNAUTHORIZED)
Missing file (400 NO_FILE)
Invalid file content / magic byte mismatch (415 INVALID_FILE_CONTENT)
Unique file IDs per upload
Concurrent upload isolation
Testing
Tests follow the existing routes-d pattern (supertest + express, buildApp(), beforeEach reset, __seed* helpers).

npm test -- routes-d/tests/kyc.upload.test.ts
closes https://github.com/nextellarlabs/nextellar/issues/386