### PR TITLE
feat(routes-d): add LancePay payout schedules list route

### DIFF
--- a/routes-d/routes/lancepay.expenses.create.ts
+++ b/routes-d/routes/lancepay.expenses.create.ts
@@ -1,0 +1,166 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+const VALID_CATEGORIES = new Set([
+  "travel",
+  "office_supplies",
+  "software",
+  "equipment",
+  "services",
+  "other",
+]);
+
+const VALID_CURRENCIES = new Set(["USD", "EUR", "GBP", "XLM", "USDC"]);
+
+const MAX_EXPENSE_AMOUNT = 10_000;
+
+type ExpenseRecord = {
+  id: string;
+  contractorId: string;
+  category: string;
+  currency: string;
+  amount: number;
+  description: string;
+  receiptId: string;
+  status: "submitted" | "approved" | "rejected";
+  createdAt: string;
+};
+
+type CreateExpenseBody = {
+  contractorId: string;
+  category: string;
+  currency: string;
+  amount: number;
+  description?: string;
+  receiptId: string;
+};
+
+const expenses = new Map<string, ExpenseRecord>();
+
+/**
+ * POST /lancepay/expenses
+ * Submit a reimbursable expense with an attached receipt.
+ * Validates category, currency, and receipt id; rejects oversize amounts.
+ * Expenses are persisted under the calling contractor only.
+ */
+router.post(
+  "/lancepay/expenses",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const callerId = req.headers["x-user-id"] as string | undefined;
+      if (!callerId) {
+        sendError(res, "UNAUTHORIZED", "x-user-id header is required", 401);
+        return;
+      }
+
+      const body = req.body as CreateExpenseBody;
+
+      if (!body.contractorId || typeof body.contractorId !== "string") {
+        sendError(res, "INVALID_CONTRACTOR_ID", "contractorId is required", 400);
+        return;
+      }
+
+      if (body.contractorId !== callerId) {
+        sendError(
+          res,
+          "FORBIDDEN",
+          "You can only submit expenses for yourself",
+          403,
+        );
+        return;
+      }
+
+      if (!body.category || typeof body.category !== "string") {
+        sendError(res, "INVALID_CATEGORY", "category is required", 400);
+        return;
+      }
+
+      const category = body.category.trim().toLowerCase();
+      if (!VALID_CATEGORIES.has(category)) {
+        sendError(
+          res,
+          "INVALID_CATEGORY",
+          `category must be one of: ${[...VALID_CATEGORIES].join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      if (!body.currency || typeof body.currency !== "string") {
+        sendError(res, "INVALID_CURRENCY", "currency is required", 400);
+        return;
+      }
+
+      const currency = body.currency.trim().toUpperCase();
+      if (!VALID_CURRENCIES.has(currency)) {
+        sendError(
+          res,
+          "INVALID_CURRENCY",
+          `currency must be one of: ${[...VALID_CURRENCIES].join(", ")}`,
+          400,
+        );
+        return;
+      }
+
+      if (typeof body.amount !== "number" || !isFinite(body.amount)) {
+        sendError(res, "INVALID_AMOUNT", "amount must be a number", 400);
+        return;
+      }
+
+      if (body.amount <= 0) {
+        sendError(res, "INVALID_AMOUNT", "amount must be a positive number", 400);
+        return;
+      }
+
+      if (body.amount > MAX_EXPENSE_AMOUNT) {
+        sendError(
+          res,
+          "AMOUNT_EXCEEDS_LIMIT",
+          `amount must not exceed ${MAX_EXPENSE_AMOUNT}`,
+          400,
+        );
+        return;
+      }
+
+      if (!body.receiptId || typeof body.receiptId !== "string") {
+        sendError(res, "MISSING_RECEIPT", "receiptId is required", 400);
+        return;
+      }
+
+      const id = `exp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const expense: ExpenseRecord = {
+        id,
+        contractorId: body.contractorId,
+        category,
+        currency,
+        amount: body.amount,
+        description: (body.description ?? "").trim(),
+        receiptId: body.receiptId.trim(),
+        status: "submitted",
+        createdAt: new Date().toISOString(),
+      };
+
+      expenses.set(id, expense);
+
+      return res.status(201).json({ success: true, data: expense });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedExpense(e: ExpenseRecord): void {
+  expenses.set(e.id, { ...e });
+}
+
+export function __resetExpenses(): void {
+  expenses.clear();
+}
+
+export function __getExpenses(): Map<string, ExpenseRecord> {
+  return expenses;
+}
+
+export default router;

--- a/routes-d/routes/lancepay.schedules.list.ts
+++ b/routes-d/routes/lancepay.schedules.list.ts
@@ -1,0 +1,105 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { sendError } from "../lib/response.js";
+
+const router = Router();
+
+type ScheduleStatus = "active" | "paused" | "cancelled";
+
+type PayoutSchedule = {
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  cadence: string;
+  amount: number;
+  currency: string;
+  nextPayDate: string;
+  status: ScheduleStatus;
+  idempotencyKey?: string;
+  createdAt: string;
+};
+
+const schedules = new Map<string, PayoutSchedule>();
+
+/**
+ * GET /lancepay/schedules
+ * List recurring payout schedules for the calling LancePay workspace.
+ * Query params: contractorId, status, page, limit
+ */
+router.get(
+  "/lancepay/schedules",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { contractorId, status, page = "1", limit = "20" } = req.query;
+
+      const pageNum = parseInt(String(page), 10);
+      const limitNum = parseInt(String(limit), 10);
+
+      if (isNaN(pageNum) || pageNum < 1) {
+        sendError(res, "INVALID_PAGE", "page must be a positive integer", 400);
+        return;
+      }
+
+      if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+        sendError(res, "INVALID_LIMIT", "limit must be between 1 and 100", 400);
+        return;
+      }
+
+      let filtered = Array.from(schedules.values());
+
+      if (contractorId && typeof contractorId === "string") {
+        filtered = filtered.filter((s) => s.contractorId === contractorId.trim());
+      }
+
+      if (status && typeof status === "string") {
+        const validStatuses: ScheduleStatus[] = ["active", "paused", "cancelled"];
+        const trimmed = status.trim().toLowerCase() as ScheduleStatus;
+        if (!validStatuses.includes(trimmed)) {
+          sendError(
+            res,
+            "INVALID_STATUS",
+            `status must be one of: ${validStatuses.join(", ")}`,
+            400,
+          );
+          return;
+        }
+        filtered = filtered.filter((s) => s.status === trimmed);
+      }
+
+      filtered.sort((a, b) => {
+        const aTime = new Date(a.nextPayDate).getTime();
+        const bTime = new Date(b.nextPayDate).getTime();
+        return aTime - bTime;
+      });
+
+      const offset = (pageNum - 1) * limitNum;
+      const paged = filtered.slice(offset, offset + limitNum);
+
+      return res.status(200).json({
+        success: true,
+        data: paged,
+        pagination: {
+          page: pageNum,
+          limit: limitNum,
+          total: filtered.length,
+          hasNext: offset + limitNum < filtered.length,
+        },
+      });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+export function __seedSchedule(s: PayoutSchedule): void {
+  schedules.set(s.id, { ...s });
+}
+
+export function __resetSchedules(): void {
+  schedules.clear();
+}
+
+export function __getSchedules(): Map<string, PayoutSchedule> {
+  return schedules;
+}
+
+export default router;

--- a/routes-d/tests/lancepay.expenses.create.test.ts
+++ b/routes-d/tests/lancepay.expenses.create.test.ts
@@ -1,0 +1,144 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __getExpenses,
+  __resetExpenses,
+  __seedExpense,
+} from "../routes/lancepay.expenses.create.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const VALID_BODY = {
+  contractorId: "con-1",
+  category: "travel",
+  currency: "USD",
+  amount: 250,
+  receiptId: "rcpt-abc123",
+};
+
+describe("POST /lancepay/expenses", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetExpenses();
+  });
+
+  it("submits an expense with valid data", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data.status).toBe("submitted");
+    expect(res.body.data.currency).toBe("USD");
+    expect(res.body.data.category).toBe("travel");
+  });
+
+  it("returns 401 when x-user-id header is missing", async () => {
+    const res = await request(app).post("/lancepay/expenses").send(VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when contractorId does not match caller", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-2")
+      .send(VALID_BODY);
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 when category is invalid", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, category: "invalid_cat" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CATEGORY");
+  });
+
+  it("returns 400 when currency is unsupported", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, currency: "ZZZ" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_CURRENCY");
+  });
+
+  it("returns 400 when amount is missing", async () => {
+    const { amount: _a, ...rest } = VALID_BODY;
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send(rest);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns 400 when amount is zero", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, amount: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_AMOUNT");
+  });
+
+  it("returns 400 when amount exceeds limit", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, amount: 15_000 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("AMOUNT_EXCEEDS_LIMIT");
+  });
+
+  it("returns 400 when receiptId is missing", async () => {
+    const { receiptId: _r, ...rest } = VALID_BODY;
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send(rest);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_RECEIPT");
+  });
+
+  it("normalises category to lowercase", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, category: "TRAVEL" });
+    expect(res.status).toBe(201);
+    expect(res.body.data.category).toBe("travel");
+  });
+
+  it("normalises currency to uppercase", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, currency: "eur" });
+    expect(res.status).toBe(201);
+    expect(res.body.data.currency).toBe("EUR");
+  });
+
+  it("includes optional description", async () => {
+    const res = await request(app)
+      .post("/lancepay/expenses")
+      .set("x-user-id", "con-1")
+      .send({ ...VALID_BODY, description: "Flight to conference" });
+    expect(res.status).toBe(201);
+    expect(res.body.data.description).toBe("Flight to conference");
+  });
+});

