### PR TITLE
feat: add sanctions list screening on outgoing payments

### DIFF
--- a/routes-d/docs/PR-387-sanctions-screening.md
+++ b/routes-d/docs/PR-387-sanctions-screening.md
@@ -1,0 +1,57 @@
+# Sanctions List Screening on Outgoing Payments
+
+## Summary
+
+Add sanctions list screening for outgoing payment destinations via a pluggable screening engine inside `routes-d/`.
+
+## Changes
+
+- **`routes-d/lib/sanctionsScreening.ts`** — Sanctions screening library with:
+  - `SanctionsListSource` interface for pluggable list backends
+  - Default in-memory list source with case-insensitive exact-match lookup
+  - `screenDestination(destination, source?)` returns `clean`, `hit`, or `error` status
+  - Built-in audit log recording every screening result with destination, decision, timestamp, and unique audit ID
+  - Test helpers (`__setSanctionsList`, `__addSanctionsEntry`, `__setSourceError`, `__resetAll`)
+
+- **`routes-d/routes/payments.screen.ts`** — `POST /payments/screen` endpoint:
+  - Authentication via `x-user-id` header
+  - Accepts `{ destination }` in request body
+  - Returns `200` with `{ status: "clean" }` for non-listed destinations
+  - Returns `403 SANCTIONS_HIT` for listed parties
+  - Returns `503 SCREENING_UNAVAILABLE` when the list source is unreachable
+  - Whitespace trimming on destination
+
+- **`routes-d/tests/unit/sanctionsScreening.test.ts`** — Unit tests (18 tests) covering:
+  - Clean (non-listed destination)
+  - Hit (listed destination)
+  - Case-insensitive matching
+  - Source unavailable (error state)
+  - Source throws during check
+  - Empty list
+  - Multiple entries
+  - Audit log recording and ID uniqueness
+  - Error status in audit log
+  - Audit log reset
+  - Test helper functions
+  - Custom pluggable source
+  - Unavailable custom source
+
+- **`routes-d/tests/payments.screen.test.ts`** — Route integration tests (8 tests) covering:
+  - Successful clean response (200)
+  - Sanctions hit rejection (403 `SANCTIONS_HIT`)
+  - Source unavailable (503 `SCREENING_UNAVAILABLE`)
+  - Missing authentication (401 `UNAUTHORIZED`)
+  - Missing destination (400 `INVALID_DESTINATION`)
+  - Non-string destination (400)
+  - Whitespace trimming
+  - Audit log integration
+
+## Testing
+
+Unit and integration tests follow the existing routes-d pattern (`supertest` + `express`, `buildApp()`, `beforeEach` reset).
+
+```bash
+npm test -- routes-d/tests/unit/sanctionsScreening.test.ts routes-d/tests/payments.screen.test.ts
+```
+
+closes #387

