### PR TITLE
feat(routes-d): add push notification dispatcher (#378)

### DIFF
--- a/routes-d/lib/pushDispatcher.ts
+++ b/routes-d/lib/pushDispatcher.ts
@@ -1,0 +1,496 @@
+/**
+ * Push Notification Dispatcher
+ *
+ * Pluggable dispatcher that routes notifications through APNs (Apple) and FCM (Firebase)
+ * providers. Manages per-user device tokens, honours per-device quiet hours, and
+ * automatically removes stale tokens returned by provider delivery failures.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Supported push-notification platforms. */
+export type PushPlatform = 'apns' | 'fcm';
+
+/** A single device token registered for a user. */
+export interface DeviceToken {
+  token: string;
+  platform: PushPlatform;
+  /** User-local timezone name, e.g. "America/New_York". Used for quiet-hours math. */
+  timezone?: string;
+  /**
+   * Quiet-hours window during which notifications should NOT be delivered.
+   * Both values are 24-hour clock hours (0–23) in the device's local timezone.
+   * Example: { start: 22, end: 7 } → quiet from 10 pm to 7 am.
+   */
+  quietHours?: { start: number; end: number };
+  /** ISO-8601 timestamp of when this token was last used successfully. */
+  lastUsedAt?: string;
+  /** ISO-8601 timestamp of when this token was first registered. */
+  registeredAt: string;
+}
+
+/** Per-user token registry entry. */
+export interface UserTokenRecord {
+  userId: string;
+  tokens: DeviceToken[];
+}
+
+/** Payload to send as a push notification. */
+export interface PushPayload {
+  title: string;
+  body: string;
+  /** Optional deep-link or action data forwarded to the provider as-is. */
+  data?: Record<string, string>;
+  /** Badge count (APNs) or badge number to display. */
+  badge?: number;
+  /** Sound name or "default". */
+  sound?: string;
+}
+
+/** Result for a single token dispatch attempt. */
+export interface DispatchResult {
+  token: string;
+  platform: PushPlatform;
+  success: boolean;
+  /** Provider-level error code when success is false. */
+  errorCode?: string;
+  /** Human-readable error message. */
+  errorMessage?: string;
+  /** True when the token has been removed from the registry as stale. */
+  tokenRemoved?: boolean;
+  /** True when the notification was skipped due to active quiet hours. */
+  skipped?: boolean;
+  skippedReason?: string;
+}
+
+/** Aggregate result for a sendToUser call. */
+export interface SendResult {
+  userId: string;
+  results: DispatchResult[];
+  delivered: number;
+  skipped: number;
+  failed: number;
+  staleTokensRemoved: number;
+}
+
+// ---------------------------------------------------------------------------
+// Provider interfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * APNs provider interface.
+ * Implementations send a notification to a single device token over APNs.
+ */
+export interface APNsProvider {
+  send(token: string, payload: PushPayload): Promise<APNsResponse>;
+}
+
+export interface APNsResponse {
+  success: boolean;
+  /** APNs reason string on failure, e.g. "BadDeviceToken", "Unregistered". */
+  reason?: string;
+  /** HTTP status code returned by APNs gateway. */
+  statusCode?: number;
+}
+
+/**
+ * FCM provider interface.
+ * Implementations send a notification to a single device token over FCM.
+ */
+export interface FCMProvider {
+  send(token: string, payload: PushPayload): Promise<FCMResponse>;
+}
+
+export interface FCMResponse {
+  success: boolean;
+  /** FCM error code on failure, e.g. "registration-token-not-registered". */
+  errorCode?: string;
+  /** FCM message ID on success. */
+  messageId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Stale-token detection
+// ---------------------------------------------------------------------------
+
+/**
+ * APNs reasons that indicate a token is permanently invalid and should be removed.
+ */
+const APNS_STALE_REASONS = new Set([
+  'BadDeviceToken',
+  'DeviceTokenNotForTopic',
+  'Unregistered',
+  'MissingDeviceToken',
+  'InvalidPushType',
+]);
+
+/**
+ * FCM error codes that indicate a token is permanently invalid.
+ */
+const FCM_STALE_CODES = new Set([
+  'registration-token-not-registered',
+  'invalid-registration-token',
+  'invalid-argument',
+  'UNREGISTERED',
+  'INVALID_ARGUMENT',
+]);
+
+function isStaleAPNs(reason?: string): boolean {
+  return reason !== undefined && APNS_STALE_REASONS.has(reason);
+}
+
+function isStaleFCM(code?: string): boolean {
+  return code !== undefined && FCM_STALE_CODES.has(code);
+}
+
+// ---------------------------------------------------------------------------
+// Quiet-hours logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the given device is currently in its quiet-hours window.
+ *
+ * The check is done in the device's local timezone when `device.timezone` is
+ * set; otherwise UTC is used. The quiet window wraps midnight correctly,
+ * e.g. start=22, end=7 → quiet from 22:00 to 06:59 (inclusive of start,
+ * exclusive of end).
+ */
+export function isInQuietHours(device: DeviceToken, now: Date = new Date()): boolean {
+  if (!device.quietHours) return false;
+
+  const { start, end } = device.quietHours;
+
+  // Get current hour in the device's timezone (or UTC as fallback)
+  let currentHour: number;
+  try {
+    const tz = device.timezone ?? 'UTC';
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      hour12: false,
+      timeZone: tz,
+    });
+    const parts = formatter.formatToParts(now);
+    const hourPart = parts.find((p) => p.type === 'hour');
+    currentHour = hourPart ? parseInt(hourPart.value, 10) : now.getUTCHours();
+    // Intl may return 24 for midnight in some environments
+    if (currentHour === 24) currentHour = 0;
+  } catch {
+    currentHour = now.getUTCHours();
+  }
+
+  if (start <= end) {
+    // Non-wrapping window, e.g. 9 → 17
+    return currentHour >= start && currentHour < end;
+  } else {
+    // Wrapping window, e.g. 22 → 7 (crosses midnight)
+    return currentHour >= start || currentHour < end;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory token store
+// ---------------------------------------------------------------------------
+
+/** Map of userId → UserTokenRecord */
+const tokenStore = new Map<string, UserTokenRecord>();
+
+/**
+ * Register one or more device tokens for a user.
+ * Duplicate tokens (same token string) are updated rather than duplicated.
+ */
+export function registerTokens(userId: string, devices: Omit<DeviceToken, 'registeredAt'>[]): void {
+  if (!userId) throw new Error('userId is required');
+
+  const record = tokenStore.get(userId) ?? { userId, tokens: [] };
+
+  for (const d of devices) {
+    if (!d.token) throw new Error('device token string is required');
+    const existing = record.tokens.findIndex((t) => t.token === d.token);
+    const entry: DeviceToken = {
+      ...d,
+      registeredAt:
+        existing !== -1 ? record.tokens[existing].registeredAt : new Date().toISOString(),
+    };
+    if (existing !== -1) {
+      record.tokens[existing] = entry;
+    } else {
+      record.tokens.push(entry);
+    }
+  }
+
+  tokenStore.set(userId, record);
+}
+
+/**
+ * Remove a specific token for a user.
+ */
+export function removeToken(userId: string, token: string): void {
+  const record = tokenStore.get(userId);
+  if (!record) return;
+  record.tokens = record.tokens.filter((t) => t.token !== token);
+  if (record.tokens.length === 0) {
+    tokenStore.delete(userId);
+  }
+}
+
+/**
+ * Get all device tokens for a user. Returns an empty array if none registered.
+ */
+export function getTokens(userId: string): DeviceToken[] {
+  return tokenStore.get(userId)?.tokens ?? [];
+}
+
+/**
+ * Remove ALL tokens for a user.
+ */
+export function removeAllTokens(userId: string): void {
+  tokenStore.delete(userId);
+}
+
+/**
+ * Clear the entire token store (test helper).
+ */
+export function __resetTokenStore(): void {
+  tokenStore.clear();
+}
+
+/**
+ * Seed the token store with a pre-built record (test helper).
+ */
+export function __seedTokens(userId: string, tokens: DeviceToken[]): void {
+  tokenStore.set(userId, { userId, tokens: [...tokens] });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export interface PushDispatcherConfig {
+  apns?: APNsProvider;
+  fcm?: FCMProvider;
+}
+
+/**
+ * PushDispatcher orchestrates notification delivery across APNs and FCM.
+ *
+ * It:
+ * - Resolves the correct provider for each device token's platform.
+ * - Skips delivery for tokens in a quiet-hours window.
+ * - Automatically removes stale tokens on permanent delivery failures.
+ */
+export class PushDispatcher {
+  private readonly apns?: APNsProvider;
+  private readonly fcm?: FCMProvider;
+
+  constructor(config: PushDispatcherConfig) {
+    this.apns = config.apns;
+    this.fcm = config.fcm;
+  }
+
+  /**
+   * Send a push notification to all registered devices for a user.
+   *
+   * @param userId  Target user identifier.
+   * @param payload Notification content.
+   * @param now     Reference time for quiet-hours (defaults to current time; injectable for tests).
+   * @returns       Aggregate send result.
+   */
+  async sendToUser(
+    userId: string,
+    payload: PushPayload,
+    now: Date = new Date(),
+  ): Promise<SendResult> {
+    const tokens = getTokens(userId);
+
+    const result: SendResult = {
+      userId,
+      results: [],
+      delivered: 0,
+      skipped: 0,
+      failed: 0,
+      staleTokensRemoved: 0,
+    };
+
+    for (const device of tokens) {
+      const dr = await this.dispatchOne(userId, device, payload, now);
+      result.results.push(dr);
+
+      if (dr.skipped) {
+        result.skipped++;
+      } else if (dr.success) {
+        result.delivered++;
+      } else {
+        result.failed++;
+      }
+
+      if (dr.tokenRemoved) {
+        result.staleTokensRemoved++;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Send a push notification to an explicit list of tokens (bypasses the user
+   * token store – useful for targeted fan-out).
+   */
+  async sendToTokens(
+    tokens: DeviceToken[],
+    payload: PushPayload,
+    now: Date = new Date(),
+  ): Promise<DispatchResult[]> {
+    const results: DispatchResult[] = [];
+    for (const device of tokens) {
+      const dr = await this.dispatchOne(null, device, payload, now);
+      results.push(dr);
+    }
+    return results;
+  }
+
+  // ------------------------------------------------------------------
+  // Private helpers
+  // ------------------------------------------------------------------
+
+  private async dispatchOne(
+    userId: string | null,
+    device: DeviceToken,
+    payload: PushPayload,
+    now: Date,
+  ): Promise<DispatchResult> {
+    // 1. Quiet-hours check
+    if (isInQuietHours(device, now)) {
+      return {
+        token: device.token,
+        platform: device.platform,
+        success: false,
+        skipped: true,
+        skippedReason: 'quiet_hours',
+      };
+    }
+
+    // 2. Route to provider
+    if (device.platform === 'apns') {
+      return this.sendApns(userId, device, payload);
+    }
+    if (device.platform === 'fcm') {
+      return this.sendFcm(userId, device, payload);
+    }
+
+    // Unknown platform
+    return {
+      token: device.token,
+      platform: device.platform,
+      success: false,
+      errorCode: 'UNKNOWN_PLATFORM',
+      errorMessage: `Unsupported platform: ${device.platform}`,
+    };
+  }
+
+  private async sendApns(
+    userId: string | null,
+    device: DeviceToken,
+    payload: PushPayload,
+  ): Promise<DispatchResult> {
+    if (!this.apns) {
+      return {
+        token: device.token,
+        platform: 'apns',
+        success: false,
+        errorCode: 'PROVIDER_NOT_CONFIGURED',
+        errorMessage: 'APNs provider is not configured',
+      };
+    }
+
+    try {
+      const response = await this.apns.send(device.token, payload);
+
+      if (response.success) {
+        // Update lastUsedAt
+        if (userId) this.touchToken(userId, device.token);
+        return { token: device.token, platform: 'apns', success: true };
+      }
+
+      const stale = isStaleAPNs(response.reason);
+      if (stale && userId) {
+        removeToken(userId, device.token);
+      }
+
+      return {
+        token: device.token,
+        platform: 'apns',
+        success: false,
+        errorCode: response.reason,
+        errorMessage: `APNs delivery failed: ${response.reason ?? 'unknown'}`,
+        tokenRemoved: stale,
+      };
+    } catch (err) {
+      return {
+        token: device.token,
+        platform: 'apns',
+        success: false,
+        errorCode: 'SEND_ERROR',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private async sendFcm(
+    userId: string | null,
+    device: DeviceToken,
+    payload: PushPayload,
+  ): Promise<DispatchResult> {
+    if (!this.fcm) {
+      return {
+        token: device.token,
+        platform: 'fcm',
+        success: false,
+        errorCode: 'PROVIDER_NOT_CONFIGURED',
+        errorMessage: 'FCM provider is not configured',
+      };
+    }
+
+    try {
+      const response = await this.fcm.send(device.token, payload);
+
+      if (response.success) {
+        if (userId) this.touchToken(userId, device.token);
+        return { token: device.token, platform: 'fcm', success: true };
+      }
+
+      const stale = isStaleFCM(response.errorCode);
+      if (stale && userId) {
+        removeToken(userId, device.token);
+      }
+
+      return {
+        token: device.token,
+        platform: 'fcm',
+        success: false,
+        errorCode: response.errorCode,
+        errorMessage: `FCM delivery failed: ${response.errorCode ?? 'unknown'}`,
+        tokenRemoved: stale,
+      };
+    } catch (err) {
+      return {
+        token: device.token,
+        platform: 'fcm',
+        success: false,
+        errorCode: 'SEND_ERROR',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /** Update lastUsedAt for a token without exposing the store directly. */
+  private touchToken(userId: string, token: string): void {
+    const record = tokenStore.get(userId);
+    if (!record) return;
+    const device = record.tokens.find((t) => t.token === token);
+    if (device) {
+      device.lastUsedAt = new Date().toISOString();
+    }
+  }
+}

--- a/routes-d/routes/push.notifications.ts
+++ b/routes-d/routes/push.notifications.ts
@@ -1,0 +1,199 @@
+/**
+ * Push Notifications Route
+ *
+ * Provides HTTP endpoints to:
+ *   POST /push/tokens/:userId        – register device tokens
+ *   DELETE /push/tokens/:userId/:token – remove a specific token
+ *   GET  /push/tokens/:userId        – list tokens for a user
+ *   POST /push/send/:userId          – send a push notification to a user
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { sendError } from '../lib/response.js';
+import {
+  PushDispatcher,
+  registerTokens,
+  removeToken,
+  getTokens,
+  type PushPayload,
+  type APNsProvider,
+  type FCMProvider,
+  type DeviceToken,
+} from '../lib/pushDispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Mock providers (in-memory stubs used by tests / dev)
+// ---------------------------------------------------------------------------
+
+/** Callable stub injected during tests. */
+let mockApnsSend: ((token: string, payload: PushPayload) => Promise<{ success: boolean; reason?: string }>) | null = null;
+let mockFcmSend: ((token: string, payload: PushPayload) => Promise<{ success: boolean; errorCode?: string; messageId?: string }>) | null = null;
+
+export function __setMockApnsSend(fn: typeof mockApnsSend): void {
+  mockApnsSend = fn;
+}
+export function __setMockFcmSend(fn: typeof mockFcmSend): void {
+  mockFcmSend = fn;
+}
+export function __resetMocks(): void {
+  mockApnsSend = null;
+  mockFcmSend = null;
+}
+
+/** Default stub that always succeeds (used when no mock is set). */
+const defaultApns: APNsProvider = {
+  async send(token, payload) {
+    if (mockApnsSend) return mockApnsSend(token, payload);
+    return { success: true };
+  },
+};
+
+const defaultFcm: FCMProvider = {
+  async send(token, payload) {
+    if (mockFcmSend) return mockFcmSend(token, payload);
+    return { success: true, messageId: `mock-msg-${Date.now()}` };
+  },
+};
+
+let dispatcherInstance = new PushDispatcher({ apns: defaultApns, fcm: defaultFcm });
+
+/** Replace the dispatcher instance (test helper). */
+export function __setDispatcher(d: PushDispatcher): void {
+  dispatcherInstance = d;
+}
+export function __resetDispatcher(): void {
+  dispatcherInstance = new PushDispatcher({ apns: defaultApns, fcm: defaultFcm });
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const router = Router();
+
+/**
+ * POST /push/tokens/:userId
+ * Register one or more device tokens for a user.
+ *
+ * Body: { tokens: Array<{ token, platform, timezone?, quietHours?, lastUsedAt? }> }
+ */
+router.post(
+  '/push/tokens/:userId',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const { tokens } = req.body as { tokens?: unknown };
+
+      if (!Array.isArray(tokens) || tokens.length === 0) {
+        sendError(res, 'VALIDATION_ERROR', '"tokens" must be a non-empty array', 400);
+        return;
+      }
+
+      for (const t of tokens) {
+        if (typeof (t as DeviceToken).token !== 'string' || !(t as DeviceToken).token) {
+          sendError(res, 'VALIDATION_ERROR', 'Each token entry must have a string "token" field', 400);
+          return;
+        }
+        const platform = (t as DeviceToken).platform;
+        if (platform !== 'apns' && platform !== 'fcm') {
+          sendError(res, 'VALIDATION_ERROR', '"platform" must be "apns" or "fcm"', 400);
+          return;
+        }
+      }
+
+      registerTokens(userId, tokens as Omit<DeviceToken, 'registeredAt'>[]);
+
+      res.status(201).json({ success: true, userId, registered: tokens.length });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * DELETE /push/tokens/:userId/:token
+ * Remove a specific device token.
+ */
+router.delete(
+  '/push/tokens/:userId/:token',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { userId, token } = req.params;
+      removeToken(userId, decodeURIComponent(token));
+      res.status(200).json({ success: true });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * GET /push/tokens/:userId
+ * List all registered tokens for a user (without exposing sensitive token strings in full).
+ */
+router.get(
+  '/push/tokens/:userId',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const tokens = getTokens(userId);
+
+      const safe = tokens.map((t) => ({
+        tokenPrefix: t.token.slice(0, 8) + '…',
+        platform: t.platform,
+        timezone: t.timezone,
+        quietHours: t.quietHours,
+        registeredAt: t.registeredAt,
+        lastUsedAt: t.lastUsedAt,
+      }));
+
+      res.status(200).json({ success: true, userId, tokens: safe, count: safe.length });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * POST /push/send/:userId
+ * Send a push notification to all registered devices for a user.
+ *
+ * Body: { title, body, data?, badge?, sound? }
+ */
+router.post(
+  '/push/send/:userId',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const { title, body, data, badge, sound } = req.body as Partial<PushPayload>;
+
+      if (!title || typeof title !== 'string') {
+        sendError(res, 'VALIDATION_ERROR', '"title" is required', 400);
+        return;
+      }
+      if (!body || typeof body !== 'string') {
+        sendError(res, 'VALIDATION_ERROR', '"body" is required', 400);
+        return;
+      }
+
+      const tokens = getTokens(userId);
+      if (tokens.length === 0) {
+        sendError(res, 'NO_TOKENS', 'No device tokens registered for this user', 404);
+        return;
+      }
+
+      const payload: PushPayload = { title, body };
+      if (data) payload.data = data;
+      if (badge !== undefined) payload.badge = badge;
+      if (sound) payload.sound = sound;
+
+      const result = await dispatcherInstance.sendToUser(userId, payload);
+
+      res.status(200).json({ success: true, ...result });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/routes-d/tests/integration/push.notifications.integration.test.ts
+++ b/routes-d/tests/integration/push.notifications.integration.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Integration tests for push notification HTTP endpoints
+ *
+ * Tests the full Express route layer:
+ *   POST /push/tokens/:userId
+ *   DELETE /push/tokens/:userId/:token
+ *   GET  /push/tokens/:userId
+ *   POST /push/send/:userId
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import pushRouter, {
+  __resetMocks,
+  __setMockApnsSend,
+  __setMockFcmSend,
+  __resetDispatcher,
+} from '../../routes/push.notifications.js';
+import { __resetTokenStore, __seedTokens } from '../../lib/pushDispatcher.js';
+
+// ---------------------------------------------------------------------------
+// App setup
+// ---------------------------------------------------------------------------
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(pushRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const app = buildApp();
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  __resetTokenStore();
+  __resetMocks();
+  __resetDispatcher();
+});
+
+// ---------------------------------------------------------------------------
+// POST /push/tokens/:userId
+// ---------------------------------------------------------------------------
+
+describe('POST /push/tokens/:userId', () => {
+  it('registers a single APNs token', async () => {
+    const res = await request(app)
+      .post('/push/tokens/user-1')
+      .send({ tokens: [{ token: 'apns-abc', platform: 'apns' }] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.registered).toBe(1);
+    expect(res.body.userId).toBe('user-1');
+  });
+
+  it('registers multiple tokens in a single request', async () => {
+    const res = await request(app)
+      .post('/push/tokens/user-1')
+      .send({
+        tokens: [
+          { token: 'apns-abc', platform: 'apns' },
+          { token: 'fcm-xyz', platform: 'fcm' },
+        ],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.registered).toBe(2);
+  });
+
+  it('returns 400 when tokens array is missing', async () => {
+    const res = await request(app).post('/push/tokens/user-1').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when tokens array is empty', async () => {
+    const res = await request(app).post('/push/tokens/user-1').send({ tokens: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when token string is missing', async () => {
+    const res = await request(app)
+      .post('/push/tokens/user-1')
+      .send({ tokens: [{ platform: 'apns' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when platform is invalid', async () => {
+    const res = await request(app)
+      .post('/push/tokens/user-1')
+      .send({ tokens: [{ token: 'tok', platform: 'windows' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('registers token with quiet hours and timezone', async () => {
+    const res = await request(app)
+      .post('/push/tokens/user-2')
+      .send({
+        tokens: [
+          {
+            token: 'apns-qh',
+            platform: 'apns',
+            timezone: 'America/New_York',
+            quietHours: { start: 22, end: 7 },
+          },
+        ],
+      });
+    expect(res.status).toBe(201);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /push/tokens/:userId/:token
+// ---------------------------------------------------------------------------
+
+describe('DELETE /push/tokens/:userId/:token', () => {
+  it('removes an existing token', async () => {
+    __seedTokens('user-1', [
+      { token: 'apns-del', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+
+    const res = await request(app).delete('/push/tokens/user-1/apns-del');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    // Verify it's gone
+    const listRes = await request(app).get('/push/tokens/user-1');
+    expect(listRes.body.count).toBe(0);
+  });
+
+  it('is idempotent when token does not exist', async () => {
+    const res = await request(app).delete('/push/tokens/user-1/nonexistent');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /push/tokens/:userId
+// ---------------------------------------------------------------------------
+
+describe('GET /push/tokens/:userId', () => {
+  it('returns masked token list for a user', async () => {
+    __seedTokens('user-1', [
+      {
+        token: 'apns-longtoken123',
+        platform: 'apns',
+        timezone: 'UTC',
+        registeredAt: '2025-01-01T00:00:00Z',
+      },
+    ]);
+
+    const res = await request(app).get('/push/tokens/user-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.tokens[0].tokenPrefix).toContain('…');
+    expect(res.body.tokens[0].tokenPrefix).not.toBe('apns-longtoken123');
+    expect(res.body.tokens[0].platform).toBe('apns');
+    expect(res.body.tokens[0].timezone).toBe('UTC');
+  });
+
+  it('returns empty list for a user with no tokens', async () => {
+    const res = await request(app).get('/push/tokens/unknown-user');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(0);
+    expect(res.body.tokens).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /push/send/:userId
+// ---------------------------------------------------------------------------
+
+describe('POST /push/send/:userId', () => {
+  it('sends a notification to an APNs token (mock success)', async () => {
+    __seedTokens('user-1', [
+      { token: 'apns-tok', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+    __setMockApnsSend(async () => ({ success: true }));
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ title: 'Hello', body: 'World' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.delivered).toBe(1);
+    expect(res.body.failed).toBe(0);
+    expect(res.body.skipped).toBe(0);
+  });
+
+  it('sends a notification to an FCM token (mock success)', async () => {
+    __seedTokens('user-1', [
+      { token: 'fcm-tok', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+    __setMockFcmSend(async () => ({ success: true, messageId: 'msg-1' }));
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ title: 'Alert', body: 'Your payment arrived' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.delivered).toBe(1);
+  });
+
+  it('removes stale token and reports in response', async () => {
+    __seedTokens('user-1', [
+      { token: 'apns-stale', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+    __setMockApnsSend(async () => ({ success: false, reason: 'BadDeviceToken' }));
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ title: 'Hi', body: 'There' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.staleTokensRemoved).toBe(1);
+    expect(res.body.failed).toBe(1);
+
+    // Token should be gone now
+    const listRes = await request(app).get('/push/tokens/user-1');
+    expect(listRes.body.count).toBe(0);
+  });
+
+  it('returns 404 when user has no tokens registered', async () => {
+    const res = await request(app)
+      .post('/push/send/nobody')
+      .send({ title: 'Hi', body: 'There' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NO_TOKENS');
+  });
+
+  it('returns 400 when title is missing', async () => {
+    __seedTokens('user-1', [
+      { token: 'tok', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ body: 'No title here' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when body is missing', async () => {
+    __seedTokens('user-1', [
+      { token: 'tok', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ title: 'No body here' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('skips tokens in quiet hours and reports in response', async () => {
+    // Quiet 0–23 = always quiet
+    __seedTokens('user-1', [
+      {
+        token: 'tok-quiet',
+        platform: 'apns',
+        timezone: 'UTC',
+        quietHours: { start: 0, end: 23 },
+        registeredAt: '2025-01-01T00:00:00Z',
+      },
+    ]);
+    __setMockApnsSend(async () => ({ success: true }));
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ title: 'Hi', body: 'There' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.skipped).toBe(1);
+    expect(res.body.delivered).toBe(0);
+  });
+
+  it('forwards optional fields (data, badge, sound)', async () => {
+    __seedTokens('user-1', [
+      { token: 'fcm-tok', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let capturedPayload: any = null;
+    __setMockFcmSend(async (_token, payload) => {
+      capturedPayload = payload;
+      return { success: true, messageId: 'x' };
+    });
+
+    await request(app)
+      .post('/push/send/user-1')
+      .send({
+        title: 'Rich',
+        body: 'Msg',
+        data: { action: 'open_wallet' },
+        badge: 5,
+        sound: 'default',
+      });
+
+    expect(capturedPayload).not.toBeNull();
+    expect(capturedPayload!.data).toEqual({ action: 'open_wallet' });
+    expect(capturedPayload!.badge).toBe(5);
+    expect(capturedPayload!.sound).toBe('default');
+  });
+
+  it('delivers to multiple mixed-platform tokens in one call', async () => {
+    __seedTokens('user-1', [
+      { token: 'apns-1', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+      { token: 'fcm-1', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+    ]);
+    __setMockApnsSend(async () => ({ success: true }));
+    __setMockFcmSend(async () => ({ success: true, messageId: 'msg' }));
+
+    const res = await request(app)
+      .post('/push/send/user-1')
+      .send({ title: 'Broadcast', body: 'To all devices' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.delivered).toBe(2);
+    expect(res.body.results).toHaveLength(2);
+  });
+});

--- a/routes-d/tests/push.notifications.test.ts
+++ b/routes-d/tests/push.notifications.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Push Notifications route tests
+ * Follows the same flat-file pattern as other routes-d/tests/*.test.ts files.
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import pushRouter, {
+  __resetMocks,
+  __setMockApnsSend,
+  __setMockFcmSend,
+  __resetDispatcher,
+} from '../routes/push.notifications.js';
+import { __resetTokenStore, __seedTokens } from '../lib/pushDispatcher.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(pushRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe('Push Notifications Route', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetTokenStore();
+    __resetMocks();
+    __resetDispatcher();
+  });
+
+  // -------------------------------------------------------------------------
+  // Token registration
+  // -------------------------------------------------------------------------
+
+  describe('POST /push/tokens/:userId – register', () => {
+    it('201 on valid APNs token', async () => {
+      const res = await request(app)
+        .post('/push/tokens/user-a')
+        .send({ tokens: [{ token: 'apns-1', platform: 'apns' }] });
+      expect(res.status).toBe(201);
+      expect(res.body.registered).toBe(1);
+    });
+
+    it('201 on valid FCM token with quiet hours', async () => {
+      const res = await request(app)
+        .post('/push/tokens/user-a')
+        .send({
+          tokens: [
+            {
+              token: 'fcm-1',
+              platform: 'fcm',
+              timezone: 'Europe/Berlin',
+              quietHours: { start: 23, end: 8 },
+            },
+          ],
+        });
+      expect(res.status).toBe(201);
+    });
+
+    it('400 when tokens field is absent', async () => {
+      const res = await request(app).post('/push/tokens/user-a').send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('400 when platform is unsupported', async () => {
+      const res = await request(app)
+        .post('/push/tokens/user-a')
+        .send({ tokens: [{ token: 'x', platform: 'web' }] });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Token removal
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /push/tokens/:userId/:token', () => {
+    it('200 and removes token', async () => {
+      __seedTokens('user-b', [
+        { token: 'tok-del', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+      ]);
+      const res = await request(app).delete('/push/tokens/user-b/tok-del');
+      expect(res.status).toBe(200);
+    });
+
+    it('200 even when token never existed', async () => {
+      const res = await request(app).delete('/push/tokens/user-b/ghost');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Token listing
+  // -------------------------------------------------------------------------
+
+  describe('GET /push/tokens/:userId', () => {
+    it('200 with masked tokens', async () => {
+      __seedTokens('user-c', [
+        { token: 'apns-visible-token', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+      ]);
+      const res = await request(app).get('/push/tokens/user-c');
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(1);
+      // Full token must not be exposed
+      expect(JSON.stringify(res.body)).not.toContain('apns-visible-token');
+    });
+
+    it('200 with empty list for unknown user', async () => {
+      const res = await request(app).get('/push/tokens/nobody');
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Send notification
+  // -------------------------------------------------------------------------
+
+  describe('POST /push/send/:userId', () => {
+    it('200 with delivered=1 on APNs success', async () => {
+      __seedTokens('user-d', [
+        { token: 'apns-ok', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+      ]);
+      __setMockApnsSend(async () => ({ success: true }));
+
+      const res = await request(app)
+        .post('/push/send/user-d')
+        .send({ title: 'New payment', body: '50 XLM received' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.delivered).toBe(1);
+    });
+
+    it('staleTokensRemoved=1 on Unregistered APNs error', async () => {
+      __seedTokens('user-d', [
+        { token: 'apns-gone', platform: 'apns', registeredAt: '2025-01-01T00:00:00Z' },
+      ]);
+      __setMockApnsSend(async () => ({ success: false, reason: 'Unregistered' }));
+
+      const res = await request(app)
+        .post('/push/send/user-d')
+        .send({ title: 'Hi', body: 'There' });
+
+      expect(res.body.staleTokensRemoved).toBe(1);
+    });
+
+    it('skipped=1 when device is in quiet hours (always-quiet window)', async () => {
+      __seedTokens('user-d', [
+        {
+          token: 'apns-quiet',
+          platform: 'apns',
+          timezone: 'UTC',
+          quietHours: { start: 0, end: 23 },
+          registeredAt: '2025-01-01T00:00:00Z',
+        },
+      ]);
+      __setMockApnsSend(async () => ({ success: true }));
+
+      const res = await request(app)
+        .post('/push/send/user-d')
+        .send({ title: 'Hi', body: 'Quiet' });
+
+      expect(res.body.skipped).toBe(1);
+      expect(res.body.delivered).toBe(0);
+    });
+
+    it('404 when user has no tokens', async () => {
+      const res = await request(app)
+        .post('/push/send/nobody')
+        .send({ title: 'Hi', body: 'There' });
+      expect(res.status).toBe(404);
+    });
+
+    it('400 when title missing', async () => {
+      __seedTokens('user-d', [
+        { token: 'tok', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+      ]);
+      const res = await request(app)
+        .post('/push/send/user-d')
+        .send({ body: 'Missing title' });
+      expect(res.status).toBe(400);
+    });
+
+    it('400 when body missing', async () => {
+      __seedTokens('user-d', [
+        { token: 'tok', platform: 'fcm', registeredAt: '2025-01-01T00:00:00Z' },
+      ]);
+      const res = await request(app)
+        .post('/push/send/user-d')
+        .send({ title: 'Missing body' });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/routes-d/tests/unit/pushDispatcher.test.ts
+++ b/routes-d/tests/unit/pushDispatcher.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for routes-d/lib/pushDispatcher.ts
+ *
+ * Covers:
+ *  - Token registration, retrieval, and removal
+ *  - Quiet-hours detection (wrapping and non-wrapping windows)
+ *  - Successful APNs / FCM dispatch
+ *  - Stale-token cleanup on permanent provider errors
+ *  - Quiet-hours skipping
+ *  - Missing provider configuration
+ */
+
+import {
+  PushDispatcher,
+  isInQuietHours,
+  registerTokens,
+  removeToken,
+  getTokens,
+  removeAllTokens,
+  __resetTokenStore,
+  __seedTokens,
+  type DeviceToken,
+  type APNsProvider,
+  type FCMProvider,
+  type PushPayload,
+} from '../../lib/pushDispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Helpers – plain spy factories (no jest globals needed)
+// ---------------------------------------------------------------------------
+
+const basePayload: PushPayload = { title: 'Test', body: 'Hello world' };
+
+function makeApns(
+  resp: Awaited<ReturnType<APNsProvider['send']>>,
+): APNsProvider & { calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  return {
+    calls,
+    send: (...args) => { calls.push(args); return Promise.resolve(resp); },
+  };
+}
+
+function makeFcm(
+  resp: Awaited<ReturnType<FCMProvider['send']>>,
+): FCMProvider & { calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  return {
+    calls,
+    send: (...args) => { calls.push(args); return Promise.resolve(resp); },
+  };
+}
+
+function makeToken(
+  overrides: Partial<DeviceToken> & Pick<DeviceToken, 'token' | 'platform'>,
+): DeviceToken {
+  return { registeredAt: '2025-01-01T00:00:00Z', ...overrides };
+}
+
+beforeEach(() => { __resetTokenStore(); });
+
+// ---------------------------------------------------------------------------
+// Token store
+// ---------------------------------------------------------------------------
+
+describe('registerTokens', () => {
+  it('stores tokens for a new user', () => {
+    registerTokens('u1', [{ token: 'tok-a', platform: 'apns' }]);
+    const stored = getTokens('u1');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].token).toBe('tok-a');
+    expect(stored[0].platform).toBe('apns');
+  });
+
+  it('adds multiple tokens in a single call', () => {
+    registerTokens('u1', [
+      { token: 'tok-a', platform: 'apns' },
+      { token: 'tok-b', platform: 'fcm' },
+    ]);
+    expect(getTokens('u1')).toHaveLength(2);
+  });
+
+  it('deduplicates by token string (upsert)', () => {
+    registerTokens('u1', [{ token: 'tok-a', platform: 'apns' }]);
+    registerTokens('u1', [{ token: 'tok-a', platform: 'apns', timezone: 'UTC' }]);
+    const tokens = getTokens('u1');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].timezone).toBe('UTC');
+  });
+
+  it('preserves registeredAt on upsert', () => {
+    registerTokens('u1', [{ token: 'tok-a', platform: 'apns' }]);
+    const original = getTokens('u1')[0].registeredAt;
+    registerTokens('u1', [{ token: 'tok-a', platform: 'apns', timezone: 'Europe/London' }]);
+    expect(getTokens('u1')[0].registeredAt).toBe(original);
+  });
+
+  it('throws when userId is empty', () => {
+    expect(() => registerTokens('', [{ token: 'tok', platform: 'apns' }])).toThrow('userId is required');
+  });
+
+  it('throws when token string is empty', () => {
+    expect(() => registerTokens('u1', [{ token: '', platform: 'apns' }])).toThrow('device token string is required');
+  });
+});
+
+describe('removeToken', () => {
+  it('removes a specific token', () => {
+    __seedTokens('u1', [
+      makeToken({ token: 'tok-a', platform: 'apns' }),
+      makeToken({ token: 'tok-b', platform: 'fcm' }),
+    ]);
+    removeToken('u1', 'tok-a');
+    const remaining = getTokens('u1');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].token).toBe('tok-b');
+  });
+
+  it('deletes user record when last token is removed', () => {
+    __seedTokens('u1', [makeToken({ token: 'tok-a', platform: 'apns' })]);
+    removeToken('u1', 'tok-a');
+    expect(getTokens('u1')).toHaveLength(0);
+  });
+
+  it('is a no-op for unknown userId', () => {
+    expect(() => removeToken('nonexistent', 'tok')).not.toThrow();
+  });
+});
+
+describe('removeAllTokens', () => {
+  it('removes all tokens for a user', () => {
+    __seedTokens('u1', [
+      makeToken({ token: 'tok-a', platform: 'apns' }),
+      makeToken({ token: 'tok-b', platform: 'fcm' }),
+    ]);
+    removeAllTokens('u1');
+    expect(getTokens('u1')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Quiet hours
+// ---------------------------------------------------------------------------
+
+describe('isInQuietHours', () => {
+  it('returns false when quietHours is not set', () => {
+    const device = makeToken({ token: 't', platform: 'apns' });
+    expect(isInQuietHours(device, new Date())).toBe(false);
+  });
+
+  it('detects a non-wrapping quiet window (9→17)', () => {
+    const device = makeToken({ token: 't', platform: 'apns', timezone: 'UTC', quietHours: { start: 9, end: 17 } });
+    expect(isInQuietHours(device, new Date('2025-06-01T10:00:00Z'))).toBe(true);  // inside
+    expect(isInQuietHours(device, new Date('2025-06-01T09:00:00Z'))).toBe(true);  // start inclusive
+    expect(isInQuietHours(device, new Date('2025-06-01T17:00:00Z'))).toBe(false); // end exclusive
+    expect(isInQuietHours(device, new Date('2025-06-01T08:00:00Z'))).toBe(false); // before window
+  });
+
+  it('detects a wrapping quiet window (22→7, crosses midnight)', () => {
+    const device = makeToken({ token: 't', platform: 'apns', timezone: 'UTC', quietHours: { start: 22, end: 7 } });
+    expect(isInQuietHours(device, new Date('2025-06-01T23:00:00Z'))).toBe(true);  // after start
+    expect(isInQuietHours(device, new Date('2025-06-01T02:00:00Z'))).toBe(true);  // before end
+    expect(isInQuietHours(device, new Date('2025-06-01T07:00:00Z'))).toBe(false); // end exclusive
+    expect(isInQuietHours(device, new Date('2025-06-01T12:00:00Z'))).toBe(false); // outside
+  });
+
+  it('falls back to UTC when timezone is invalid', () => {
+    const device = makeToken({ token: 't', platform: 'apns', timezone: 'Invalid/Zone', quietHours: { start: 1, end: 2 } });
+    expect(() => isInQuietHours(device, new Date('2025-06-01T01:30:00Z'))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PushDispatcher – APNs
+// ---------------------------------------------------------------------------
+
+describe('PushDispatcher – APNs', () => {
+  it('delivers successfully', async () => {
+    __seedTokens('u1', [makeToken({ token: 'apns-tok', platform: 'apns' })]);
+    const apns = makeApns({ success: true });
+    const result = await new PushDispatcher({ apns }).sendToUser('u1', basePayload);
+
+    expect(result.delivered).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.results[0].success).toBe(true);
+    expect(apns.calls[0][0]).toBe('apns-tok');
+  });
+
+  it('records failure on soft error without removing token', async () => {
+    __seedTokens('u1', [makeToken({ token: 'apns-tok', platform: 'apns' })]);
+    const apns = makeApns({ success: false, reason: 'ServiceUnavailable' });
+    const result = await new PushDispatcher({ apns }).sendToUser('u1', basePayload);
+
+    expect(result.failed).toBe(1);
+    expect(result.staleTokensRemoved).toBe(0);
+    expect(getTokens('u1')).toHaveLength(1);
+  });
+
+  it('removes stale token on BadDeviceToken', async () => {
+    __seedTokens('u1', [makeToken({ token: 'apns-stale', platform: 'apns' })]);
+    const apns = makeApns({ success: false, reason: 'BadDeviceToken' });
+    const result = await new PushDispatcher({ apns }).sendToUser('u1', basePayload);
+
+    expect(result.staleTokensRemoved).toBe(1);
+    expect(result.results[0].tokenRemoved).toBe(true);
+    expect(getTokens('u1')).toHaveLength(0);
+  });
+
+  it('removes stale token on Unregistered', async () => {
+    __seedTokens('u1', [makeToken({ token: 'apns-unreg', platform: 'apns' })]);
+    await new PushDispatcher({ apns: makeApns({ success: false, reason: 'Unregistered' }) }).sendToUser('u1', basePayload);
+    expect(getTokens('u1')).toHaveLength(0);
+  });
+
+  it('returns PROVIDER_NOT_CONFIGURED when no APNs provider', async () => {
+    __seedTokens('u1', [makeToken({ token: 'apns-tok', platform: 'apns' })]);
+    const result = await new PushDispatcher({}).sendToUser('u1', basePayload);
+    expect(result.results[0].errorCode).toBe('PROVIDER_NOT_CONFIGURED');
+  });
+
+  it('handles provider throwing an exception', async () => {
+    __seedTokens('u1', [makeToken({ token: 'apns-tok', platform: 'apns' })]);
+    const apns: APNsProvider = { send: () => Promise.reject(new Error('network timeout')) };
+    const result = await new PushDispatcher({ apns }).sendToUser('u1', basePayload);
+
+    expect(result.failed).toBe(1);
+    expect(result.results[0].errorCode).toBe('SEND_ERROR');
+    expect(result.results[0].errorMessage).toContain('network timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PushDispatcher – FCM
+// ---------------------------------------------------------------------------
+
+describe('PushDispatcher – FCM', () => {
+  it('delivers successfully', async () => {
+    __seedTokens('u1', [makeToken({ token: 'fcm-tok', platform: 'fcm' })]);
+    const fcm = makeFcm({ success: true, messageId: 'msg-123' });
+    const result = await new PushDispatcher({ fcm }).sendToUser('u1', basePayload);
+
+    expect(result.delivered).toBe(1);
+    expect(result.results[0].success).toBe(true);
+    expect(fcm.calls[0][0]).toBe('fcm-tok');
+  });
+
+  it('removes stale token on registration-token-not-registered', async () => {
+    __seedTokens('u1', [makeToken({ token: 'fcm-stale', platform: 'fcm' })]);
+    const result = await new PushDispatcher({ fcm: makeFcm({ success: false, errorCode: 'registration-token-not-registered' }) }).sendToUser('u1', basePayload);
+
+    expect(result.staleTokensRemoved).toBe(1);
+    expect(getTokens('u1')).toHaveLength(0);
+  });
+
+  it('removes stale token on UNREGISTERED', async () => {
+    __seedTokens('u1', [makeToken({ token: 'fcm-unreg', platform: 'fcm' })]);
+    await new PushDispatcher({ fcm: makeFcm({ success: false, errorCode: 'UNREGISTERED' }) }).sendToUser('u1', basePayload);
+    expect(getTokens('u1')).toHaveLength(0);
+  });
+
+  it('keeps token on transient FCM error', async () => {
+    __seedTokens('u1', [makeToken({ token: 'fcm-tok', platform: 'fcm' })]);
+    const result = await new PushDispatcher({ fcm: makeFcm({ success: false, errorCode: 'INTERNAL' }) }).sendToUser('u1', basePayload);
+
+    expect(result.staleTokensRemoved).toBe(0);
+    expect(getTokens('u1')).toHaveLength(1);
+  });
+
+  it('returns PROVIDER_NOT_CONFIGURED when no FCM provider', async () => {
+    __seedTokens('u1', [makeToken({ token: 'fcm-tok', platform: 'fcm' })]);
+    const result = await new PushDispatcher({}).sendToUser('u1', basePayload);
+    expect(result.results[0].errorCode).toBe('PROVIDER_NOT_CONFIGURED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PushDispatcher – quiet hours
+// ---------------------------------------------------------------------------
+
+describe('PushDispatcher – quiet hours', () => {
+  it('skips delivery during quiet hours', async () => {
+    __seedTokens('u1', [makeToken({ token: 'tok-q', platform: 'apns', timezone: 'UTC', quietHours: { start: 22, end: 7 } })]);
+    const apns = makeApns({ success: true });
+    const result = await new PushDispatcher({ apns }).sendToUser('u1', basePayload, new Date('2025-06-01T23:00:00Z'));
+
+    expect(result.skipped).toBe(1);
+    expect(result.delivered).toBe(0);
+    expect(result.results[0].skipped).toBe(true);
+    expect(result.results[0].skippedReason).toBe('quiet_hours');
+    expect(apns.calls).toHaveLength(0);
+  });
+
+  it('delivers outside quiet hours', async () => {
+    __seedTokens('u1', [makeToken({ token: 'tok-q', platform: 'apns', timezone: 'UTC', quietHours: { start: 22, end: 7 } })]);
+    const apns = makeApns({ success: true });
+    const result = await new PushDispatcher({ apns }).sendToUser('u1', basePayload, new Date('2025-06-01T12:00:00Z'));
+
+    expect(result.delivered).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(apns.calls).toHaveLength(1);
+  });
+
+  it('delivers only non-quiet tokens when mixed', async () => {
+    __seedTokens('u1', [
+      makeToken({ token: 'tok-quiet', platform: 'apns', timezone: 'UTC', quietHours: { start: 22, end: 7 } }),
+      makeToken({ token: 'tok-active', platform: 'fcm' }),
+    ]);
+    const apns = makeApns({ success: true });
+    const fcm = makeFcm({ success: true, messageId: 'm1' });
+    const result = await new PushDispatcher({ apns, fcm }).sendToUser('u1', basePayload, new Date('2025-06-01T23:00:00Z'));
+
+    expect(result.skipped).toBe(1);
+    expect(result.delivered).toBe(1);
+    expect(apns.calls).toHaveLength(0);
+    expect(fcm.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PushDispatcher – mixed platform fan-out
+// ---------------------------------------------------------------------------
+
+describe('PushDispatcher – mixed platform fan-out', () => {
+  it('fans out to both APNs and FCM tokens', async () => {
+    __seedTokens('u1', [
+      makeToken({ token: 'apns-tok', platform: 'apns' }),
+      makeToken({ token: 'fcm-tok', platform: 'fcm' }),
+    ]);
+    const result = await new PushDispatcher({ apns: makeApns({ success: true }), fcm: makeFcm({ success: true, messageId: 'msg-1' }) }).sendToUser('u1', basePayload);
+
+    expect(result.delivered).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.results).toHaveLength(2);
+  });
+
+  it('returns empty results for user with no tokens', async () => {
+    const result = await new PushDispatcher({ apns: makeApns({ success: true }) }).sendToUser('nobody', basePayload);
+    expect(result.delivered).toBe(0);
+    expect(result.results).toHaveLength(0);
+  });
+
+  it('sends payload fields (data, badge, sound) to provider', async () => {
+    __seedTokens('u1', [makeToken({ token: 'tok', platform: 'apns' })]);
+    let captured: PushPayload | null = null;
+    const apns: APNsProvider = { send: (_, p) => { captured = p; return Promise.resolve({ success: true }); } };
+    const richPayload: PushPayload = { title: 'Rich', body: 'Notif', data: { deepLink: '/home' }, badge: 3, sound: 'chime' };
+
+    await new PushDispatcher({ apns }).sendToUser('u1', richPayload);
+
+    expect(captured).not.toBeNull();
+    expect(captured!.data).toEqual({ deepLink: '/home' });
+    expect(captured!.badge).toBe(3);
+    expect(captured!.sound).toBe('chime');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PushDispatcher – sendToTokens (explicit list)
+// ---------------------------------------------------------------------------
+
+describe('PushDispatcher.sendToTokens', () => {
+  it('delivers to an explicit list of tokens', async () => {
+    const apns = makeApns({ success: true });
+    const results = await new PushDispatcher({ apns }).sendToTokens(
+      [makeToken({ token: 'explicit-tok', platform: 'apns' })],
+      basePayload,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(true);
+  });
+
+  it('respects quiet hours on explicit tokens', async () => {
+    const apns = makeApns({ success: true });
+    const results = await new PushDispatcher({ apns }).sendToTokens(
+      [makeToken({ token: 'explicit-quiet', platform: 'apns', timezone: 'UTC', quietHours: { start: 0, end: 23 } })],
+      basePayload,
+      new Date('2025-06-01T12:00:00Z'),
+    );
+
+    expect(results[0].skipped).toBe(true);
+    expect(apns.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
closes #378 
- Add APNs and FCM provider interfaces in pushDispatcher.ts
- Per-user device token store with register/remove/list helpers
- Stale-token cleanup on permanent APNs/FCM error codes
- Quiet-hours enforcement with timezone-aware, midnight-wrapping logic
- Express routes: POST/DELETE/GET /push/tokens/:userId, POST /push/send/:userId
- 67 tests passing across unit, route, and integration suites