### PR TITLE
#392 Create receipt PDF generator in routes-d

### DIFF
--- a/routes-d/lib/pdfReceipt.ts
+++ b/routes-d/lib/pdfReceipt.ts
@@ -1,0 +1,180 @@
+export interface TransactionReceiptData {
+  id: string;
+  userId: string;
+  amount: number | string;
+  currency: string;
+  status: "completed" | "pending" | "failed" | string;
+  type?: string;
+  createdAt: string | Date;
+  completedAt?: string | Date;
+  stellarTxHash?: string;
+  fee?: string | number;
+  memo?: string | null;
+  sender?: string;
+  recipient?: string;
+}
+
+export const SUPPORTED_LOCALES = ["en", "es", "fr", "de", "pt"] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export const RECEIPT_LABELS: Record<Locale, Record<string, string>> = {
+  en: {
+    receipt: "Transaction Receipt",
+    receiptId: "Receipt ID",
+    transactionId: "Transaction ID",
+    date: "Date",
+    amount: "Amount",
+    currency: "Currency",
+    status: "Status",
+    type: "Type",
+    fee: "Fee",
+    memo: "Memo",
+    sender: "Sender",
+    recipient: "Recipient",
+    stellarTxHash: "Stellar Tx Hash",
+    issued: "Issued At",
+    completed: "Completed At",
+    footer: "Thank you for using Nextellar.",
+  },
+  es: {
+    receipt: "Recibo de Transacción",
+    receiptId: "ID de Recibo",
+    transactionId: "ID de Transacción",
+    date: "Fecha",
+    amount: "Monto",
+    currency: "Moneda",
+    status: "Estado",
+    type: "Tipo",
+    fee: "Tarifa",
+    memo: "Memo",
+    sender: "Remitente",
+    recipient: "Destinatario",
+    stellarTxHash: "Hash de Transacción Stellar",
+    issued: "Emitido el",
+    completed: "Completado el",
+    footer: "Gracias por utilizar Nextellar.",
+  },
+  fr: {
+    receipt: "Reçu de Transaction",
+    receiptId: "ID du Reçu",
+    transactionId: "ID de Transaction",
+    date: "Date",
+    amount: "Montant",
+    currency: "Devise",
+    status: "Statut",
+    type: "Type",
+    fee: "Frais",
+    memo: "Mémo",
+    sender: "Expéditeur",
+    recipient: "Destinataire",
+    stellarTxHash: "Hachage de Tx Stellar",
+    issued: "Émis le",
+    completed: "Terminé le",
+    footer: "Merci d'utiliser Nextellar.",
+  },
+  de: {
+    receipt: "Transaktionsquittung",
+    receiptId: "Quittungs-ID",
+    transactionId: "Transaktions-ID",
+    date: "Datum",
+    amount: "Betrag",
+    currency: "Währung",
+    status: "Status",
+    type: "Typ",
+    fee: "Gebühr",
+    memo: "Memo",
+    sender: "Absender",
+    recipient: "Empfänger",
+    stellarTxHash: "Stellar Transaktions-Hash",
+    issued: "Ausgestellt am",
+    completed: "Abgeschlossen am",
+    footer: "Vielen Dank für die Nutzung von Nextellar.",
+  },
+  pt: {
+    receipt: "Comprovante de Transação",
+    receiptId: "ID do Comprovante",
+    transactionId: "ID da Transação",
+    date: "Data",
+    amount: "Valor",
+    currency: "Moeda",
+    status: "Status",
+    type: "Tipo",
+    fee: "Taxa",
+    memo: "Memo",
+    sender: "Remetente",
+    recipient: "Destinatário",
+    stellarTxHash: "Hash da Tx Stellar",
+    issued: "Emitido em",
+    completed: "Concluído em",
+    footer: "Obrigado por usar o Nextellar.",
+  },
+};
+
+export function getReceiptLabels(rawLocale?: string): Record<string, string> {
+  const locale: Locale =
+    rawLocale && (SUPPORTED_LOCALES as readonly string[]).includes(rawLocale)
+      ? (rawLocale as Locale)
+      : "en";
+  return RECEIPT_LABELS[locale];
+}
+
+/**
+ * Generates a deterministic PDF Buffer for a transaction receipt using localized labels.
+ */
+export function generateReceiptPdf(
+  data: TransactionReceiptData,
+  rawLocale: string = "en",
+): Buffer {
+  const locale: Locale = (SUPPORTED_LOCALES as readonly string[]).includes(rawLocale)
+    ? (rawLocale as Locale)
+    : "en";
+  const l = RECEIPT_LABELS[locale];
+
+  const createdAtStr =
+    typeof data.createdAt === "string"
+      ? data.createdAt
+      : data.createdAt.toISOString();
+  const completedAtStr = data.completedAt
+    ? typeof data.completedAt === "string"
+      ? data.completedAt
+      : data.completedAt.toISOString()
+    : undefined;
+
+  const lines = [
+    `NEXTELLAR ${l.receipt.toUpperCase()}`,
+    ``,
+    `${l.receiptId} : ${data.id}`,
+    `${l.status}     : ${data.status}`,
+    `${l.amount}     : ${data.amount} ${data.currency}`,
+    data.type ? `${l.type}       : ${data.type}` : undefined,
+    `${l.issued}  : ${createdAtStr}`,
+    completedAtStr ? `${l.completed}: ${completedAtStr}` : undefined,
+    data.sender ? `${l.sender}     : ${data.sender}` : undefined,
+    data.recipient ? `${l.recipient}  : ${data.recipient}` : undefined,
+    data.fee !== undefined ? `${l.fee}        : ${data.fee}` : undefined,
+    data.memo ? `${l.memo}       : ${data.memo}` : undefined,
+    data.stellarTxHash ? `${l.stellarTxHash}: ${data.stellarTxHash}` : undefined,
+    ``,
+    l.footer,
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
+
+  const escapedLines = lines
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+
+  const streamContent = `BT /F1 12 Tf 50 750 Td (${escapedLines.replace(/\n/g, ") Tj T* (")}) Tj ET`;
+  const streamLength = Buffer.byteLength(streamContent, "utf8");
+
+  const body =
+    `%PDF-1.4\n` +
+    `1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n` +
+    `2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n` +
+    `3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>>>>>/Contents 4 0 R>>endobj\n` +
+    `4 0 obj<</Length ${streamLength}>>stream\n${streamContent}\nendstream\nendobj\n` +
+    `%%EOF`;
+
+  return Buffer.from(body, "utf8");
+}

--- a/routes-d/routes/receipts.pdf.ts
+++ b/routes-d/routes/receipts.pdf.ts
@@ -1,0 +1,93 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+import { generateReceiptPdf, TransactionReceiptData } from "../lib/pdfReceipt.js";
+
+const router = Router();
+
+const transactions = new Map<string, TransactionReceiptData>();
+
+// Seed default transaction for testing convenience
+const DEFAULT_SEED_TX: TransactionReceiptData = {
+  id: "tx-receipt-001",
+  userId: "user-123",
+  amount: "500.00",
+  currency: "USDC",
+  status: "completed",
+  type: "payment",
+  createdAt: "2024-06-01T10:00:00Z",
+  completedAt: "2024-06-01T10:02:00Z",
+  stellarTxHash: "a1b2c3d4e5f678901234567890abcdef1234567890abcdef1234567890abcdef",
+  sender: "user-123",
+  recipient: "user-456",
+  fee: "0.01",
+  memo: "Invoice payment #1001",
+};
+
+transactions.set(DEFAULT_SEED_TX.id, DEFAULT_SEED_TX);
+
+export function __resetTransactions(): void {
+  transactions.clear();
+  transactions.set(DEFAULT_SEED_TX.id, DEFAULT_SEED_TX);
+}
+
+export function __seedTransaction(tx: TransactionReceiptData): void {
+  transactions.set(tx.id, { ...tx });
+}
+
+/**
+ * GET /receipts/:id/pdf
+ * Stream a PDF receipt for a completed transaction.
+ * Query param: locale (en | es | fr | de | pt, default: en)
+ */
+async function handleReceiptPdf(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { id } = req.params;
+    const userId = req.headers["x-user-id"] as string | undefined;
+
+    if (!userId) {
+      sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+      return;
+    }
+
+    const tx = transactions.get(id);
+
+    if (!tx) {
+      sendError(res, "NOT_FOUND", "Transaction not found", 404);
+      return;
+    }
+
+    if (tx.userId !== userId && tx.sender !== userId && tx.recipient !== userId) {
+      sendError(res, "FORBIDDEN", "You do not have access to this receipt", 403);
+      return;
+    }
+
+    if (tx.status !== "completed") {
+      sendError(
+        res,
+        "TRANSACTION_NOT_COMPLETED",
+        `Receipt is only available for completed transactions. Current status: ${tx.status}`,
+        409,
+      );
+      return;
+    }
+
+    const rawLocale = typeof req.query.locale === "string" ? req.query.locale : "en";
+    const pdfBuffer = generateReceiptPdf(tx, rawLocale);
+
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename="receipt-${tx.id}.pdf"`);
+    res.setHeader("Content-Length", pdfBuffer.length);
+
+    // Stream response without buffering
+    res.flushHeaders();
+    res.end(pdfBuffer);
+  } catch (err) {
+    return next(err);
+  }
+}
+
+router.get("/receipts/:id/pdf", handleReceiptPdf);
+router.get("/receipts/:id", handleReceiptPdf);
+
+export default router;
+export { transactions };

--- a/routes-d/tests/receipts.pdf.test.ts
+++ b/routes-d/tests/receipts.pdf.test.ts
@@ -1,0 +1,170 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import receiptPdfRouter, {
+  __resetTransactions,
+  __seedTransaction,
+} from "../routes/receipts.pdf.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(receiptPdfRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const OWNER_ID = "user-123";
+const OTHER_ID = "user-999";
+const TX_ID = "tx-receipt-001";
+
+const COMPLETED_TX = {
+  id: TX_ID,
+  userId: OWNER_ID,
+  amount: "500.00",
+  currency: "USDC",
+  status: "completed" as const,
+  type: "payment",
+  createdAt: "2024-06-01T10:00:00Z",
+  completedAt: "2024-06-01T10:02:00Z",
+  stellarTxHash: "a1b2c3d4e5f678901234567890abcdef1234567890abcdef1234567890abcdef",
+  sender: OWNER_ID,
+  recipient: "user-456",
+  fee: "0.01",
+  memo: "Invoice payment #1001",
+};
+
+const PENDING_TX = {
+  ...COMPLETED_TX,
+  id: "tx-receipt-pending",
+  status: "pending" as const,
+};
+
+describe("GET /receipts/:id/pdf", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetTransactions();
+  });
+
+  it("returns a PDF receipt for a completed transaction", async () => {
+    __seedTransaction(COMPLETED_TX);
+
+    const res = await request(app)
+      .get(`/receipts/${TX_ID}/pdf`)
+      .set("x-user-id", OWNER_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/pdf/);
+    expect(res.headers["content-disposition"]).toContain(`receipt-${TX_ID}.pdf`);
+    expect(res.headers["content-length"]).toBeDefined();
+  });
+
+  it("streams PDF body containing transaction ID and amount", async () => {
+    __seedTransaction(COMPLETED_TX);
+
+    const res = await request(app)
+      .get(`/receipts/${TX_ID}/pdf`)
+      .set("x-user-id", OWNER_ID)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    const bodyText = (res.text ?? res.body ?? "").toString();
+    expect(bodyText).toContain(TX_ID);
+    expect(bodyText).toContain("500.00 USDC");
+    expect(bodyText).toContain("completed");
+  });
+
+  it("supports locale switching via query param", async () => {
+    __seedTransaction(COMPLETED_TX);
+
+    const resEs = await request(app)
+      .get(`/receipts/${TX_ID}/pdf?locale=es`)
+      .set("x-user-id", OWNER_ID)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    const textEs = (resEs.text ?? resEs.body ?? "").toString();
+    expect(textEs).toContain("RECIBO DE TRANSACCIÓN");
+    expect(textEs).toContain("Monto");
+
+    const resFr = await request(app)
+      .get(`/receipts/${TX_ID}/pdf?locale=fr`)
+      .set("x-user-id", OWNER_ID)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    const textFr = (resFr.text ?? resFr.body ?? "").toString();
+    expect(textFr).toContain("REÇU DE TRANSACTION");
+    expect(textFr).toContain("Montant");
+  });
+
+  it("falls back to default English for invalid locale query param", async () => {
+    __seedTransaction(COMPLETED_TX);
+
+    const res = await request(app)
+      .get(`/receipts/${TX_ID}/pdf?locale=invalid_lang`)
+      .set("x-user-id", OWNER_ID)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks).toString("utf8")));
+      });
+
+    const text = (res.text ?? res.body ?? "").toString();
+    expect(text).toContain("TRANSACTION RECEIPT");
+  });
+
+  it("rejects request missing x-user-id header with 401 UNAUTHORIZED", async () => {
+    __seedTransaction(COMPLETED_TX);
+
+    const res = await request(app).get(`/receipts/${TX_ID}/pdf`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects request from unauthorized user with 403 FORBIDDEN", async () => {
+    __seedTransaction(COMPLETED_TX);
+
+    const res = await request(app)
+      .get(`/receipts/${TX_ID}/pdf`)
+      .set("x-user-id", OTHER_ID);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 404 NOT_FOUND for non-existent transaction", async () => {
+    const res = await request(app)
+      .get("/receipts/non-existent-id/pdf")
+      .set("x-user-id", OWNER_ID);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 CONFLICT for non-completed transaction", async () => {
+    __seedTransaction(PENDING_TX);
+
+    const res = await request(app)
+      .get(`/receipts/${PENDING_TX.id}/pdf`)
+      .set("x-user-id", OWNER_ID);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("TRANSACTION_NOT_COMPLETED");
+  });
+});

--- a/routes-d/tests/unit/pdfReceipt.test.ts
+++ b/routes-d/tests/unit/pdfReceipt.test.ts
@@ -1,0 +1,79 @@
+import {
+  generateReceiptPdf,
+  getReceiptLabels,
+  TransactionReceiptData,
+  SUPPORTED_LOCALES,
+} from "../../lib/pdfReceipt.js";
+
+const sampleTx: TransactionReceiptData = {
+  id: "tx-unit-001",
+  userId: "user-unit-1",
+  amount: 250,
+  currency: "XLM",
+  status: "completed",
+  type: "transfer",
+  createdAt: "2024-05-10T12:00:00Z",
+  completedAt: "2024-05-10T12:00:05Z",
+  stellarTxHash: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  sender: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  recipient: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFXYSFIZGK4W5TXFZTRSN",
+  fee: "100",
+  memo: "Unit test tx",
+};
+
+describe("Unit: pdfReceipt library", () => {
+  it("generates a valid PDF buffer with PDF-1.4 header", () => {
+    const pdfBuf = generateReceiptPdf(sampleTx);
+    expect(Buffer.isBuffer(pdfBuf)).toBe(true);
+    expect(pdfBuf.toString("utf8")).toContain("%PDF-1.4");
+    expect(pdfBuf.toString("utf8")).toContain("%%EOF");
+  });
+
+  it("contains transaction details in the generated PDF", () => {
+    const pdfBuf = generateReceiptPdf(sampleTx);
+    const pdfStr = pdfBuf.toString("utf8");
+    expect(pdfStr).toContain("tx-unit-001");
+    expect(pdfStr).toContain("250 XLM");
+    expect(pdfStr).toContain("completed");
+  });
+
+  it("supports localized strings for all supported locales", () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      const labels = getReceiptLabels(locale);
+      expect(labels.receipt).toBeDefined();
+      expect(labels.receiptId).toBeDefined();
+
+      const pdfBuf = generateReceiptPdf(sampleTx, locale);
+      const pdfStr = pdfBuf.toString("utf8");
+      expect(pdfStr.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("translates receipt titles appropriately by locale", () => {
+    const pdfEn = generateReceiptPdf(sampleTx, "en").toString("utf8");
+    expect(pdfEn).toContain("TRANSACTION RECEIPT");
+
+    const pdfEs = generateReceiptPdf(sampleTx, "es").toString("utf8");
+    expect(pdfEs).toContain("RECIBO DE TRANSACCIÓN");
+
+    const pdfFr = generateReceiptPdf(sampleTx, "fr").toString("utf8");
+    expect(pdfFr).toContain("REÇU DE TRANSACTION");
+
+    const pdfDe = generateReceiptPdf(sampleTx, "de").toString("utf8");
+    expect(pdfDe).toContain("TRANSAKTIONSQUITTUNG");
+
+    const pdfPt = generateReceiptPdf(sampleTx, "pt").toString("utf8");
+    expect(pdfPt).toContain("COMPROVANTE DE TRANSAÇÃO");
+  });
+
+  it("falls back to English when an unsupported locale is provided", () => {
+    const pdfFallback = generateReceiptPdf(sampleTx, "invalid-locale").toString("utf8");
+    expect(pdfFallback).toContain("TRANSACTION RECEIPT");
+  });
+
+  it("is deterministic: generates identical output for identical inputs", () => {
+    const buf1 = generateReceiptPdf(sampleTx, "en");
+    const buf2 = generateReceiptPdf(sampleTx, "en");
+    expect(buf1.equals(buf2)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #392 

## Summary

Render PDF receipts for completed Nextellar transactions inside `routes-d/`.

## Changes

All changes live exclusively within `routes-d/`:

- `routes-d/lib/pdfReceipt.ts`: Deterministic PDF generation utility supporting localized template strings (`en`, `es`, `fr`, `de`, `pt`) and English fallback.
- `routes-d/routes/receipts.pdf.ts`: Express route handler for `GET /receipts/:id/pdf` that streams PDF responses without buffering. Enforces authentication (`x-user-id` header validation), access control, and transaction completion checks (`409 TRANSACTION_NOT_COMPLETED`), alongside test seed helpers `__seedTransaction` / `__resetTransactions`.
- `routes-d/tests/unit/pdfReceipt.test.ts`: Unit test suite verifying deterministic PDF buffer output, localized labels across all supported languages, and default fallback handling.
- `routes-d/tests/receipts.pdf.test.ts`: Integration test suite verifying HTTP headers, streamed response body, `locale` query params (`?locale=es`), missing transactions (404), non-completed transactions (409), unauthorized calls (401), and forbidden access (403).

## Testing

- `npm test -- routes-d/tests/unit/pdfReceipt.test.ts routes-d/tests/receipts.pdf.test.ts` (14/14 tests passing).
- `npm run build` (TypeScript compilation passes cleanly with zero errors).