--- a/routes-d/lib/sanctionsScreening.ts
+++ b/routes-d/lib/sanctionsScreening.ts
@@ -1,0 +1,126 @@
+export type ScreeningResult = {
+  destination: string;
+  status: "clean" | "hit" | "error";
+  matchedEntry?: string;
+  matchedList?: string;
+  timestamp: Date;
+};
+
+export type AuditLogEntry = ScreeningResult & {
+  id: string;
+};
+
+export interface SanctionsListSource {
+  check(destination: string): Promise<{ hit: boolean; entry?: string; list?: string }>;
+  available(): Promise<boolean>;
+}
+
+const auditLog: AuditLogEntry[] = [];
+let auditCounter = 0;
+
+let sanctionsList: string[] = [];
+
+let sourceError: Error | null = null;
+
+const defaultSource: SanctionsListSource = {
+  async check(destination: string) {
+    if (sourceError) throw sourceError;
+    const normalized = destination.toUpperCase();
+    const match = sanctionsList.find(
+      (entry) => entry.toUpperCase() === normalized,
+    );
+    if (match) {
+      return { hit: true, entry: match, list: "OFAC_SDN" };
+    }
+    return { hit: false };
+  },
+  async available() {
+    return sourceError === null;
+  },
+};
+
+export function getDefaultSource(): SanctionsListSource {
+  return defaultSource;
+}
+
+export async function screenDestination(
+  destination: string,
+  source: SanctionsListSource = defaultSource,
+): Promise<ScreeningResult> {
+  const entryId = `audit-${++auditCounter}`;
+  const now = new Date();
+
+  try {
+    const available = await source.available();
+    if (!available) {
+      const result: ScreeningResult = {
+        destination,
+        status: "error",
+        timestamp: now,
+      };
+      auditLog.push({ ...result, id: entryId });
+      return result;
+    }
+
+    const checkResult = await source.check(destination);
+
+    if (checkResult.hit) {
+      const result: ScreeningResult = {
+        destination,
+        status: "hit",
+        matchedEntry: checkResult.entry,
+        matchedList: checkResult.list,
+        timestamp: now,
+      };
+      auditLog.push({ ...result, id: entryId });
+      return result;
+    }
+
+    const result: ScreeningResult = {
+      destination,
+      status: "clean",
+      timestamp: now,
+    };
+    auditLog.push({ ...result, id: entryId });
+    return result;
+  } catch {
+    const result: ScreeningResult = {
+      destination,
+      status: "error",
+      timestamp: now,
+    };
+    auditLog.push({ ...result, id: entryId });
+    return result;
+  }
+}
+
+export function getAuditLog(): readonly AuditLogEntry[] {
+  return [...auditLog];
+}
+
+export function resetAuditLog(): void {
+  auditLog.length = 0;
+  auditCounter = 0;
+}
+
+export function __setSanctionsList(entries: string[]): void {
+  sanctionsList = [...entries];
+}
+
+export function __addSanctionsEntry(entry: string): void {
+  sanctionsList.push(entry);
+}
+
+export function __getSanctionsList(): string[] {
+  return [...sanctionsList];
+}
+
+export function __setSourceError(error: Error | null): void {
+  sourceError = error;
+}
+
+export function __resetAll(): void {
+  resetAuditLog();
+  sanctionsList = [];
+  sourceError = null;
+}

