### PR TITLE
feat: add ErrorBoundary component to template

### DIFF
--- a/src/templates/default/src/app/layout.tsx
+++ b/src/templates/default/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,9 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/templates/default/src/components/ErrorBoundary.tsx
+++ b/src/templates/default/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  showDetails: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    this.setState({
+      error,
+      errorInfo,
+    });
+  }
+
+  handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+  };
+
+  toggleDetails = () => {
+    this.setState((prevState) => ({
+      showDetails: !prevState.showDetails,
+    }));
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen items-center justify-center p-4">
+          <div className="max-w-md w-full rounded-lg border border-gray-200 bg-white p-6 shadow-lg dark:border-gray-700 dark:bg-gray-900">
+            <div className="mb-4">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                Something went wrong
+              </h2>
+              <p className="mt-2 text-gray-600 dark:text-gray-400">
+                An unexpected error occurred. Please try again or contact support
+                if the problem persists.
+              </p>
+            </div>
+
+            <button
+              onClick={this.handleReset}
+              className="mb-4 w-full rounded-lg bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              Try Again
+            </button>
+
+            <button
+              onClick={this.toggleDetails}
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2 font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              {this.state.showDetails ? 'Hide Details' : 'Show Details'}
+            </button>
+
+            {this.state.showDetails && this.state.error && (
+              <div className="mt-4 rounded-lg bg-gray-100 p-4 dark:bg-gray-800">
+                <h3 className="mb-2 font-semibold text-gray-900 dark:text-white">
+                  Error Details
+                </h3>
+                <pre className="overflow-auto text-sm text-gray-700 dark:text-gray-300">
+                  {this.state.error.toString()}
+                  {this.state.errorInfo?.componentStack}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
Closes #101

## Summary
Adds a React ErrorBoundary component to the default template to gracefully handle rendering errors from external API calls (Horizon, Soroban RPC) and wallet extensions.

## Changes
- Created [src/components/ErrorBoundary.tsx](cci:7://file:///c:/Users/Alademehin%20samuel/OneDrive/Desktop/goMyCode/nextellar/src/templates/default/src/components/ErrorBoundary.tsx:0:0-0:0) - A class component that:
  - Catches rendering errors in its children
  - Displays a user-friendly fallback UI with error message, "Try Again" button, and optional "Show Details" toggle
  - Logs error details to console.error with component stack trace
  - Resets state when user clicks "Try Again"
  - Respects existing theme (light/dark mode compatible)

- Modified [src/app/layout.tsx](cci:7://file:///c:/Users/Alademehin%20samuel/OneDrive/Desktop/goMyCode/nextellar/src/templates/default/src/app/layout.tsx:0:0-0:0) - Wrapped main app content with ErrorBoundary

## Acceptance Criteria
- ✅ ErrorBoundary component