### PR TITLE
ci: scaffold-matrix workflow across templates, Node 20/22, 3 OSes

### DIFF
--- a/.github/workflows/scaffold-matrix.yml
+++ b/.github/workflows/scaffold-matrix.yml
@@ -1,0 +1,85 @@
+name: Scaffold Matrix
+
+# Trigger strategy (see issue #678):
+# - pull_request: fast smoke pass, ubuntu + Node 20 only, all 5 template variants.
+#   Keeps PR-blocking time to one OS/Node combo x 5 variants instead of the full 30.
+# - schedule (nightly) + workflow_dispatch: full matrix across all OS x Node x variant
+#   combinations, catching platform-specific regressions without blocking every PR.
+
+on:
+  pull_request:
+    paths:
+      - 'src/templates/**'
+      - 'src/lib/scaffold.ts'
+      - 'bin/**'
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  pr-smoke:
+    if: github.event_name == 'pull_request'
+    name: smoke (${{ matrix.variant.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20]
+        variant:
+          - { name: default, args: '--template default' }
+          - { name: minimal, args: '--template minimal' }
+          - { name: defi, args: '--template defi' }
+          - { name: default-js, args: '--template default --javascript' }
+          - { name: with-contracts, args: '--template default --with-contracts' }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Scaffold app
+        shell: bash
+        run: |
+          node dist/bin/nextellar.js scaffolded-app --defaults --skip-install ${{ matrix.variant.args }}
+      - name: Install + build generated app
+        shell: bash
+        working-directory: scaffolded-app
+        run: |
+          npm install
+          npm run build
+
+  nightly-full:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: full (${{ matrix.os }}, node ${{ matrix.node }}, ${{ matrix.variant.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [20, 22]
+        variant:
+          - { name: default, args: '--template default' }
+          - { name: minimal, args: '--template minimal' }
+          - { name: defi, args: '--template defi' }
+          - { name: default-js, args: '--template default --javascript' }
+          - { name: with-contracts, args: '--template default --with-contracts' }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Scaffold app
+        shell: bash
+        run: |
+          node dist/bin/nextellar.js scaffolded-app --defaults --skip-install ${{ matrix.variant.args }}
+      - name: Install + build generated app
+        shell: bash
+        working-directory: scaffolded-app
+        run: |
+          npm install
+          npm run build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scaffold-matrix.yml` covering the 5 required scaffold variants (`default`, `minimal`, `defi`, `default --javascript`, `default --with-contracts`), each built with the CLI then `npm install` + `next build` in the generated app.
- `--with-contracts` runs frontend build only — scaffold just copies `contracts-template` files, no cargo invocation happens anywhere in this workflow.

## Trigger strategy (documented per issue ask)
Full 3-OS x 2-Node x 5-variant matrix is 30 jobs — too slow to block every PR. Split into two jobs:
- **`pr-smoke`**: runs on `pull_request` touching `src/templates/**`, `src/lib/scaffold.ts`, or `bin/**`. `ubuntu-latest` + Node 20 only, all 5 variants — 5 jobs, fast PR feedback.
- **`nightly-full`**: runs on a nightly cron (03:00 UTC) and `workflow_dispatch`. Full `ubuntu-latest`/`macos-latest`/`windows-latest` x Node 20/22 x 5-variant matrix — 30 jobs, catches OS/Node-specific regressions without blocking PRs.

A PR that deletes a template file fails `pr-smoke` naturally, since the scaffold step errors on the missing template.

Closes #678

## Test plan
- [ ] `pr-smoke` job goes green on this PR
- [ ] Nightly full matrix goes green on `main` after merge
- [ ] Maintainer review/approval