--- a/routes-d/routes/payments.screen.ts
+++ b/routes-d/routes/payments.screen.ts
@@ -1,0 +1,59 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import { screenDestination } from "../lib/sanctionsScreening.js";
+
+const router = Router();
+
+type ScreenPaymentBody = {
+  destination: string;
+};
+
+router.post(
+  "/payments/screen",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.headers["x-user-id"] as string | undefined;
+      if (!userId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const body = req.body as ScreenPaymentBody;
+
+      if (!body.destination || typeof body.destination !== "string") {
+        sendError(res, "INVALID_DESTINATION", "destination is required and must be a string", 400);
+        return;
+      }
+
+      const result = await screenDestination(body.destination.trim());
+
+      if (result.status === "error") {
+        sendError(res, "SCREENING_UNAVAILABLE", "Sanctions list source is currently unavailable", 503);
+        return;
+      }
+
+      if (result.status === "hit") {
+        sendError(
+          res,
+          "SANCTIONS_HIT",
+          `Destination is listed on a sanctions list (${result.matchedList})`,
+          403,
+        );
+        return;
+      }
+
+      res.status(200).json({
+        success: true,
+        data: {
+          destination: result.destination,
+          status: result.status,
+          timestamp: result.timestamp,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/payments.screen.test.ts
+++ b/routes-d/tests/payments.screen.test.ts
@@ -1,0 +1,125 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import screenRouter from "../routes/payments.screen.js";
+import {
+  __resetAll,
+  __setSanctionsList,
+  __setSourceError,
+  getAuditLog,
+} from "../lib/sanctionsScreening.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(screenRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const SANCTIONED_ADDR = "GCANMZYBQSBY4U6UY7V7ZA5P7LG5V6Q6V5PZ5Q6V7A5P7LG5V6Q6V5P";
+const CLEAN_ADDR = "GA7OPG4E2Z5Q6V7A5P7LG5V6Q6V5PZ5Q6V7A5P7LG5V6Q6V5PZ5";
+
+describe("POST /payments/screen", () => {
+  const app = buildApp();
+  const authHeader = { "x-user-id": "user-001" };
+
+  beforeEach(() => {
+    __resetAll();
+  });
+
+  it("returns 200 with clean status for a non-listed destination", async () => {
+    __setSanctionsList([SANCTIONED_ADDR]);
+
+    const res = await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({ destination: CLEAN_ADDR });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe("clean");
+    expect(res.body.data.destination).toBe(CLEAN_ADDR);
+    expect(res.body.data.timestamp).toBeDefined();
+  });
+
+  it("returns 403 with SANCTIONS_HIT for a listed destination", async () => {
+    __setSanctionsList([SANCTIONED_ADDR]);
+
+    const res = await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({ destination: SANCTIONED_ADDR });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("SANCTIONS_HIT");
+    expect(res.body.error.message).toContain("OFAC_SDN");
+  });
+
+  it("returns 503 SCREENING_UNAVAILABLE when the list source is unavailable", async () => {
+    __setSourceError(new Error("Source unavailable"));
+
+    const res = await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({ destination: CLEAN_ADDR });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe("SCREENING_UNAVAILABLE");
+  });
+
+  it("returns 401 UNAUTHORIZED when x-user-id header is missing", async () => {
+    const res = await request(app)
+      .post("/payments/screen")
+      .send({ destination: CLEAN_ADDR });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 INVALID_DESTINATION when destination is missing", async () => {
+    const res = await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DESTINATION");
+  });
+
+  it("returns 400 when destination is not a string", async () => {
+    const res = await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({ destination: 123 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_DESTINATION");
+  });
+
+  it("trims whitespace from destination", async () => {
+    __setSanctionsList([SANCTIONED_ADDR]);
+
+    const res = await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({ destination: `  ${CLEAN_ADDR}  ` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("clean");
+    expect(res.body.data.destination).toBe(CLEAN_ADDR);
+  });
+
+  it("records screening in audit log on success", async () => {
+    await request(app)
+      .post("/payments/screen")
+      .set(authHeader)
+      .send({ destination: CLEAN_ADDR });
+
+    const log = getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].destination).toBe(CLEAN_ADDR);
+    expect(log[0].status).toBe("clean");
+  });
+});

--- a/routes-d/tests/unit/sanctionsScreening.test.ts
+++ b/routes-d/tests/unit/sanctionsScreening.test.ts
@@ -1,0 +1,224 @@
+import {
+  screenDestination,
+  getAuditLog,
+  resetAuditLog,
+  __resetAll,
+  __setSanctionsList,
+  __addSanctionsEntry,
+  __setSourceError,
+  __getSanctionsList,
+  getDefaultSource,
+  type SanctionsListSource,
+  type ScreeningResult,
+} from "../../lib/sanctionsScreening.js";
+
+const SANCTIONED_ADDR = "GCANMZYBQSBY4U6UY7V7ZA5P7LG5V6Q6V5PZ5Q6V7A5P7LG5V6Q6V5P";
+const CLEAN_ADDR = "GA7OPG4E2Z5Q6V7A5P7LG5V6Q6V5PZ5Q6V7A5P7LG5V6Q6V5PZ5";
+
+describe("sanctionsScreening", () => {
+  beforeEach(() => {
+    __resetAll();
+  });
+
+  describe("screenDestination", () => {
+    it("returns clean for a non-listed destination", async () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+
+      const result = await screenDestination(CLEAN_ADDR);
+
+      expect(result.status).toBe("clean");
+      expect(result.destination).toBe(CLEAN_ADDR);
+      expect(result.matchedEntry).toBeUndefined();
+      expect(result.matchedList).toBeUndefined();
+      expect(result.timestamp).toBeInstanceOf(Date);
+    });
+
+    it("returns hit for a listed destination", async () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+
+      const result = await screenDestination(SANCTIONED_ADDR);
+
+      expect(result.status).toBe("hit");
+      expect(result.destination).toBe(SANCTIONED_ADDR);
+      expect(result.matchedEntry).toBe(SANCTIONED_ADDR);
+      expect(result.matchedList).toBe("OFAC_SDN");
+    });
+
+    it("is case-insensitive when matching", async () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+
+      const mixedCase = SANCTIONED_ADDR.toLowerCase();
+      const result = await screenDestination(mixedCase);
+
+      expect(result.status).toBe("hit");
+      expect(result.matchedEntry).toBe(SANCTIONED_ADDR);
+    });
+
+    it("returns error when the source is unavailable", async () => {
+      __setSourceError(new Error("Source unavailable"));
+
+      const result = await screenDestination(CLEAN_ADDR);
+
+      expect(result.status).toBe("error");
+      expect(result.destination).toBe(CLEAN_ADDR);
+    });
+
+    it("returns error when the source throws during check", async () => {
+      const failingSource: SanctionsListSource = {
+        async check() {
+          throw new Error("Network error");
+        },
+        async available() {
+          return true;
+        },
+      };
+
+      const result = await screenDestination(CLEAN_ADDR, failingSource);
+
+      expect(result.status).toBe("error");
+    });
+
+    it("handles an empty sanctions list", async () => {
+      __setSanctionsList([]);
+
+      const result = await screenDestination(SANCTIONED_ADDR);
+
+      expect(result.status).toBe("clean");
+    });
+
+    it("matches against multiple entries", async () => {
+      __setSanctionsList([
+        "GAAAA111111111111111111111111111111111111111111111111111111111",
+        SANCTIONED_ADDR,
+        "GBBBB222222222222222222222222222222222222222222222222222222222",
+      ]);
+
+      const result = await screenDestination(SANCTIONED_ADDR);
+
+      expect(result.status).toBe("hit");
+      expect(result.matchedEntry).toBe(SANCTIONED_ADDR);
+    });
+  });
+
+  describe("audit log", () => {
+    it("records every screening result", async () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+
+      await screenDestination(CLEAN_ADDR);
+      await screenDestination(SANCTIONED_ADDR);
+
+      const log = getAuditLog();
+      expect(log).toHaveLength(2);
+      expect(log[0].status).toBe("clean");
+      expect(log[0].destination).toBe(CLEAN_ADDR);
+      expect(log[1].status).toBe("hit");
+      expect(log[1].destination).toBe(SANCTIONED_ADDR);
+      expect(log[1].matchedEntry).toBe(SANCTIONED_ADDR);
+    });
+
+    it("assigns unique audit IDs", async () => {
+      await screenDestination(CLEAN_ADDR);
+      await screenDestination(CLEAN_ADDR);
+
+      const log = getAuditLog();
+      expect(log[0].id).not.toBe(log[1].id);
+    });
+
+    it("records error status in audit log", async () => {
+      __setSourceError(new Error("Down"));
+
+      await screenDestination(CLEAN_ADDR);
+
+      const log = getAuditLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].status).toBe("error");
+      expect(log[0].destination).toBe(CLEAN_ADDR);
+    });
+
+    it("resetAuditLog clears the audit trail", async () => {
+      await screenDestination(CLEAN_ADDR);
+      expect(getAuditLog()).toHaveLength(1);
+
+      resetAuditLog();
+      expect(getAuditLog()).toHaveLength(0);
+    });
+  });
+
+  describe("test helpers", () => {
+    it("__setSanctionsList sets the list", () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+      expect(__getSanctionsList()).toEqual([SANCTIONED_ADDR]);
+    });
+
+    it("__addSanctionsEntry appends to the list", () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+      __addSanctionsEntry("GABCDEF123456789012345678901234567890123456789012345678901234567");
+      expect(__getSanctionsList()).toHaveLength(2);
+    });
+
+    it("__resetAll clears everything", async () => {
+      __setSanctionsList([SANCTIONED_ADDR]);
+      await screenDestination(CLEAN_ADDR);
+      expect(getAuditLog()).toHaveLength(1);
+      expect(__getSanctionsList()).toHaveLength(1);
+
+      __resetAll();
+      expect(getAuditLog()).toHaveLength(0);
+      expect(__getSanctionsList()).toHaveLength(0);
+    });
+
+    it("__setSourceError(null) restores availability", async () => {
+      __setSourceError(new Error("Down"));
+      await screenDestination(CLEAN_ADDR);
+      expect((await screenDestination(CLEAN_ADDR)).status).toBe("error");
+
+      __setSourceError(null);
+      const result = await screenDestination(CLEAN_ADDR);
+      expect(result.status).toBe("clean");
+    });
+  });
+
+  describe("pluggable source", () => {
+    it("uses a custom source when provided", async () => {
+      const customSource: SanctionsListSource = {
+        async check(destination: string) {
+          if (destination === "blocked-addr") {
+            return { hit: true, entry: "blocked-addr", list: "CUSTOM" };
+          }
+          return { hit: false };
+        },
+        async available() {
+          return true;
+        },
+      };
+
+      const blocked = await screenDestination("blocked-addr", customSource);
+      expect(blocked.status).toBe("hit");
+      expect(blocked.matchedList).toBe("CUSTOM");
+
+      const allowed = await screenDestination("safe-addr", customSource);
+      expect(allowed.status).toBe("clean");
+    });
+
+    it("rejects when custom source is unavailable", async () => {
+      const unavailableSource: SanctionsListSource = {
+        async check() {
+          return { hit: false };
+        },
+        async available() {
+          return false;
+        },
+      };
+
+      const result = await screenDestination(CLEAN_ADDR, unavailableSource);
+      expect(result.status).toBe("error");
+    });
+
+    it("getDefaultSource returns the default source", () => {
+      const source = getDefaultSource();
+      expect(source).toBeDefined();
+      expect(typeof source.check).toBe("function");
+      expect(typeof source.available).toBe("function");
+    });
+  });
+});