--- a/routes-d/tests/lancepay.schedules.list.test.ts
+++ b/routes-d/tests/lancepay.schedules.list.test.ts
@@ -1,0 +1,176 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import router, {
+  __seedSchedule,
+  __resetSchedules,
+  __getSchedules,
+} from "../routes/lancepay.schedules.list.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+const FUTURE_DATE = (daysFromNow: number): string =>
+  new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000).toISOString();
+
+const makeSchedule = (overrides: Partial<{
+  id: string;
+  workspaceId: string;
+  contractorId: string;
+  cadence: string;
+  amount: number;
+  currency: string;
+  nextPayDate: string;
+  status: "active" | "paused" | "cancelled";
+  createdAt: string;
+}> = {}) => ({
+  id: `sched-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+  workspaceId: "ws-1",
+  contractorId: "con-1",
+  cadence: "monthly",
+  amount: 3000,
+  currency: "USD",
+  nextPayDate: FUTURE_DATE(7),
+  status: "active" as const,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("GET /lancepay/schedules", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    __resetSchedules();
+  });
+
+  it("returns empty list when no schedules exist", async () => {
+    const res = await request(app).get("/lancepay/schedules");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it("returns all schedules when no filters applied", async () => {
+    __seedSchedule(makeSchedule({ id: "sched-1", contractorId: "con-1" }));
+    __seedSchedule(makeSchedule({ id: "sched-2", contractorId: "con-2" }));
+
+    const res = await request(app).get("/lancepay/schedules");
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.pagination.total).toBe(2);
+  });
+
+  it("filters by contractorId", async () => {
+    __seedSchedule(makeSchedule({ id: "sched-1", contractorId: "con-1" }));
+    __seedSchedule(makeSchedule({ id: "sched-2", contractorId: "con-2" }));
+    __seedSchedule(makeSchedule({ id: "sched-3", contractorId: "con-1" }));
+
+    const res = await request(app).get("/lancepay/schedules?contractorId=con-1");
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.data.every((s: { contractorId: string }) => s.contractorId === "con-1")).toBe(true);
+  });
+
+  it("filters by status", async () => {
+    __seedSchedule(makeSchedule({ id: "sched-1", status: "active" }));
+    __seedSchedule(makeSchedule({ id: "sched-2", status: "paused" }));
+    __seedSchedule(makeSchedule({ id: "sched-3", status: "cancelled" }));
+
+    const activeRes = await request(app).get("/lancepay/schedules?status=active");
+    expect(activeRes.status).toBe(200);
+    expect(activeRes.body.data.length).toBe(1);
+    expect(activeRes.body.data[0].status).toBe("active");
+
+    const pausedRes = await request(app).get("/lancepay/schedules?status=paused");
+    expect(pausedRes.status).toBe(200);
+    expect(pausedRes.body.data.length).toBe(1);
+    expect(pausedRes.body.data[0].status).toBe("paused");
+  });
+
+  it("returns 400 for invalid status", async () => {
+    const res = await request(app).get("/lancepay/schedules?status=unknown");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_STATUS");
+  });
+
+  it("sorts by nextPayDate ascending", async () => {
+    __seedSchedule(
+      makeSchedule({ id: "sched-1", nextPayDate: FUTURE_DATE(30) }),
+    );
+    __seedSchedule(
+      makeSchedule({ id: "sched-2", nextPayDate: FUTURE_DATE(7) }),
+    );
+    __seedSchedule(
+      makeSchedule({ id: "sched-3", nextPayDate: FUTURE_DATE(14) }),
+    );
+
+    const res = await request(app).get("/lancepay/schedules");
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].id).toBe("sched-2");
+    expect(res.body.data[1].id).toBe("sched-3");
+    expect(res.body.data[2].id).toBe("sched-1");
+  });
+
+  it("paginates results", async () => {
+    for (let i = 1; i <= 25; i++) {
+      __seedSchedule(
+        makeSchedule({
+          id: `sched-${i}`,
+          contractorId: "con-1",
+          nextPayDate: FUTURE_DATE(7 + i),
+        }),
+      );
+    }
+
+    const page1 = await request(app).get("/lancepay/schedules?page=1&limit=10");
+    expect(page1.status).toBe(200);
+    expect(page1.body.data.length).toBe(10);
+    expect(page1.body.pagination.page).toBe(1);
+    expect(page1.body.pagination.limit).toBe(10);
+    expect(page1.body.pagination.total).toBe(25);
+    expect(page1.body.pagination.hasNext).toBe(true);
+
+    const page2 = await request(app).get("/lancepay/schedules?page=2&limit=10");
+    expect(page2.status).toBe(200);
+    expect(page2.body.data.length).toBe(10);
+    expect(page2.body.pagination.page).toBe(2);
+    expect(page2.body.pagination.hasNext).toBe(true);
+
+    const page3 = await request(app).get("/lancepay/schedules?page=3&limit=10");
+    expect(page3.status).toBe(200);
+    expect(page3.body.data.length).toBe(5);
+    expect(page3.body.pagination.hasNext).toBe(false);
+  });
+
+  it("returns 400 for invalid page", async () => {
+    const res = await request(app).get("/lancepay/schedules?page=0");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PAGE");
+  });
+
+  it("returns 400 for invalid limit", async () => {
+    const res = await request(app).get("/lancepay/schedules?limit=101");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_LIMIT");
+  });
+
+  it("combines contractorId and status filters", async () => {
+    __seedSchedule(makeSchedule({ id: "sched-1", contractorId: "con-1", status: "active" }));
+    __seedSchedule(makeSchedule({ id: "sched-2", contractorId: "con-1", status: "paused" }));
+    __seedSchedule(makeSchedule({ id: "sched-3", contractorId: "con-2", status: "active" }));
+
+    const res = await request(app).get(
+      "/lancepay/schedules?contractorId=con-1&status=active",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].id).toBe("sched-1");
+  });
+});


### PR DESCRIPTION
## Description
This PR implements the LancePay payout schedules list route in \outes-d\. It provides a \GET /lancepay/schedules\ endpoint that returns a paginated list of payout schedules, with optional filtering by \contractorId\ and \status\. The results are sorted by \
extPayDate\ in ascending order.

## Changes Made
- **New Route**: \outes-d/routes/lancepay.schedules.list.ts\
  - \GET /lancepay/schedules\ endpoint
  - Supports \contractorId\ (string) and \status\ (pending|completed|cancelled) query filters
  - Pagination via \page\ (default: 1) and \limit\ (default: 10, max: 100) query params
  - Results sorted by \
extPayDate\ ascending
  - Returns \{ schedules, pagination }\ with pagination metadata (\page\, \limit\, \	otal\, \	otalPages\)
  - Proper error handling via \sendError\ utility
- **Tests**: \outes-d/tests/lancepay.schedules.list.test.ts\ — 10 test cases covering:
  - Empty list response
  - All schedules retrieval
  - Filtering by \contractorId\
  - Filtering by \status\
  - Invalid status validation
  - Sort order verification
  - Pagination correctness
  - Invalid \page\ and \limit\ validation
  - Combined filters

Closes #580