### PR TITLE
feat(routes-d): add GET /accounts/:id/profile endpoint

### DIFF
--- a/routes-d/routes/accounts.profile.ts
+++ b/routes-d/routes/accounts.profile.ts
@@ -1,0 +1,105 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type StellarAccountData = {
+  id: string;
+  sequence: string;
+  domain?: string;
+  lastModified: string;
+};
+
+type PublicProfile = {
+  id: string;
+  displayName?: string;
+  domain?: string;
+  sequence: string;
+  lastModified: string;
+};
+
+const onChainAccounts = new Map<string, StellarAccountData>();
+const offChainDisplayNames = new Map<string, string>();
+
+function isValidStellarAccountId(id: string): boolean {
+  return typeof id === "string" && id.length === 56 && id.startsWith("G");
+}
+
+router.get(
+  "/accounts/:id/profile",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+
+      if (!isValidStellarAccountId(id)) {
+        sendError(res, "INVALID_ACCOUNT_ID", "The provided account ID is not a valid Stellar public key", 400);
+        return;
+      }
+
+      const account = onChainAccounts.get(id);
+      if (!account) {
+        sendError(res, "ACCOUNT_NOT_FOUND", "No account found for the provided Stellar account ID", 404);
+        return;
+      }
+
+      const profile: PublicProfile = {
+        id: account.id,
+        sequence: account.sequence,
+        lastModified: account.lastModified,
+      };
+
+      if (account.domain) {
+        profile.domain = account.domain;
+      }
+
+      const displayName = offChainDisplayNames.get(id);
+      if (displayName) {
+        profile.displayName = displayName;
+      }
+
+      return res.status(200).json({ success: true, data: profile });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+const KNOWN_ACCOUNTS: StellarAccountData[] = [
+  {
+    id: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNZ",
+    sequence: "1234567",
+    domain: "example.com",
+    lastModified: "2024-06-01T12:00:00Z",
+  },
+  {
+    id: "GBRP6K5FQ4U3YNC6XKX5XVH6F5GX5X5X5X5X5X5X5X5X5X5X5X5X5X5X",
+    sequence: "8901234",
+    lastModified: "2024-07-15T08:30:00Z",
+  },
+];
+
+for (const account of KNOWN_ACCOUNTS) {
+  onChainAccounts.set(account.id, account);
+}
+
+export function __resetAccounts(): void {
+  onChainAccounts.clear();
+  offChainDisplayNames.clear();
+  for (const account of KNOWN_ACCOUNTS) {
+    onChainAccounts.set(account.id, account);
+  }
+}
+
+export function __seedAccount(account: StellarAccountData): void {
+  onChainAccounts.set(account.id, account);
+}
+
+export function __setDisplayName(accountId: string, displayName: string): void {
+  offChainDisplayNames.set(accountId, displayName);
+}
+
+export function __getOnChainAccounts(): Map<string, StellarAccountData> {
+  return onChainAccounts;
+}
+
+export default router;

--- a/routes-d/tests/accounts.profile.test.ts
+++ b/routes-d/tests/accounts.profile.test.ts
@@ -1,0 +1,130 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import accountsProfileRouter, {
+  __resetAccounts,
+  __seedAccount,
+  __setDisplayName,
+} from "../routes/accounts.profile.js";
+
+const KNOWN_ACCOUNT_ID = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNZ";
+const KNOWN_ACCOUNT_NO_DOMAIN = "GBRP6K5FQ4U3YNC6XKX5XVH6F5GX5X5X5X5X5X5X5X5X5X5X5X5X5X5X";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(accountsProfileRouter);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("GET /accounts/:id/profile", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetAccounts();
+  });
+
+  it("returns public profile for a known account with full on-chain data", async () => {
+    const res = await request(app).get(`/accounts/${KNOWN_ACCOUNT_ID}/profile`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe(KNOWN_ACCOUNT_ID);
+    expect(res.body.data.sequence).toBe("1234567");
+    expect(res.body.data.domain).toBe("example.com");
+    expect(res.body.data.lastModified).toBe("2024-06-01T12:00:00Z");
+  });
+
+  it("includes displayName when off-chain display name is set", async () => {
+    __setDisplayName(KNOWN_ACCOUNT_ID, "Alice");
+
+    const res = await request(app).get(`/accounts/${KNOWN_ACCOUNT_ID}/profile`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.displayName).toBe("Alice");
+  });
+
+  it("omits displayName when off-chain display name is not set", async () => {
+    const res = await request(app).get(`/accounts/${KNOWN_ACCOUNT_ID}/profile`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).not.toHaveProperty("displayName");
+  });
+
+  it("omits domain when not present in on-chain data", async () => {
+    const res = await request(app).get(`/accounts/${KNOWN_ACCOUNT_NO_DOMAIN}/profile`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(KNOWN_ACCOUNT_NO_DOMAIN);
+    expect(res.body.data.sequence).toBe("8901234");
+    expect(res.body.data).not.toHaveProperty("domain");
+  });
+
+  it("returns 400 for an invalid Stellar account ID format", async () => {
+    const res = await request(app).get("/accounts/invalid-id/profile");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_ACCOUNT_ID");
+  });
+
+  it("returns 404 for an unknown account", async () => {
+    const unknownId = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const res = await request(app).get(`/accounts/${unknownId}/profile`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("ACCOUNT_NOT_FOUND");
+  });
+
+  it("returns only explicitly public fields (no internal data)", async () => {
+    const res = await request(app).get(`/accounts/${KNOWN_ACCOUNT_ID}/profile`);
+
+    expect(res.status).toBe(200);
+    const keys = Object.keys(res.body.data);
+    expect(keys).toEqual(expect.arrayContaining(["id", "sequence", "lastModified"]));
+    expect(keys.every((k) =>
+      ["id", "displayName", "domain", "sequence", "lastModified"].includes(k),
+    )).toBe(true);
+  });
+
+  it("supports a custom-seeded account with partial on-chain data", async () => {
+    const customId = "GC3O2R44KE7F6QK5XH5G5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X";
+    __resetAccounts();
+    __seedAccount({
+      id: customId,
+      sequence: "42",
+      lastModified: "2025-01-10T16:00:00Z",
+    });
+
+    const res = await request(app).get(`/accounts/${customId}/profile`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(customId);
+    expect(res.body.data.sequence).toBe("42");
+    expect(res.body.data.lastModified).toBe("2025-01-10T16:00:00Z");
+    expect(res.body.data).not.toHaveProperty("domain");
+    expect(res.body.data).not.toHaveProperty("displayName");
+  });
+
+  it("combines on-chain and off-chain data together", async () => {
+    const customId = "GC3O2R44KE7F6QK5XH5G5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X";
+    __resetAccounts();
+    __seedAccount({
+      id: customId,
+      sequence: "99",
+      domain: "stellar.org",
+      lastModified: "2025-03-20T09:00:00Z",
+    });
+    __setDisplayName(customId, "Bob");
+
+    const res = await request(app).get(`/accounts/${customId}/profile`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(customId);
+    expect(res.body.data.sequence).toBe("99");
+    expect(res.body.data.domain).toBe("stellar.org");
+    expect(res.body.data.displayName).toBe("Bob");
+    expect(res.body.data.lastModified).toBe("2025-03-20T09:00:00Z");
+  });
+});


### PR DESCRIPTION
## Description

Implements issue #383 — a public account profile lookup endpoint in \outes-d/\.

\GET /accounts/:id/profile\ returns on-chain account data (id, sequence, domain, lastModified) combined with off-chain display names. Built with in-memory stores for the prototype, following the same patterns as other \outes-d/\ endpoints.

## Changes

- **\outes-d/routes/accounts.profile.ts\** — new route file with:
  - \GET /accounts/:id/profile\ endpoint
  - Stellar account ID validation (56-char, G-starting)
  - On-chain data store seeded with two known accounts
  - Off-chain display name support
  - Proper 400/404 error responses via \sendError\
  - Test helpers: \__resetAccounts\, \__seedAccount\, \__setDisplayName\, \__getOnChainAccounts\

- **\outes-d/tests/accounts.profile.test.ts\** — 9 test cases:
  - Known account full data
  - displayName inclusion
  - displayName omission
  - domain omission
  - Invalid ID (400)
  - Unknown account (404)
  - Public field exposure only
  - Custom-seeded partial account
  - Combined on-chain + off-chain data

## Testing

All 9 tests pass:
\\\
PASS routes-d/tests/accounts.profile.test.ts
  GET /accounts/:id/profile
    ✓ returns public profile for a known account with full on-chain data
    ✓ includes displayName when off-chain display name is set
    ✓ omits displayName when off-chain display name is not set
    ✓ omits domain when not present in on-chain data
    ✓ returns 400 for an invalid Stellar account ID format
    ✓ returns 404 for an unknown account
    ✓ returns only explicitly public fields (no internal data)
    ✓ supports a custom-seeded account with partial on-chain data
    ✓ combines on-chain and off-chain data together
\\\

## Related

Closes #383