### PR DESCRIPTION
# Sanctions List Screening on Outgoing Payments

## Summary

Add sanctions list screening for outgoing payment destinations via a pluggable screening engine inside `routes-d/`.

## Changes

- **`routes-d/lib/sanctionsScreening.ts`** — Sanctions screening library with:
  - `SanctionsListSource` interface for pluggable list backends
  - Default in-memory list source with case-insensitive exact-match lookup
  - `screenDestination(destination, source?)` returns `clean`, `hit`, or `error` status
  - Built-in audit log recording every screening result with destination, decision, timestamp, and unique audit ID
  - Test helpers (`__setSanctionsList`, `__addSanctionsEntry`, `__setSourceError`, `__resetAll`)

- **`routes-d/routes/payments.screen.ts`** — `POST /payments/screen` endpoint:
  - Authentication via `x-user-id` header
  - Accepts `{ destination }` in request body
  - Returns `200` with `{ status: "clean" }` for non-listed destinations
  - Returns `403 SANCTIONS_HIT` for listed parties
  - Returns `503 SCREENING_UNAVAILABLE` when the list source is unreachable
  - Whitespace trimming on destination

- **`routes-d/tests/unit/sanctionsScreening.test.ts`** — Unit tests (18 tests) covering:
  - Clean (non-listed destination)
  - Hit (listed destination)
  - Case-insensitive matching
  - Source unavailable (error state)
  - Source throws during check
  - Empty list
  - Multiple entries
  - Audit log recording and ID uniqueness
  - Error status in audit log
  - Audit log reset
  - Test helper functions
  - Custom pluggable source
  - Unavailable custom source

- **`routes-d/tests/payments.screen.test.ts`** — Route integration tests (8 tests) covering:
  - Successful clean response (200)
  - Sanctions hit rejection (403 `SANCTIONS_HIT`)
  - Source unavailable (503 `SCREENING_UNAVAILABLE`)
  - Missing authentication (401 `UNAUTHORIZED`)
  - Missing destination (400 `INVALID_DESTINATION`)
  - Non-string destination (400)
  - Whitespace trimming
  - Audit log integration

## Testing

Unit and integration tests follow the existing routes-d pattern (`supertest` + `express`, `buildApp()`, `beforeEach` reset).

```bash
npm test -- routes-d/tests/unit/sanctionsScreening.test.ts routes-d/tests/payments.screen.test.ts
```

closes #387
