### PR TITLE
added unit tests for interactive prompt module

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -12,6 +12,7 @@ export default {
   },
   moduleNameMapper: {
     '^\\.\\./contexts$': '<rootDir>/src/mocks/wallet-contexts-mock.ts',
+    '^@clack/prompts$': '<rootDir>/tests/mocks/clack-prompts.js',
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -181,12 +181,24 @@ export async function runInteractivePrompts(
 
   outro(pc.dim(`Creating ${projectName}...`));
 
-  return {
-    projectName,
-    horizonUrl,
-    sorobanUrl,
-    wallets,
-    packageManager,
-    skipInstall,
-  };
+  const result: PromptResult = { projectName };
+
+  if (!ctx.networkFlagProvided) {
+    result.horizonUrl = horizonUrl;
+    result.sorobanUrl = sorobanUrl;
+  }
+
+  if (!ctx.walletsFlagProvided) {
+    result.wallets = wallets;
+  }
+
+  if (!ctx.packageManagerFlagProvided) {
+    result.packageManager = packageManager;
+  }
+
+  if (!ctx.skipInstallFlagProvided) {
+    result.skipInstall = skipInstall;
+  }
+
+  return result;
 }

--- a/tests/mocks/clack-prompts.js
+++ b/tests/mocks/clack-prompts.js
@@ -1,0 +1,19 @@
+import { jest } from "@jest/globals";
+
+export const intro = jest.fn();
+export const text = jest.fn();
+export const isCancel = jest.fn();
+export const select = jest.fn();
+export const multiselect = jest.fn();
+export const confirm = jest.fn();
+export const outro = jest.fn();
+
+export default {
+  intro,
+  text,
+  isCancel,
+  select,
+  multiselect,
+  confirm,
+  outro,
+};

--- a/tests/mocks/picocolors.js
+++ b/tests/mocks/picocolors.js
@@ -1,0 +1,3 @@
+export const bold = (value) => value;
+export const dim = (value) => value;
+export default { bold, dim };

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.unstable_mockModule("@clack/prompts", () => ({
+  __esModule: true,
+  default: {
+    intro: jest.fn(),
+    text: jest.fn(),
+    isCancel: jest.fn(),
+    select: jest.fn(),
+    multiselect: jest.fn(),
+    confirm: jest.fn(),
+    outro: jest.fn(),
+  },
+  intro: jest.fn(),
+  text: jest.fn(),
+  isCancel: jest.fn(),
+  select: jest.fn(),
+  multiselect: jest.fn(),
+  confirm: jest.fn(),
+  outro: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/lib/install.js", () => ({
+  detectPackageManager: jest.fn(),
+}));
+
+const {
+  confirm,
+  intro,
+  isCancel,
+  multiselect,
+  outro,
+  select,
+  text,
+} = await import("@clack/prompts");
+const { detectPackageManager } = await import("../src/lib/install.js");
+const { runInteractivePrompts } = await import("../src/lib/prompts.js");
+
+type PromptContext = Parameters<typeof runInteractivePrompts>[0];
+
+const mockedText = text as unknown as jest.Mock;
+const mockedSelect = select as unknown as jest.Mock;
+const mockedMultiselect = multiselect as unknown as jest.Mock;
+const mockedConfirm = confirm as unknown as jest.Mock;
+const mockedIsCancel = isCancel as unknown as jest.Mock;
+const mockedIntro = intro as unknown as jest.Mock;
+const mockedOutro = outro as unknown as jest.Mock;
+const mockedDetectPackageManager = detectPackageManager as unknown as jest.Mock;
+
+function buildContext(overrides: Partial<PromptContext> = {}): PromptContext {
+  return {
+    initialProjectName: "my-app",
+    cwd: "/tmp",
+    defaultWallets: ["freighter"],
+    packageManagerFromFlag: undefined,
+    networkFlagProvided: false,
+    walletsFlagProvided: false,
+    packageManagerFlagProvided: false,
+    skipInstallFlagProvided: false,
+    ...overrides,
+  };
+}
+
+describe("runInteractivePrompts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedText.mockResolvedValue("my-app");
+    mockedSelect.mockImplementation((options: { message?: string }) => {
+      if (options?.message === "Package manager") {
+        return Promise.resolve("npm");
+      }
+      return Promise.resolve("testnet");
+    });
+    mockedMultiselect.mockResolvedValue(["freighter"]);
+    mockedConfirm.mockResolvedValue(true);
+    mockedIsCancel.mockReturnValue(false);
+    mockedDetectPackageManager.mockReturnValue("npm");
+  });
+
+  it("skips the network prompt when the network flags are provided", async () => {
+    const result = await runInteractivePrompts(
+      buildContext({ networkFlagProvided: true })
+    );
+
+    const messages = mockedSelect.mock.calls.map(([options]) => options.message);
+    expect(messages).toContain("Package manager");
+    expect(messages).not.toContain("Which Stellar network?");
+    expect(result).toEqual({
+      projectName: "my-app",
+      wallets: ["freighter"],
+      packageManager: "npm",
+      skipInstall: false,
+    });
+  });
+
+  it("skips the wallet prompt when the wallets flag is provided", async () => {
+    const result = await runInteractivePrompts(
+      buildContext({ walletsFlagProvided: true })
+    );
+
+    expect(mockedMultiselect).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      projectName: "my-app",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      sorobanUrl: "https://soroban-testnet.stellar.org",
+      packageManager: "npm",
+      skipInstall: false,
+    });
+  });
+
+  it("skips the package manager prompt when the package manager flag is provided", async () => {
+    const result = await runInteractivePrompts(
+      buildContext({ packageManagerFlagProvided: true })
+    );
+
+    const messages = mockedSelect.mock.calls.map(([options]) => options.message);
+    expect(messages).toContain("Which Stellar network?");
+    expect(messages).not.toContain("Package manager");
+    expect(result).toEqual({
+      projectName: "my-app",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      sorobanUrl: "https://soroban-testnet.stellar.org",
+      wallets: ["freighter"],
+      skipInstall: false,
+    });
+  });
+
+  it("skips the install prompt when the skip install flag is provided", async () => {
+    const result = await runInteractivePrompts(
+      buildContext({ skipInstallFlagProvided: true })
+    );
+
+    expect(mockedConfirm).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      projectName: "my-app",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      sorobanUrl: "https://soroban-testnet.stellar.org",
+      wallets: ["freighter"],
+      packageManager: "npm",
+    });
+  });
+
+  it("returns null for cancellations so the CLI exits without scaffolding", async () => {
+    mockedIsCancel.mockReturnValueOnce(true);
+
+    const result = await runInteractivePrompts(buildContext());
+
+    expect(result).toBeNull();
+    expect(mockedOutro).toHaveBeenCalled();
+    expect(mockedSelect).not.toHaveBeenCalled();
+    expect(mockedMultiselect).not.toHaveBeenCalled();
+    expect(mockedConfirm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Close #643 


## Summary

This PR adds unit tests for the interactive prompt flow in prompts.ts and tightens the prompt result shape so it only includes fields that were actually prompted for.

## What changed

- Added new tests in prompts.test.ts covering:
  - skipping prompts when the corresponding flags are provided
  - cancellation returning a value that exits cleanly without scaffolding
  - the returned result containing only the prompted-for fields alongside projectName
- Updated prompts.ts to avoid returning undefined placeholder fields when a prompt is skipped.
- Added lightweight Jest module stubs in jest.config.mjs, clack-prompts.js, and picocolors.js so the suite runs without real TTY interaction.

## Testing

Verified with:

```bash
NODE_OPTIONS='--experimental-vm-modules --no-warnings' npx jest --runTestsByPath tests/prompts.test.ts --runInBand --config jest.config.mjs
```

Result:
- 1/1 test suite passed
- 5/5 tests passed