### PR TITLE
feat(compliance): add travel rule data exchange endpoint (#390)

### DIFF
--- a/routes-d/auth/mutualAuth.ts
+++ b/routes-d/auth/mutualAuth.ts
@@ -1,0 +1,212 @@
+/**
+ * routes-d/auth/mutualAuth.ts
+ *
+ * Mutual-authentication middleware for the travel rule data exchange endpoint.
+ *
+ * Authentication scheme
+ * ─────────────────────
+ * Each authorised partner exchange is issued:
+ *   1. A stable `partnerId` (e.g. "exchange-abc").
+ *   2. A shared secret (`TRAVEL_RULE_PARTNER_SECRET_<PARTNERID>`).
+ *
+ * Request authentication
+ * ──────────────────────
+ * The caller MUST include two HTTP headers on every request:
+ *
+ *   X-Partner-Id     : partnerId
+ *   X-Partner-Sig    : HMAC-SHA-256( partnerId + ":" + timestamp + ":" + body-sha256,
+ *                                    partnerSecret )
+ *                      encoded as lowercase hex.
+ *   X-Partner-Ts     : Unix timestamp in seconds (string). Requests older than
+ *                      PARTNER_SIG_WINDOW_SECONDS (default 300 s) are rejected.
+ *
+ * The signature binds the partner id, a freshness timestamp, and a SHA-256 hash of
+ * the raw request body so the middleware can detect replay and tampering.
+ *
+ * Partner registry
+ * ────────────────
+ * Partners are registered via environment variables:
+ *
+ *   TRAVEL_RULE_PARTNER_SECRET_<PARTNERID>   Shared secret for that partner.
+ *
+ * Multiple partners are supported; each has its own secret variable.
+ *
+ * Environment variables
+ * ─────────────────────
+ *   PARTNER_SIG_WINDOW_SECONDS   Maximum age of a signed request (default 300).
+ */
+
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { sendError } from '../lib/response.js';
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+const DEFAULT_WINDOW_SECONDS = 300;
+
+function sigWindowSeconds(): number {
+  const raw = process.env.PARTNER_SIG_WINDOW_SECONDS;
+  if (raw) {
+    const n = parseInt(raw, 10);
+    if (!isNaN(n) && n > 0) return n;
+  }
+  return DEFAULT_WINDOW_SECONDS;
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface PartnerRequest extends Request {
+  /** Authenticated partner identifier, set by `requirePartner`. */
+  partnerId?: string;
+}
+
+// ── Secret resolution ──────────────────────────────────────────────────────
+
+/**
+ * Reads the shared secret for `partnerId` from the environment.
+ * Returns `undefined` if not configured (partner is unknown).
+ */
+export function resolvePartnerSecret(partnerId: string): string | undefined {
+  const key = `TRAVEL_RULE_PARTNER_SECRET_${partnerId.toUpperCase().replace(/-/g, '_')}`;
+  return process.env[key];
+}
+
+// ── Signature helpers ──────────────────────────────────────────────────────
+
+/**
+ * Computes the expected HMAC-SHA-256 signature for a request.
+ *
+ * @param partnerId  - Caller's partner id.
+ * @param timestamp  - Unix seconds string as supplied by the caller.
+ * @param bodyHex    - Lowercase hex of the raw request body SHA-256.
+ * @param secret     - The partner's shared secret.
+ */
+export function computeSignature(
+  partnerId: string,
+  timestamp: string,
+  bodyHex: string,
+  secret: string,
+): string {
+  const message = `${partnerId}:${timestamp}:${bodyHex}`;
+  return createHmac('sha256', secret).update(message).digest('hex');
+}
+
+/**
+ * Computes the SHA-256 hex digest of a raw body buffer (or empty string).
+ */
+export function bodyDigest(rawBody: Buffer | string): string {
+  const data = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8');
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Timing-safe string comparison for HMAC values.
+ */
+export function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that mutually authenticates an inbound partner request.
+ *
+ * On success it sets `req.partnerId` and calls `next()`.
+ * On failure it returns 401 or 403 with a structured error envelope.
+ */
+export function requirePartner(
+  req: PartnerRequest,
+  res: Response,
+  next: NextFunction,
+): void {
+  const partnerId = req.headers['x-partner-id'];
+  const signature = req.headers['x-partner-sig'];
+  const timestamp = req.headers['x-partner-ts'];
+
+  if (
+    typeof partnerId !== 'string' || partnerId.trim() === '' ||
+    typeof signature !== 'string' || signature.trim() === '' ||
+    typeof timestamp !== 'string' || timestamp.trim() === ''
+  ) {
+    sendError(
+      res,
+      'MISSING_AUTH_HEADERS',
+      'X-Partner-Id, X-Partner-Sig, and X-Partner-Ts headers are required',
+      401,
+    );
+    return;
+  }
+
+  // ── Timestamp freshness ────────────────────────────────────────────────
+
+  const tsNum = parseInt(timestamp, 10);
+  if (isNaN(tsNum)) {
+    sendError(res, 'INVALID_TIMESTAMP', 'X-Partner-Ts must be a numeric Unix timestamp', 401);
+    return;
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const ageSecs = Math.abs(nowSeconds - tsNum);
+
+  if (ageSecs > sigWindowSeconds()) {
+    sendError(
+      res,
+      'REQUEST_EXPIRED',
+      `Request timestamp is too old or too far in the future (window: ${sigWindowSeconds()} s)`,
+      401,
+    );
+    return;
+  }
+
+  // ── Partner lookup ─────────────────────────────────────────────────────
+
+  const secret = resolvePartnerSecret(partnerId);
+  if (!secret) {
+    sendError(res, 'UNKNOWN_PARTNER', 'Unrecognised partner id', 403);
+    return;
+  }
+
+  // ── Signature verification ─────────────────────────────────────────────
+
+  // The raw body must have been parsed before this middleware runs (or be empty).
+  // We re-serialise from req.body when rawBody is absent for convenience.
+  const rawBody: Buffer | string =
+    (req as Request & { rawBody?: Buffer }).rawBody ??
+    (req.body !== undefined ? JSON.stringify(req.body) : '');
+
+  const digest = bodyDigest(rawBody);
+  const expected = computeSignature(partnerId, timestamp, digest, secret);
+
+  if (!safeCompare(expected, signature)) {
+    sendError(res, 'INVALID_SIGNATURE', 'Request signature verification failed', 401);
+    return;
+  }
+
+  req.partnerId = partnerId;
+  next();
+}
+
+// ── Test helpers ───────────────────────────────────────────────────────────
+
+/**
+ * @internal
+ * Registers a partner secret in the environment for unit tests.
+ */
+export function __registerTestPartner(partnerId: string, secret: string): void {
+  const key = `TRAVEL_RULE_PARTNER_SECRET_${partnerId.toUpperCase().replace(/-/g, '_')}`;
+  process.env[key] = secret;
+}
+
+/**
+ * @internal
+ * Removes a partner secret from the environment after a test.
+ */
+export function __unregisterTestPartner(partnerId: string): void {
+  const key = `TRAVEL_RULE_PARTNER_SECRET_${partnerId.toUpperCase().replace(/-/g, '_')}`;
+  delete process.env[key];
+}

--- a/routes-d/docs/travel-rule.md
+++ b/routes-d/docs/travel-rule.md
@@ -1,0 +1,258 @@
+# Travel Rule Data Exchange Endpoint
+
+Exposes an API for partner Virtual Asset Service Providers (VASPs) to exchange
+originator and beneficiary information as required by the FATF Travel Rule
+(Recommendation 16).
+
+## Routes
+
+| Method | Path                                               | Description                        |
+| ------ | -------------------------------------------------- | ---------------------------------- |
+| POST   | `/compliance/travel-rule/transfers`                | Submit a travel rule record        |
+| GET    | `/compliance/travel-rule/transfers/:transferId`    | Fetch an existing record (with PII)|
+
+All routes require **mutual partner authentication** (see below).
+
+---
+
+## Authentication
+
+### Mutual Partner Authentication
+
+Every request must include three HTTP headers:
+
+| Header           | Description                                                        |
+| ---------------- | ------------------------------------------------------------------ |
+| `X-Partner-Id`   | Your assigned partner identifier, e.g. `exchange-abc`             |
+| `X-Partner-Ts`   | Current Unix timestamp in seconds (string)                         |
+| `X-Partner-Sig`  | HMAC-SHA-256 signature (lowercase hex, 64 chars)                   |
+
+#### Signature algorithm
+
+```
+message  = partnerId + ":" + timestamp + ":" + sha256(rawBody)
+signature = HMAC-SHA-256(message, partnerSecret)
+```
+
+- `sha256(rawBody)` is the lowercase hex digest of the raw UTF-8 request body.
+  For GET requests with no body, use the SHA-256 of an empty string.
+- `partnerSecret` is the shared secret issued during partner onboarding.
+- Requests with a timestamp older than **300 seconds** (configurable via
+  `PARTNER_SIG_WINDOW_SECONDS`) are rejected.
+
+#### Partner secret registration
+
+Partner secrets are stored as environment variables:
+
+```
+TRAVEL_RULE_PARTNER_SECRET_<PARTNERID_UPPERCASE>
+```
+
+For example, a partner with id `exchange-abc` uses:
+
+```
+TRAVEL_RULE_PARTNER_SECRET_EXCHANGE_ABC=<shared-secret>
+```
+
+Hyphens in the partner id are converted to underscores. Secrets must be strong
+random strings (≥ 32 bytes of entropy recommended).
+
+---
+
+## Field Encryption
+
+Sensitive PII fields are encrypted at rest using **AES-256-GCM** before being
+written to the store.
+
+### Encrypted fields
+
+- `originator.name`
+- `originator.accountNumber`
+- `beneficiary.name`
+- `beneficiary.accountNumber`
+
+### Key ID (`kid`) scheme
+
+Each encrypted value carries a `kid` (key identifier) that links it to a
+specific symmetric key. This allows transparent key rotation without
+re-encrypting all existing records immediately.
+
+#### Environment variables
+
+| Variable                              | Description                                      |
+| ------------------------------------- | ------------------------------------------------ |
+| `TRAVEL_RULE_KEY_<KID>`               | 64-character hex-encoded 256-bit key             |
+| `TRAVEL_RULE_KEY_ACTIVE`              | The `kid` used when encrypting new records (default `v1`) |
+
+**Example – rotating to key `v2`:**
+
+```bash
+# Add the new key
+TRAVEL_RULE_KEY_V2=<64-hex-chars>
+
+# Switch encryption of new records to v2
+TRAVEL_RULE_KEY_ACTIVE=v2
+
+# Old records encrypted with v1 remain readable as long as TRAVEL_RULE_KEY_V1
+# is still set.  Remove v1 only after all records have been migrated.
+```
+
+#### Wire format (EncryptedField)
+
+Encrypted values are stored as JSON objects. They are never returned as-is in
+API responses; the fetch endpoint always decrypts them before responding.
+
+```json
+{
+  "kid":        "v1",
+  "iv":         "<24-char hex>",
+  "tag":        "<32-char hex>",
+  "ciphertext": "<hex>"
+}
+```
+
+---
+
+## API Reference
+
+### POST /compliance/travel-rule/transfers
+
+Submit a travel rule record for an outbound transfer.
+
+**Request body**
+
+```json
+{
+  "transferId":   "string (unique, idempotency key)",
+  "amount":       "number (positive)",
+  "asset":        "string (e.g. USDC, XLM)",
+  "originator": {
+    "name":          "string",
+    "accountNumber": "string",
+    "address":       "string (optional)"
+  },
+  "beneficiary": {
+    "name":          "string",
+    "accountNumber": "string",
+    "address":       "string (optional)"
+  }
+}
+```
+
+**Responses**
+
+| Status | Condition                                    |
+| ------ | -------------------------------------------- |
+| 201    | Record created                               |
+| 200    | Record already exists (`meta.duplicate: true`)|
+| 400    | Validation error                             |
+| 401    | Missing/invalid auth headers or signature    |
+| 403    | Unknown partner id                           |
+
+**201 response body** (PII fields are **not** returned on creation):
+
+```json
+{
+  "success": true,
+  "data": {
+    "transferId":   "tr-001",
+    "createdAt":    "2026-07-26T12:00:00.000Z",
+    "submittedBy":  "exchange-abc",
+    "amount":       500,
+    "asset":        "USDC"
+  }
+}
+```
+
+---
+
+### GET /compliance/travel-rule/transfers/:transferId
+
+Fetch a previously submitted record. PII fields are decrypted in the response.
+
+**Responses**
+
+| Status | Condition                                    |
+| ------ | -------------------------------------------- |
+| 200    | Record found and returned with decrypted PII |
+| 401    | Missing/invalid auth headers or signature    |
+| 403    | Unknown partner id                           |
+| 404    | Record not found                             |
+
+**200 response body**:
+
+```json
+{
+  "success": true,
+  "data": {
+    "transferId":   "tr-001",
+    "createdAt":    "2026-07-26T12:00:00.000Z",
+    "submittedBy":  "exchange-abc",
+    "amount":       500,
+    "asset":        "USDC",
+    "originator": {
+      "name":          "Alice Originator",
+      "accountNumber": "GABC1234567890",
+      "address":       "1 Main St"
+    },
+    "beneficiary": {
+      "name":          "Bob Beneficiary",
+      "accountNumber": "GXYZ9876543210"
+    }
+  }
+}
+```
+
+---
+
+## Error Envelope
+
+All error responses follow the standard envelope:
+
+```json
+{
+  "error": {
+    "code":    "VALIDATION_ERROR",
+    "message": "Human-readable description"
+  }
+}
+```
+
+### Error codes
+
+| Code                    | HTTP status | Meaning                                          |
+| ----------------------- | ----------- | ------------------------------------------------ |
+| `VALIDATION_ERROR`      | 400         | Request body failed validation                   |
+| `MISSING_AUTH_HEADERS`  | 401         | One or more auth headers are absent              |
+| `INVALID_TIMESTAMP`     | 401         | `X-Partner-Ts` is not a valid number             |
+| `REQUEST_EXPIRED`       | 401         | Timestamp is outside the allowed window          |
+| `INVALID_SIGNATURE`     | 401         | HMAC verification failed                         |
+| `UNKNOWN_PARTNER`       | 403         | The supplied `X-Partner-Id` has no registered secret |
+| `NOT_FOUND`             | 404         | No record exists for the given `transferId`      |
+
+---
+
+## File Structure
+
+```
+routes-d/
+├── auth/
+│   └── mutualAuth.ts          # Partner mutual-auth middleware
+├── lib/
+│   ├── crypto.ts              # AES-256-GCM field encryption / decryption
+│   └── response.ts            # sendError helper
+├── middleware/
+│   ├── errorHandler.ts        # Structured error handler + asyncHandler
+│   └── index.ts               # Re-exports middleware for consumers
+├── routes/
+│   └── compliance.travelRule.ts  # Submit + fetch route handlers
+├── tests/
+│   ├── compliance.travelRule.test.ts      # Route-level tests
+│   ├── unit/
+│   │   ├── crypto.test.ts                 # Unit tests for crypto.ts
+│   │   └── mutualAuth.test.ts             # Unit tests for mutualAuth.ts
+│   └── integration/
+│       └── compliance.travelRule.integration.test.ts
+└── docs/
+    └── travel-rule.md         # This file
+```

--- a/routes-d/lib/crypto.ts
+++ b/routes-d/lib/crypto.ts
@@ -1,0 +1,194 @@
+/**
+ * routes-d/lib/crypto.ts
+ *
+ * AES-256-GCM field-level encryption / decryption used by the travel rule
+ * data exchange endpoint.
+ *
+ * Key-id scheme
+ * ─────────────
+ * Every encrypted payload carries a `kid` (key ID) so the receiving party can
+ * identify which symmetric key was used without embedding key material in the
+ * ciphertext.  Keys are resolved from the environment at call-time via the
+ * helper `resolveKey`.
+ *
+ * Environment variables
+ * ─────────────────────
+ *   TRAVEL_RULE_KEY_<KID>   Hex-encoded 32-byte (256-bit) key, e.g.:
+ *                           TRAVEL_RULE_KEY_v1=<64 hex chars>
+ *
+ *   TRAVEL_RULE_KEY_ACTIVE  The kid to use when encrypting new payloads.
+ *                           Defaults to "v1".
+ *
+ * Wire format (JSON-serialisable EncryptedField)
+ * ───────────────────────────────────────────────
+ *   { kid, iv, tag, ciphertext }  – all values are hex strings.
+ */
+
+import nodeCrypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;   // 96-bit nonce recommended for GCM
+const TAG_BYTES = 16;  // 128-bit authentication tag
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface EncryptedField {
+  /** Key identifier that resolves to the symmetric key used for this field. */
+  kid: string;
+  /** Hex-encoded 12-byte initialisation vector. */
+  iv: string;
+  /** Hex-encoded 16-byte GCM authentication tag. */
+  tag: string;
+  /** Hex-encoded ciphertext. */
+  ciphertext: string;
+}
+
+// ── Key resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Reads the raw 32-byte key for a given `kid` from the environment.
+ * Throws a descriptive error if the variable is missing or the key length is wrong.
+ */
+export function resolveKey(kid: string): Buffer {
+  const envVar = `TRAVEL_RULE_KEY_${kid.toUpperCase()}`;
+  const hex = process.env[envVar];
+
+  if (!hex) {
+    throw new Error(
+      `Travel rule encryption key not found: ${envVar}. ` +
+        `Set the environment variable to a 64-character hex string (256-bit key).`,
+    );
+  }
+
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(
+      `Travel rule encryption key ${envVar} must be a 64-character hex string.`,
+    );
+  }
+
+  return Buffer.from(hex, 'hex');
+}
+
+/**
+ * Returns the `kid` that should be used when encrypting a new field.
+ * Falls back to "v1" if the environment variable is not set.
+ */
+export function activeKeyId(): string {
+  return (process.env.TRAVEL_RULE_KEY_ACTIVE ?? 'v1').trim();
+}
+
+// ── Core operations ────────────────────────────────────────────────────────
+
+/**
+ * Encrypts `plaintext` using AES-256-GCM and returns an `EncryptedField`.
+ *
+ * @param plaintext - UTF-8 string to encrypt (e.g. full name, account number).
+ * @param kid       - Key identifier; defaults to `activeKeyId()`.
+ */
+export function encryptField(plaintext: string, kid?: string): EncryptedField {
+  const resolvedKid = kid ?? activeKeyId();
+  const key = resolveKey(resolvedKid);
+  const iv = nodeCrypto.randomBytes(IV_BYTES);
+
+  const cipher = nodeCrypto.createCipheriv(ALGORITHM, key, iv);
+  const cipherBuf = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    kid: resolvedKid,
+    iv: iv.toString('hex'),
+    tag: tag.toString('hex'),
+    ciphertext: cipherBuf.toString('hex'),
+  };
+}
+
+/**
+ * Decrypts an `EncryptedField` and returns the original UTF-8 plaintext.
+ * Throws if authentication fails (tampered ciphertext or wrong key).
+ */
+export function decryptField(field: EncryptedField): string {
+  const key = resolveKey(field.kid);
+  const iv = Buffer.from(field.iv, 'hex');
+  const tag = Buffer.from(field.tag, 'hex');
+  const ciphertext = Buffer.from(field.ciphertext, 'hex');
+
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`Invalid IV length: expected ${IV_BYTES} bytes.`);
+  }
+  if (tag.length !== TAG_BYTES) {
+    throw new Error(`Invalid auth-tag length: expected ${TAG_BYTES} bytes.`);
+  }
+
+  const decipher = nodeCrypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+/**
+ * Convenience helper: encrypts an object's fields listed in `fieldNames` in-place
+ * (mutates and returns the same object with EncryptedField values replacing plain strings).
+ *
+ * Only processes fields that are non-empty strings; skips nullish values.
+ */
+export function encryptFields<T extends Record<string, unknown>>(
+  record: T,
+  fieldNames: (keyof T)[],
+  kid?: string,
+): T {
+  for (const name of fieldNames) {
+    const value = record[name];
+    if (typeof value === 'string' && value.length > 0) {
+      (record as Record<string, unknown>)[name as string] = encryptField(value, kid);
+    }
+  }
+  return record;
+}
+
+/**
+ * Convenience helper: decrypts EncryptedField values back to plaintext strings
+ * for the listed field names (mutates and returns the same object).
+ */
+export function decryptFields<T extends Record<string, unknown>>(
+  record: T,
+  fieldNames: (keyof T)[],
+): T {
+  for (const name of fieldNames) {
+    const value = record[name];
+    if (isEncryptedField(value)) {
+      (record as Record<string, unknown>)[name as string] = decryptField(value);
+    }
+  }
+  return record;
+}
+
+/**
+ * Type guard: narrows an unknown value to `EncryptedField`.
+ */
+export function isEncryptedField(value: unknown): value is EncryptedField {
+  if (!value || typeof value !== 'object') return false;
+  const f = value as Record<string, unknown>;
+  return (
+    typeof f.kid === 'string' &&
+    typeof f.iv === 'string' &&
+    typeof f.tag === 'string' &&
+    typeof f.ciphertext === 'string'
+  );
+}
+
+// ── Test/reset helpers (for unit tests only) ───────────────────────────────
+
+/**
+ * @internal
+ * Exposed so unit tests can inject a deterministic key without touching
+ * process.env directly.  Do not use in production code.
+ */
+export function __setTestKey(kid: string, hexKey: string): void {
+  process.env[`TRAVEL_RULE_KEY_${kid.toUpperCase()}`] = hexKey;
+}

--- a/routes-d/middleware/index.ts
+++ b/routes-d/middleware/index.ts
@@ -1,0 +1,24 @@
+/**
+ * routes-d/middleware/index.ts
+ *
+ * Central middleware registry for the routes-d module.
+ *
+ * Re-exports:
+ *   - requirePartner  – mutual partner authentication
+ *   - errorHandler    – structured error envelope
+ *   - asyncHandler    – async route wrapper that forwards errors to next()
+ *
+ * Usage example (in an Express app that mounts routes-d routes):
+ *
+ *   import { requirePartner, errorHandler } from './routes-d/middleware/index.js';
+ *
+ *   app.use(express.json());
+ *   app.use(travelRuleRouter);          // routes already have requirePartner inline
+ *   app.use(errorHandler);              // catch-all error handler
+ */
+
+export { requirePartner } from '../auth/mutualAuth.js';
+export type { PartnerRequest } from '../auth/mutualAuth.js';
+
+export { errorHandler, asyncHandler } from './errorHandler.js';
+export type { ApiError } from './errorHandler.js';

--- a/routes-d/routes/compliance.travelRule.ts
+++ b/routes-d/routes/compliance.travelRule.ts
@@ -1,0 +1,278 @@
+/**
+ * routes-d/routes/compliance.travelRule.ts
+ *
+ * Travel Rule Data Exchange Endpoint
+ * ────────────────────────────────────
+ * Implements the FATF/Travel Rule protocol for sharing originator and
+ * beneficiary information between partner Virtual Asset Service Providers
+ * (VASPs).
+ *
+ * Routes
+ * ──────
+ *   POST /compliance/travel-rule/transfers
+ *     Submit a new travel rule record for an outbound transfer.
+ *     Sensitive PII fields are encrypted at rest using AES-256-GCM.
+ *
+ *   GET  /compliance/travel-rule/transfers/:transferId
+ *     Fetch a previously submitted travel rule record.
+ *     Sensitive PII is decrypted in the response.
+ *
+ * Both routes require mutual partner authentication via the `requirePartner`
+ * middleware (X-Partner-Id / X-Partner-Sig / X-Partner-Ts headers).
+ *
+ * Encrypted fields (stored as EncryptedField objects)
+ * ────────────────────────────────────────────────────
+ *   originator.name, originator.accountNumber
+ *   beneficiary.name, beneficiary.accountNumber
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { sendError } from '../lib/response.js';
+import { encryptField, decryptField, isEncryptedField, type EncryptedField } from '../lib/crypto.js';
+import { requirePartner, type PartnerRequest } from '../auth/mutualAuth.js';
+
+const router = Router();
+
+// ── In-memory store (replace with a real DB in production) ─────────────────
+
+export interface PartyInfo {
+  name: string | EncryptedField;
+  accountNumber: string | EncryptedField;
+  address?: string;
+}
+
+export interface TravelRuleRecord {
+  transferId: string;
+  createdAt: string;
+  submittedBy: string;
+  amount: number;
+  asset: string;
+  originator: PartyInfo;
+  beneficiary: PartyInfo;
+}
+
+interface TravelRuleStore {
+  [transferId: string]: TravelRuleRecord;
+}
+
+const store: TravelRuleStore = {};
+
+// ── Exported for test resets ────────────────────────────────────────────────
+
+/**
+ * @internal – used only by tests to reset the in-memory store.
+ */
+export function __resetTravelRuleStore(): void {
+  for (const key of Object.keys(store)) {
+    delete store[key];
+  }
+}
+
+// ── Validation helpers ──────────────────────────────────────────────────────
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function isPositiveNumber(v: unknown): v is number {
+  return typeof v === 'number' && isFinite(v) && v > 0;
+}
+
+interface RawPartyInfo {
+  name?: unknown;
+  accountNumber?: unknown;
+  address?: unknown;
+}
+
+function parsePartyInfo(raw: unknown, label: string): PartyInfo | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const p = raw as RawPartyInfo;
+
+  if (!isNonEmptyString(p.name)) return null;
+  if (!isNonEmptyString(p.accountNumber)) return null;
+
+  return {
+    name: p.name.trim(),
+    accountNumber: p.accountNumber.trim(),
+    ...(isNonEmptyString(p.address) && { address: p.address.trim() }),
+  };
+}
+
+// ── Route: POST /compliance/travel-rule/transfers ──────────────────────────
+
+/**
+ * Submit a travel rule record for an outbound transfer.
+ *
+ * Request body:
+ * {
+ *   transferId    : string   – unique transfer reference (idempotency key)
+ *   amount        : number   – transfer amount (positive)
+ *   asset         : string   – asset code (e.g. "USDC")
+ *   originator    : { name, accountNumber, address? }
+ *   beneficiary   : { name, accountNumber, address? }
+ * }
+ */
+router.post(
+  '/compliance/travel-rule/transfers',
+  requirePartner as (req: Request, res: Response, next: NextFunction) => void,
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const partnerId = (req as PartnerRequest).partnerId!;
+      const body = req.body as Record<string, unknown>;
+
+      // ── Input validation ─────────────────────────────────────────────
+
+      if (!isNonEmptyString(body.transferId)) {
+        sendError(res, 'VALIDATION_ERROR', 'transferId is required', 400);
+        return;
+      }
+      if (!isPositiveNumber(body.amount)) {
+        sendError(res, 'VALIDATION_ERROR', 'amount must be a positive number', 400);
+        return;
+      }
+      if (!isNonEmptyString(body.asset)) {
+        sendError(res, 'VALIDATION_ERROR', 'asset is required', 400);
+        return;
+      }
+
+      const originator = parsePartyInfo(body.originator, 'originator');
+      if (!originator) {
+        sendError(res, 'VALIDATION_ERROR', 'originator must include name and accountNumber', 400);
+        return;
+      }
+
+      const beneficiary = parsePartyInfo(body.beneficiary, 'beneficiary');
+      if (!beneficiary) {
+        sendError(res, 'VALIDATION_ERROR', 'beneficiary must include name and accountNumber', 400);
+        return;
+      }
+
+      const transferId = (body.transferId as string).trim();
+
+      // ── Idempotency ──────────────────────────────────────────────────
+
+      if (store[transferId]) {
+        res.status(200).json({
+          success: true,
+          data: redact(store[transferId]),
+          meta: { duplicate: true },
+        });
+        return;
+      }
+
+      // ── Encrypt sensitive PII fields ─────────────────────────────────
+
+      const record: TravelRuleRecord = {
+        transferId,
+        createdAt: new Date().toISOString(),
+        submittedBy: partnerId,
+        amount: body.amount as number,
+        asset: (body.asset as string).trim().toUpperCase(),
+        originator: {
+          ...originator,
+          name: encryptField(originator.name as string),
+          accountNumber: encryptField(originator.accountNumber as string),
+        },
+        beneficiary: {
+          ...beneficiary,
+          name: encryptField(beneficiary.name as string),
+          accountNumber: encryptField(beneficiary.accountNumber as string),
+        },
+      };
+
+      store[transferId] = record;
+
+      res.status(201).json({
+        success: true,
+        data: {
+          transferId: record.transferId,
+          createdAt: record.createdAt,
+          submittedBy: record.submittedBy,
+          amount: record.amount,
+          asset: record.asset,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── Route: GET /compliance/travel-rule/transfers/:transferId ───────────────
+
+/**
+ * Fetch a submitted travel rule record by transferId.
+ * PII fields are decrypted in the response.
+ */
+router.get(
+  '/compliance/travel-rule/transfers/:transferId',
+  requirePartner as (req: Request, res: Response, next: NextFunction) => void,
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const rawParam = req.params['transferId'];
+      const transferId = Array.isArray(rawParam) ? rawParam[0] : rawParam;
+
+      if (!transferId || String(transferId).trim() === '') {
+        sendError(res, 'VALIDATION_ERROR', 'transferId path parameter is required', 400);
+        return;
+      }
+
+      const record = store[String(transferId)];
+      if (!record) {
+        sendError(res, 'NOT_FOUND', `Travel rule record not found: ${transferId}`, 404);
+        return;
+      }
+
+      // ── Decrypt PII for the response ─────────────────────────────────
+
+      res.status(200).json({
+        success: true,
+        data: decrypt(record),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a shallow copy of the record with PII fields decrypted.
+ */
+function decrypt(record: TravelRuleRecord): Record<string, unknown> {
+  const decryptParty = (party: PartyInfo): Record<string, unknown> => ({
+    ...party,
+    name: isEncryptedField(party.name) ? decryptField(party.name) : party.name,
+    accountNumber: isEncryptedField(party.accountNumber)
+      ? decryptField(party.accountNumber)
+      : party.accountNumber,
+  });
+
+  return {
+    transferId: record.transferId,
+    createdAt: record.createdAt,
+    submittedBy: record.submittedBy,
+    amount: record.amount,
+    asset: record.asset,
+    originator: decryptParty(record.originator),
+    beneficiary: decryptParty(record.beneficiary),
+  };
+}
+
+/**
+ * Returns a representation suitable for the idempotent-duplicate response:
+ * PII fields are redacted (not returned) to avoid leaking decrypted data
+ * in the 200 re-submission response.
+ */
+function redact(record: TravelRuleRecord): Record<string, unknown> {
+  return {
+    transferId: record.transferId,
+    createdAt: record.createdAt,
+    submittedBy: record.submittedBy,
+    amount: record.amount,
+    asset: record.asset,
+  };
+}
+
+export default router;

--- a/routes-d/tests/compliance.travelRule.test.ts
+++ b/routes-d/tests/compliance.travelRule.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Route tests for routes-d/routes/compliance.travelRule.ts
+ *
+ * Covers:
+ *   - POST /compliance/travel-rule/transfers (submit)
+ *   - GET  /compliance/travel-rule/transfers/:transferId (fetch)
+ *   - Unauthorized partner rejection
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import travelRuleRouter, { __resetTravelRuleStore } from '../routes/compliance.travelRule.js';
+import { __resetTravelRuleStore as resetStore } from '../routes/compliance.travelRule.js';
+import {
+  __registerTestPartner,
+  __unregisterTestPartner,
+  computeSignature,
+  bodyDigest,
+} from '../auth/mutualAuth.js';
+import { __setTestKey } from '../lib/crypto.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PARTNER_ID = 'vasp-alpha';
+const PARTNER_SECRET = 'test-secret-for-travel-rule-route';
+const KEY_KID = 'trv1';
+const KEY_HEX = '0'.repeat(64);
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(travelRuleRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+function validHeaders(body: object = {}): Record<string, string> {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const digest = bodyDigest(JSON.stringify(body));
+  const sig = computeSignature(PARTNER_ID, timestamp, digest, PARTNER_SECRET);
+  return {
+    'Content-Type': 'application/json',
+    'x-partner-id': PARTNER_ID,
+    'x-partner-ts': timestamp,
+    'x-partner-sig': sig,
+  };
+}
+
+const VALID_PAYLOAD = {
+  transferId: 'tr-001',
+  amount: 500,
+  asset: 'USDC',
+  originator: {
+    name: 'Alice Originator',
+    accountNumber: 'GABC1234567890',
+    address: '1 Main St',
+  },
+  beneficiary: {
+    name: 'Bob Beneficiary',
+    accountNumber: 'GXYZ9876543210',
+  },
+};
+
+beforeAll(() => {
+  __registerTestPartner(PARTNER_ID, PARTNER_SECRET);
+  __setTestKey(KEY_KID, KEY_HEX);
+  process.env.TRAVEL_RULE_KEY_ACTIVE = KEY_KID;
+});
+
+afterAll(() => {
+  __unregisterTestPartner(PARTNER_ID);
+  delete process.env.TRAVEL_RULE_KEY_ACTIVE;
+  delete process.env[`TRAVEL_RULE_KEY_${KEY_KID.toUpperCase()}`];
+});
+
+beforeEach(() => {
+  __resetTravelRuleStore();
+});
+
+describe('compliance travel rule routes', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  // ── POST /compliance/travel-rule/transfers ─────────────────────────────────
+
+  describe('POST /compliance/travel-rule/transfers', () => {
+    it('creates a record and returns 201 with summary (no PII)', async () => {
+      const body = { ...VALID_PAYLOAD };
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.transferId).toBe('tr-001');
+      expect(res.body.data.amount).toBe(500);
+      expect(res.body.data.asset).toBe('USDC');
+      expect(res.body.data.submittedBy).toBe(PARTNER_ID);
+
+      // PII must NOT be present in the creation response
+      expect(res.body.data.originator).toBeUndefined();
+      expect(res.body.data.beneficiary).toBeUndefined();
+    });
+
+    it('returns 200 with duplicate flag when the same transferId is submitted twice', async () => {
+      const body = { ...VALID_PAYLOAD };
+      await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body)
+        .expect(201);
+
+      const res2 = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res2.status).toBe(200);
+      expect(res2.body.meta.duplicate).toBe(true);
+      expect(res2.body.data.transferId).toBe('tr-001');
+    });
+
+    it('returns 400 when transferId is missing', async () => {
+      const body = { ...VALID_PAYLOAD, transferId: '' };
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when amount is zero or negative', async () => {
+      const body = { ...VALID_PAYLOAD, transferId: 'tr-002', amount: -1 };
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when asset is missing', async () => {
+      const body = { ...VALID_PAYLOAD, transferId: 'tr-003', asset: '' };
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when originator is missing accountNumber', async () => {
+      const body = {
+        ...VALID_PAYLOAD,
+        transferId: 'tr-004',
+        originator: { name: 'Alice' },
+      };
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when beneficiary is missing name', async () => {
+      const body = {
+        ...VALID_PAYLOAD,
+        transferId: 'tr-005',
+        beneficiary: { accountNumber: 'GABC' },
+      };
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 401 when auth headers are absent', async () => {
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .send(VALID_PAYLOAD);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('MISSING_AUTH_HEADERS');
+    });
+
+    it('returns 403 for an unregistered partner', async () => {
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const body = { ...VALID_PAYLOAD };
+      const digest = bodyDigest(JSON.stringify(body));
+      const sig = computeSignature('rouge-vasp', timestamp, digest, 'any-secret');
+
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set({
+          'Content-Type': 'application/json',
+          'x-partner-id': 'rouge-vasp',
+          'x-partner-ts': timestamp,
+          'x-partner-sig': sig,
+        })
+        .send(body);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('UNKNOWN_PARTNER');
+    });
+
+    it('returns 401 when signature does not match', async () => {
+      const headers = validHeaders(VALID_PAYLOAD);
+      headers['x-partner-sig'] = 'e'.repeat(64);
+      const res = await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(headers)
+        .send(VALID_PAYLOAD);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('INVALID_SIGNATURE');
+    });
+  });
+
+  // ── GET /compliance/travel-rule/transfers/:transferId ──────────────────────
+
+  describe('GET /compliance/travel-rule/transfers/:transferId', () => {
+    /** Auth headers for GET requests (no body → empty string digest). */
+    function getHeaders(): Record<string, string> {
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const digest = bodyDigest('');
+      const sig = computeSignature(PARTNER_ID, timestamp, digest, PARTNER_SECRET);
+      return {
+        'x-partner-id': PARTNER_ID,
+        'x-partner-ts': timestamp,
+        'x-partner-sig': sig,
+      };
+    }
+
+    async function submitRecord(): Promise<void> {
+      const body = { ...VALID_PAYLOAD };
+      await request(app)
+        .post('/compliance/travel-rule/transfers')
+        .set(validHeaders(body))
+        .send(body)
+        .expect(201);
+    }
+
+    it('returns 200 with decrypted PII for an existing record', async () => {
+      await submitRecord();
+
+      const res = await request(app)
+        .get('/compliance/travel-rule/transfers/tr-001')
+        .set(getHeaders());
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const data = res.body.data;
+      expect(data.transferId).toBe('tr-001');
+      expect(data.amount).toBe(500);
+      expect(data.asset).toBe('USDC');
+
+      // PII must be decrypted (plain strings, not EncryptedField objects)
+      expect(data.originator.name).toBe('Alice Originator');
+      expect(data.originator.accountNumber).toBe('GABC1234567890');
+      expect(data.originator.address).toBe('1 Main St');
+      expect(data.beneficiary.name).toBe('Bob Beneficiary');
+      expect(data.beneficiary.accountNumber).toBe('GXYZ9876543210');
+    });
+
+    it('returns 404 for a non-existent transferId', async () => {
+      const res = await request(app)
+        .get('/compliance/travel-rule/transfers/unknown-id')
+        .set(getHeaders());
+
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('NOT_FOUND');
+    });
+
+    it('returns 401 when auth headers are absent on fetch', async () => {
+      await submitRecord();
+      const res = await request(app).get('/compliance/travel-rule/transfers/tr-001');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for an unregistered partner on fetch', async () => {
+      await submitRecord();
+
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const digest = bodyDigest('');
+      const sig = computeSignature('rogue-vasp', timestamp, digest, 'any');
+
+      const res = await request(app)
+        .get('/compliance/travel-rule/transfers/tr-001')
+        .set({
+          'x-partner-id': 'rogue-vasp',
+          'x-partner-ts': timestamp,
+          'x-partner-sig': sig,
+        });
+
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/routes-d/tests/integration/compliance.travelRule.integration.test.ts
+++ b/routes-d/tests/integration/compliance.travelRule.integration.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Integration test for the travel rule data exchange endpoint.
+ *
+ * Exercises the full submit → fetch flow end-to-end:
+ *   1. Submit a travel rule record
+ *   2. Fetch and verify PII is decrypted correctly
+ *   3. Verify idempotent re-submission
+ *   4. Verify unauthorized partner is rejected on both routes
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import travelRuleRouter, { __resetTravelRuleStore } from '../../routes/compliance.travelRule.js';
+import {
+  __registerTestPartner,
+  __unregisterTestPartner,
+  computeSignature,
+  bodyDigest,
+} from '../../auth/mutualAuth.js';
+import { __setTestKey } from '../../lib/crypto.js';
+
+const PARTNER_ID = 'vasp-integration';
+const PARTNER_SECRET = 'integration-secret-12345';
+const KEY_KID = 'intv1';
+const KEY_HEX = '1'.repeat(64);
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(travelRuleRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+function authHeaders(body: object = {}): Record<string, string> {
+  const ts = String(Math.floor(Date.now() / 1000));
+  const digest = bodyDigest(JSON.stringify(body));
+  const sig = computeSignature(PARTNER_ID, ts, digest, PARTNER_SECRET);
+  return {
+    'Content-Type': 'application/json',
+    'x-partner-id': PARTNER_ID,
+    'x-partner-ts': ts,
+    'x-partner-sig': sig,
+  };
+}
+
+function getAuthHeaders(): Record<string, string> {
+  const ts = String(Math.floor(Date.now() / 1000));
+  const digest = bodyDigest('');
+  const sig = computeSignature(PARTNER_ID, ts, digest, PARTNER_SECRET);
+  return {
+    'x-partner-id': PARTNER_ID,
+    'x-partner-ts': ts,
+    'x-partner-sig': sig,
+  };
+}
+
+beforeAll(() => {
+  __registerTestPartner(PARTNER_ID, PARTNER_SECRET);
+  __setTestKey(KEY_KID, KEY_HEX);
+  process.env.TRAVEL_RULE_KEY_ACTIVE = KEY_KID;
+});
+
+afterAll(() => {
+  __unregisterTestPartner(PARTNER_ID);
+  delete process.env.TRAVEL_RULE_KEY_ACTIVE;
+  delete process.env[`TRAVEL_RULE_KEY_${KEY_KID.toUpperCase()}`];
+});
+
+beforeEach(() => {
+  __resetTravelRuleStore();
+});
+
+describe('Travel Rule integration', () => {
+  it('end-to-end: submit then fetch decrypts PII correctly', async () => {
+    const app = buildApp();
+
+    const submitBody = {
+      transferId: 'integration-tx-001',
+      amount: 1_200,
+      asset: 'XLM',
+      originator: {
+        name: 'Carol Originator',
+        accountNumber: 'GCARO000001',
+        address: '100 Blockchain Ave',
+      },
+      beneficiary: {
+        name: 'Dave Beneficiary',
+        accountNumber: 'GDAVE000001',
+      },
+    };
+
+    // 1. Submit
+    const submitRes = await request(app)
+      .post('/compliance/travel-rule/transfers')
+      .set(authHeaders(submitBody))
+      .send(submitBody);
+
+    expect(submitRes.status).toBe(201);
+    expect(submitRes.body.data.transferId).toBe('integration-tx-001');
+    expect(submitRes.body.data.submittedBy).toBe(PARTNER_ID);
+
+    // 2. Fetch – PII must come back as plaintext
+    const fetchRes = await request(app)
+      .get('/compliance/travel-rule/transfers/integration-tx-001')
+      .set(getAuthHeaders());
+
+    expect(fetchRes.status).toBe(200);
+
+    const data = fetchRes.body.data;
+    expect(data.transferId).toBe('integration-tx-001');
+    expect(data.amount).toBe(1_200);
+    expect(data.asset).toBe('XLM');
+    expect(data.originator.name).toBe('Carol Originator');
+    expect(data.originator.accountNumber).toBe('GCARO000001');
+    expect(data.originator.address).toBe('100 Blockchain Ave');
+    expect(data.beneficiary.name).toBe('Dave Beneficiary');
+    expect(data.beneficiary.accountNumber).toBe('GDAVE000001');
+  });
+
+  it('idempotent re-submission returns 200 with duplicate flag', async () => {
+    const app = buildApp();
+    const body = {
+      transferId: 'idem-tx-001',
+      amount: 50,
+      asset: 'USDC',
+      originator: { name: 'Eve', accountNumber: 'GEVE000001' },
+      beneficiary: { name: 'Frank', accountNumber: 'GFRANK001' },
+    };
+
+    await request(app)
+      .post('/compliance/travel-rule/transfers')
+      .set(authHeaders(body))
+      .send(body)
+      .expect(201);
+
+    const res2 = await request(app)
+      .post('/compliance/travel-rule/transfers')
+      .set(authHeaders(body))
+      .send(body);
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.meta.duplicate).toBe(true);
+  });
+
+  it('rejects submit from unregistered partner', async () => {
+    const app = buildApp();
+    const body = {
+      transferId: 'rogue-tx-001',
+      amount: 100,
+      asset: 'USDC',
+      originator: { name: 'Rogue', accountNumber: 'GROGU001' },
+      beneficiary: { name: 'Victim', accountNumber: 'GVICT001' },
+    };
+
+    const ts = String(Math.floor(Date.now() / 1000));
+    const digest = bodyDigest(JSON.stringify(body));
+    const sig = computeSignature('rogue-vasp', ts, digest, 'rogue-secret');
+
+    const res = await request(app)
+      .post('/compliance/travel-rule/transfers')
+      .set({
+        'Content-Type': 'application/json',
+        'x-partner-id': 'rogue-vasp',
+        'x-partner-ts': ts,
+        'x-partner-sig': sig,
+      })
+      .send(body);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('UNKNOWN_PARTNER');
+  });
+
+  it('rejects fetch from unregistered partner', async () => {
+    const app = buildApp();
+
+    // First submit a valid record
+    const body = {
+      transferId: 'rogue-fetch-001',
+      amount: 200,
+      asset: 'USDC',
+      originator: { name: 'Owner', accountNumber: 'GOWN001' },
+      beneficiary: { name: 'Receiver', accountNumber: 'GREC001' },
+    };
+
+    await request(app)
+      .post('/compliance/travel-rule/transfers')
+      .set(authHeaders(body))
+      .send(body)
+      .expect(201);
+
+    // Then try to fetch as an unknown partner
+    const ts = String(Math.floor(Date.now() / 1000));
+    const digest = bodyDigest('');
+    const sig = computeSignature('rogue-vasp', ts, digest, 'any');
+
+    const res = await request(app)
+      .get('/compliance/travel-rule/transfers/rogue-fetch-001')
+      .set({
+        'x-partner-id': 'rogue-vasp',
+        'x-partner-ts': ts,
+        'x-partner-sig': sig,
+      });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/routes-d/tests/unit/crypto.test.ts
+++ b/routes-d/tests/unit/crypto.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for routes-d/lib/crypto.ts
+ */
+
+import {
+  encryptField,
+  decryptField,
+  encryptFields,
+  decryptFields,
+  isEncryptedField,
+  activeKeyId,
+  resolveKey,
+  __setTestKey,
+  type EncryptedField,
+} from '../../lib/crypto.js';
+
+// ── Test fixtures ───────────────────────────────────────────────────────────
+
+const TEST_KID = 'testv1';
+const TEST_HEX_KEY = 'a'.repeat(64); // 32-byte key, all 0xaa
+
+beforeAll(() => {
+  __setTestKey(TEST_KID, TEST_HEX_KEY);
+  process.env.TRAVEL_RULE_KEY_ACTIVE = TEST_KID;
+});
+
+afterAll(() => {
+  delete process.env[`TRAVEL_RULE_KEY_${TEST_KID.toUpperCase()}`];
+  delete process.env.TRAVEL_RULE_KEY_ACTIVE;
+});
+
+// ── activeKeyId ─────────────────────────────────────────────────────────────
+
+describe('activeKeyId', () => {
+  it('returns the value of TRAVEL_RULE_KEY_ACTIVE', () => {
+    expect(activeKeyId()).toBe(TEST_KID);
+  });
+
+  it('defaults to "v1" when env var is unset', () => {
+    const original = process.env.TRAVEL_RULE_KEY_ACTIVE;
+    delete process.env.TRAVEL_RULE_KEY_ACTIVE;
+    expect(activeKeyId()).toBe('v1');
+    process.env.TRAVEL_RULE_KEY_ACTIVE = original;
+  });
+});
+
+// ── resolveKey ──────────────────────────────────────────────────────────────
+
+describe('resolveKey', () => {
+  it('returns a 32-byte Buffer for a known kid', () => {
+    const key = resolveKey(TEST_KID);
+    expect(Buffer.isBuffer(key)).toBe(true);
+    expect(key.length).toBe(32);
+  });
+
+  it('throws when the env var is missing', () => {
+    expect(() => resolveKey('missing-kid')).toThrow(/not found/i);
+  });
+
+  it('throws when the env var is the wrong length', () => {
+    process.env['TRAVEL_RULE_KEY_BADKEY'] = '0'.repeat(32); // only 16 bytes
+    expect(() => resolveKey('badkey')).toThrow(/64-character hex/i);
+    delete process.env['TRAVEL_RULE_KEY_BADKEY'];
+  });
+});
+
+// ── encryptField / decryptField ─────────────────────────────────────────────
+
+describe('encryptField / decryptField', () => {
+  it('round-trips plaintext correctly', () => {
+    const plaintext = 'Alice Wonderland';
+    const encrypted = encryptField(plaintext, TEST_KID);
+    expect(encrypted.kid).toBe(TEST_KID);
+    expect(encrypted.iv).toHaveLength(24);    // 12 bytes → 24 hex chars
+    expect(encrypted.tag).toHaveLength(32);   // 16 bytes → 32 hex chars
+    expect(encrypted.ciphertext).toBeTruthy();
+
+    const decrypted = decryptField(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('produces different ciphertexts for the same plaintext (random IV)', () => {
+    const enc1 = encryptField('same', TEST_KID);
+    const enc2 = encryptField('same', TEST_KID);
+    expect(enc1.iv).not.toBe(enc2.iv);
+    expect(enc1.ciphertext).not.toBe(enc2.ciphertext);
+  });
+
+  it('handles empty string round-trip', () => {
+    const enc = encryptField('', TEST_KID);
+    expect(decryptField(enc)).toBe('');
+  });
+
+  it('handles unicode / emoji round-trip', () => {
+    const text = '日本語テスト 🚀';
+    expect(decryptField(encryptField(text, TEST_KID))).toBe(text);
+  });
+
+  it('throws on tampered ciphertext', () => {
+    const enc = encryptField('sensitive', TEST_KID);
+    const tampered: EncryptedField = {
+      ...enc,
+      ciphertext: 'deadbeef' + enc.ciphertext.slice(8),
+    };
+    expect(() => decryptField(tampered)).toThrow();
+  });
+
+  it('throws on tampered auth tag', () => {
+    const enc = encryptField('sensitive', TEST_KID);
+    const tampered: EncryptedField = {
+      ...enc,
+      tag: 'ff'.repeat(16),
+    };
+    expect(() => decryptField(tampered)).toThrow();
+  });
+
+  it('uses activeKeyId() when no kid is passed', () => {
+    const enc = encryptField('auto-kid');
+    expect(enc.kid).toBe(TEST_KID);
+    expect(decryptField(enc)).toBe('auto-kid');
+  });
+});
+
+// ── isEncryptedField ─────────────────────────────────────────────────────────
+
+describe('isEncryptedField', () => {
+  it('returns true for a valid EncryptedField', () => {
+    const enc = encryptField('test', TEST_KID);
+    expect(isEncryptedField(enc)).toBe(true);
+  });
+
+  it('returns false for a plain string', () => {
+    expect(isEncryptedField('hello')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isEncryptedField(null)).toBe(false);
+  });
+
+  it('returns false for an incomplete object', () => {
+    expect(isEncryptedField({ kid: 'v1', iv: 'abc' })).toBe(false);
+  });
+});
+
+// ── encryptFields / decryptFields ────────────────────────────────────────────
+
+describe('encryptFields / decryptFields', () => {
+  it('encrypts and decrypts specified fields in an object', () => {
+    const record = {
+      id: 'tx-1',
+      name: 'Bob Builder',
+      accountNumber: 'GXXXXXXXXXXXXXXXX',
+      amount: 100,
+    };
+
+    encryptFields(record, ['name', 'accountNumber'], TEST_KID);
+    expect(isEncryptedField(record.name)).toBe(true);
+    expect(isEncryptedField(record.accountNumber)).toBe(true);
+    expect(record.id).toBe('tx-1');         // unchanged
+    expect(record.amount).toBe(100);        // unchanged (not a string)
+
+    decryptFields(record, ['name', 'accountNumber']);
+    expect(record.name).toBe('Bob Builder');
+    expect(record.accountNumber).toBe('GXXXXXXXXXXXXXXXX');
+  });
+
+  it('skips nullish / non-string fields silently', () => {
+    const record: Record<string, unknown> = { name: null, amount: 50 };
+    // Should not throw
+    encryptFields(record, ['name'], TEST_KID);
+    expect(record.name).toBeNull();
+  });
+});

--- a/routes-d/tests/unit/mutualAuth.test.ts
+++ b/routes-d/tests/unit/mutualAuth.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for routes-d/auth/mutualAuth.ts
+ */
+
+import {
+  computeSignature,
+  bodyDigest,
+  safeCompare,
+  resolvePartnerSecret,
+  requirePartner,
+  __registerTestPartner,
+  __unregisterTestPartner,
+} from '../../auth/mutualAuth.js';
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import type { PartnerRequest } from '../../auth/mutualAuth.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PARTNER_ID = 'exchange-test';
+const PARTNER_SECRET = 'super-secret-value-for-tests-only';
+
+beforeEach(() => {
+  __registerTestPartner(PARTNER_ID, PARTNER_SECRET);
+});
+
+afterEach(() => {
+  __unregisterTestPartner(PARTNER_ID);
+});
+
+// ── computeSignature ──────────────────────────────────────────────────────────
+
+describe('computeSignature', () => {
+  it('is deterministic for the same inputs', () => {
+    const sig1 = computeSignature(PARTNER_ID, '1000000', 'aabbcc', PARTNER_SECRET);
+    const sig2 = computeSignature(PARTNER_ID, '1000000', 'aabbcc', PARTNER_SECRET);
+    expect(sig1).toBe(sig2);
+  });
+
+  it('differs when any input changes', () => {
+    const base = computeSignature(PARTNER_ID, '1000000', 'aabbcc', PARTNER_SECRET);
+    const diffPartner = computeSignature('other-exchange', '1000000', 'aabbcc', PARTNER_SECRET);
+    const diffTs = computeSignature(PARTNER_ID, '9999999', 'aabbcc', PARTNER_SECRET);
+    const diffDigest = computeSignature(PARTNER_ID, '1000000', '112233', PARTNER_SECRET);
+    const diffSecret = computeSignature(PARTNER_ID, '1000000', 'aabbcc', 'different-secret');
+
+    expect(base).not.toBe(diffPartner);
+    expect(base).not.toBe(diffTs);
+    expect(base).not.toBe(diffDigest);
+    expect(base).not.toBe(diffSecret);
+  });
+
+  it('returns a 64-character hex string (SHA-256 HMAC)', () => {
+    const sig = computeSignature(PARTNER_ID, '100', 'abc', PARTNER_SECRET);
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── bodyDigest ────────────────────────────────────────────────────────────────
+
+describe('bodyDigest', () => {
+  it('returns a 64-char hex string for any input', () => {
+    expect(bodyDigest('hello')).toMatch(/^[0-9a-f]{64}$/);
+    expect(bodyDigest(Buffer.from('hello'))).toMatch(/^[0-9a-f]{64}$/);
+    expect(bodyDigest('')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is identical for same content as string vs Buffer', () => {
+    const str = bodyDigest('test body');
+    const buf = bodyDigest(Buffer.from('test body', 'utf8'));
+    expect(str).toBe(buf);
+  });
+});
+
+// ── safeCompare ───────────────────────────────────────────────────────────────
+
+describe('safeCompare', () => {
+  it('returns true for identical hex strings', () => {
+    const sig = computeSignature(PARTNER_ID, '1', 'x', PARTNER_SECRET);
+    expect(safeCompare(sig, sig)).toBe(true);
+  });
+
+  it('returns false for different length strings', () => {
+    expect(safeCompare('abc', 'abcd')).toBe(false);
+  });
+
+  it('returns false for different hex strings of same length', () => {
+    const a = 'a'.repeat(64);
+    const b = 'b'.repeat(64);
+    expect(safeCompare(a, b)).toBe(false);
+  });
+});
+
+// ── resolvePartnerSecret ──────────────────────────────────────────────────────
+
+describe('resolvePartnerSecret', () => {
+  it('returns the secret for a registered partner', () => {
+    expect(resolvePartnerSecret(PARTNER_ID)).toBe(PARTNER_SECRET);
+  });
+
+  it('returns undefined for an unknown partner', () => {
+    expect(resolvePartnerSecret('unknown-partner')).toBeUndefined();
+  });
+});
+
+// ── requirePartner middleware (via supertest) ─────────────────────────────────
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.post(
+    '/test',
+    requirePartner as (req: Request, res: Response, next: NextFunction) => void,
+    (req: Request, res: Response) => {
+      res.status(200).json({ partnerId: (req as PartnerRequest).partnerId });
+    },
+  );
+  return app;
+}
+
+/** Builds a valid set of auth headers for a given body at the current time. */
+function validHeaders(body: object = {}): Record<string, string> {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const digest = bodyDigest(JSON.stringify(body));
+  const sig = computeSignature(PARTNER_ID, timestamp, digest, PARTNER_SECRET);
+  return {
+    'x-partner-id': PARTNER_ID,
+    'x-partner-ts': timestamp,
+    'x-partner-sig': sig,
+  };
+}
+
+describe('requirePartner middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  it('accepts a valid partner request and sets req.partnerId', async () => {
+    const body = { foo: 'bar' };
+    const res = await request(app).post('/test').set(validHeaders(body)).send(body);
+    expect(res.status).toBe(200);
+    expect(res.body.partnerId).toBe(PARTNER_ID);
+  });
+
+  it('returns 401 when X-Partner-Id header is missing', async () => {
+    const headers = validHeaders();
+    delete (headers as Record<string, string>)['x-partner-id'];
+    const res = await request(app).post('/test').set(headers);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('MISSING_AUTH_HEADERS');
+  });
+
+  it('returns 401 when X-Partner-Sig header is missing', async () => {
+    const headers = validHeaders();
+    delete (headers as Record<string, string>)['x-partner-sig'];
+    const res = await request(app).post('/test').set(headers);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('MISSING_AUTH_HEADERS');
+  });
+
+  it('returns 401 when X-Partner-Ts header is missing', async () => {
+    const headers = validHeaders();
+    delete (headers as Record<string, string>)['x-partner-ts'];
+    const res = await request(app).post('/test').set(headers);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('MISSING_AUTH_HEADERS');
+  });
+
+  it('returns 401 when timestamp is non-numeric', async () => {
+    const headers = validHeaders();
+    (headers as Record<string, string>)['x-partner-ts'] = 'not-a-number';
+    const res = await request(app).post('/test').set(headers);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_TIMESTAMP');
+  });
+
+  it('returns 401 when timestamp is too old', async () => {
+    const body = {};
+    const oldTs = String(Math.floor(Date.now() / 1000) - 600); // 10 minutes ago
+    const digest = bodyDigest(JSON.stringify(body));
+    const sig = computeSignature(PARTNER_ID, oldTs, digest, PARTNER_SECRET);
+    const res = await request(app)
+      .post('/test')
+      .set({
+        'x-partner-id': PARTNER_ID,
+        'x-partner-ts': oldTs,
+        'x-partner-sig': sig,
+      })
+      .send(body);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('REQUEST_EXPIRED');
+  });
+
+  it('returns 403 when partner id is unknown', async () => {
+    const body = {};
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const digest = bodyDigest(JSON.stringify(body));
+    const sig = computeSignature('unknown-partner', timestamp, digest, PARTNER_SECRET);
+    const res = await request(app)
+      .post('/test')
+      .set({
+        'x-partner-id': 'unknown-partner',
+        'x-partner-ts': timestamp,
+        'x-partner-sig': sig,
+      })
+      .send(body);
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('UNKNOWN_PARTNER');
+  });
+
+  it('returns 401 when signature is wrong', async () => {
+    const headers = validHeaders({ foo: 'bar' });
+    (headers as Record<string, string>)['x-partner-sig'] = 'f'.repeat(64);
+    const res = await request(app).post('/test').set(headers).send({ foo: 'bar' });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_SIGNATURE');
+  });
+});


### PR DESCRIPTION
Closes #390 
- Add routes-d/routes/compliance.travelRule.ts with POST submit and GET fetch handlers for FATF Travel Rule originator/beneficiary data
- Add routes-d/lib/crypto.ts: AES-256-GCM field encryption with key-id (kid) scheme for key rotation support
- Add routes-d/auth/mutualAuth.ts: mutual partner authentication via HMAC-SHA-256 signatures with replay-window enforcement
- Add routes-d/middleware/index.ts: re-exports requirePartner, errorHandler, and asyncHandler for consumers
- Add unit tests (crypto, mutualAuth), route tests, and integration tests under routes-d/tests/ — 54 tests, all passing
- Add routes-d/docs/travel-rule.md documenting the API, key-id scheme, and authentication protocol