### PR TITLE
test(doctor): mocked tool-check tests; fix(cli): keep project dir + network hints on install failure

### DIFF
--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -30,13 +30,35 @@ function satisfiesMinVersion(v: string, minMajor: number) {
   return major >= minMajor;
 }
 
-async function runCommand(cmd: string, timeout = 5000) {
+export type CommandRunner = (
+  cmd: string,
+  timeout?: number,
+) => Promise<{ ok: boolean; out: string }>;
+
+async function defaultCommandRunner(cmd: string, timeout = 5000) {
   try {
     const { stdout } = await exec(cmd, { timeout });
     return { ok: true, out: stdout.trim() };
   } catch (err: any) {
     return { ok: false, out: String(err?.message || err) };
   }
+}
+
+let commandRunner: CommandRunner = defaultCommandRunner;
+
+/**
+ * Test-only seam (#639): substitutes the runner every tool check (node,
+ * npm, yarn, pnpm, git, rustc, stellar CLI, wasm32 target) goes through,
+ * so tests can force each check to pass/fail deterministically without
+ * spawning a real subprocess. Pass `undefined` to restore the real,
+ * subprocess-spawning runner.
+ */
+export function setCommandRunnerForTest(runner: CommandRunner | undefined): void {
+  commandRunner = runner ?? defaultCommandRunner;
+}
+
+async function runCommand(cmd: string, timeout = 5000) {
+  return commandRunner(cmd, timeout);
 }
 
 async function checkNode(): Promise<CheckResult> {
@@ -210,8 +232,20 @@ async function checkSoroban(): Promise<CheckResult> {
   }
 }
 
+let freeMemoryProvider: () => number = () => os.freemem();
+
+/**
+ * Test-only seam (#639): the disk/RAM check reads real free memory, which
+ * makes its result depend on whatever else is running on the machine at
+ * test time — flaky in exactly the same way an unmocked subprocess call
+ * would be. Pass `undefined` to restore the real os.freemem()-based check.
+ */
+export function setFreeMemoryProviderForTest(provider: (() => number) | undefined): void {
+  freeMemoryProvider = provider ?? (() => os.freemem());
+}
+
 async function checkDisk(): Promise<CheckResult> {
-  const free = os.freemem();
+  const free = freeMemoryProvider();
   const ok = free > 1_000_000_000; // > 1GB
   return {
     id: "disk",

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -71,6 +71,43 @@ export function getInstallCommand(
 }
 
 /**
+ * Common network/registry failure signatures worth calling out explicitly
+ * rather than leaving the user to decode a raw npm/yarn/pnpm stack trace
+ * (#673). Matched against the install error's message.
+ */
+const NETWORK_ERROR_HINTS: Array<{ pattern: RegExp; hint: string }> = [
+  {
+    pattern: /ENOTFOUND/,
+    hint: "DNS lookup failed — check your internet connection, or that the configured registry URL is correct.",
+  },
+  {
+    pattern: /ETIMEDOUT/,
+    hint: "The request timed out — check your internet connection, or try again on a more stable network.",
+  },
+  {
+    pattern: /EAI_AGAIN/,
+    hint: "Temporary DNS resolution failure — check your internet connection and try again.",
+  },
+  {
+    pattern: /\b403\b|Forbidden/,
+    hint: "Received a 403 Forbidden from the registry — check your registry authentication, or that you're not behind a proxy blocking the request.",
+  },
+  {
+    pattern: /proxy/i,
+    hint: "A proxy may be interfering with the request — check your package manager's proxy configuration (e.g. `npm config get proxy`).",
+  },
+];
+
+/**
+ * Returns a targeted, human hint for a known network/registry failure
+ * pattern in `errorMessage`, or undefined if nothing matched.
+ */
+export function networkErrorHint(errorMessage: string | undefined): string | undefined {
+  if (!errorMessage) return undefined;
+  return NETWORK_ERROR_HINTS.find(({ pattern }) => pattern.test(errorMessage))?.hint;
+}
+
+/**
  * Runs package manager installation in the specified directory
  * Streams output to console and handles errors gracefully
  */
@@ -124,6 +161,11 @@ export async function runInstall(
     console.error("\n🔧 To resolve this issue:");
     console.error(`   cd ${path.basename(cwd)}`);
     console.error(`   ${command} ${args.join(" ")}`);
+
+    const hint = networkErrorHint(errorMessage);
+    if (hint) {
+      console.error(`\n💡 ${hint}`);
+    }
 
     if (logPath) {
       console.error(

--- a/src/lib/scaffold.ts
+++ b/src/lib/scaffold.ts
@@ -112,6 +112,13 @@ export async function scaffold(options: ScaffoldOptions) {
     await fs.remove(targetDir);
   }
 
+  // Tracks whether fs.copy completed, so the catch block below only wipes
+  // targetDir for failures before/during that copy (#673) — once files are
+  // scaffolded, a later install failure must never delete them, or "run
+  // install manually" (the error message we give the user) becomes
+  // impossible: there'd be nothing left to install into.
+  let filesScaffolded = false;
+
   try {
     await fs.copy(templateDir, targetDir, {
       filter: (src) => {
@@ -120,6 +127,7 @@ export async function scaffold(options: ScaffoldOptions) {
       },
       preserveTimestamps: true,
     });
+    filesScaffolded = true;
 
     if (withContracts) {
       const contractsTemplateDir = path.join(
@@ -232,8 +240,16 @@ export async function scaffold(options: ScaffoldOptions) {
     });
 
     if (!result.success && !skipInstall) {
+      // Files are already on disk at this point (filesScaffolded is true) —
+      // tell the user exactly what to run rather than the old generic
+      // message, which was misleading anyway: the catch block used to
+      // delete targetDir right after this throw, making "run install
+      // manually" impossible (#673).
       throw new Error(
-        `Dependency installation failed. Please run "${result.packageManager} install" manually in "${appName}".`,
+        `Dependency installation failed, but your project files were created.\n` +
+          `Finish setup by running:\n\n` +
+          `  cd ${appName}\n` +
+          `  ${result.packageManager} install\n`,
       );
     }
 
@@ -254,7 +270,11 @@ export async function scaffold(options: ScaffoldOptions) {
       { noTelemetryFlag: telemetryEnabled === false },
     );
   } catch (error) {
-    if (await fs.pathExists(targetDir)) {
+    // Only clean up when scaffolding didn't get far enough to leave a
+    // usable project behind (#673) — a copy-phase failure leaves nothing
+    // worth keeping, but an install-only failure leaves real, valuable
+    // work that the user was just told how to finish setting up.
+    if (!filesScaffolded && (await fs.pathExists(targetDir))) {
       console.log(pc.yellow(`Cleaning up incomplete project directory "${appName}"...`));
       await fs.remove(targetDir);
     }

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,216 @@
+import { jest } from '@jest/globals';
+import {
+  runDoctor,
+  setCommandRunnerForTest,
+  setFreeMemoryProviderForTest,
+  type CommandRunner,
+} from '../src/lib/doctor.js';
+
+// Every check runDoctor() runs concurrently, keyed by the exact command
+// string each check invokes (see src/lib/doctor.ts). Defaults simulate a
+// fully healthy toolchain; individual tests override just the command(s)
+// they care about via `withRunner`.
+const HEALTHY: Record<string, { ok: boolean; out: string }> = {
+  'node --version': { ok: true, out: 'v20.10.0' },
+  'npm --version': { ok: true, out: '10.2.3' },
+  'yarn --version': { ok: true, out: '1.22.19' },
+  'pnpm --version': { ok: true, out: '8.10.0' },
+  'git --version': { ok: true, out: 'git version 2.42.0' },
+  'rustc --version': { ok: true, out: 'rustc 1.73.0' },
+  'stellar --version': { ok: true, out: 'stellar-cli 20.0.0' },
+  'rustup target list --installed': { ok: true, out: 'wasm32-unknown-unknown\nx86_64-apple-darwin' },
+};
+
+function withRunner(overrides: Record<string, { ok: boolean; out: string }> = {}): CommandRunner {
+  const table = { ...HEALTHY, ...overrides };
+  return async (cmd: string) => table[cmd] ?? { ok: false, out: 'command not found' };
+}
+
+describe('doctor', () => {
+  const originalFetch = global.fetch;
+  const originalLog = console.log;
+
+  beforeEach(() => {
+    // checkHorizon/checkSoroban use fetch directly; mocking their specific
+    // behavior is out of scope here (split into a separate testing issue —
+    // see doctor.ts's checkHorizon/checkSoroban), but a real network call
+    // must never happen during this test run regardless, so this stub
+    // always resolves ok.
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as unknown as typeof fetch;
+    // checkDisk reads real free memory otherwise, which makes it depend on
+    // whatever else is running on the test machine — default to a healthy
+    // 4GB so exit-code tests aren't at the mercy of real memory pressure.
+    setFreeMemoryProviderForTest(() => 4_000_000_000);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    console.log = originalLog;
+    setCommandRunnerForTest(undefined);
+    setFreeMemoryProviderForTest(undefined);
+  });
+
+  describe('exit-code semantics', () => {
+    it('returns 0 when every required check passes, even if an optional check fails', async () => {
+      setCommandRunnerForTest(withRunner({ 'yarn --version': { ok: false, out: 'not found' } }));
+      console.log = jest.fn();
+
+      const code = await runDoctor();
+
+      expect(code).toBe(0);
+    });
+
+    it('returns 1 when a required check fails', async () => {
+      setCommandRunnerForTest(withRunner({ 'git --version': { ok: false, out: 'not found' } }));
+      console.log = jest.fn();
+
+      const code = await runDoctor();
+
+      expect(code).toBe(1);
+    });
+
+    it('returns 1 when multiple required checks fail', async () => {
+      setCommandRunnerForTest(
+        withRunner({
+          'git --version': { ok: false, out: 'not found' },
+          'npm --version': { ok: false, out: 'not found' },
+        }),
+      );
+      console.log = jest.fn();
+
+      const code = await runDoctor();
+
+      expect(code).toBe(1);
+    });
+
+    it('returns 0 when only optional checks fail (rust toolchain entirely absent)', async () => {
+      setCommandRunnerForTest(
+        withRunner({
+          'rustc --version': { ok: false, out: 'not found' },
+          'stellar --version': { ok: false, out: 'not found' },
+          'rustup target list --installed': { ok: false, out: 'not found' },
+          'yarn --version': { ok: false, out: 'not found' },
+          'pnpm --version': { ok: false, out: 'not found' },
+        }),
+      );
+      console.log = jest.fn();
+
+      const code = await runDoctor();
+
+      expect(code).toBe(0);
+    });
+  });
+
+  describe('Node.js version gating', () => {
+    it('passes when node --version reports >= 20', async () => {
+      setCommandRunnerForTest(withRunner({ 'node --version': { ok: true, out: 'v20.0.0' } }));
+      let captured = '';
+      console.log = jest.fn((line: string) => {
+        captured += line;
+      });
+
+      await runDoctor({ json: true });
+
+      const parsed = JSON.parse(captured);
+      const nodeCheck = parsed.checks.find((c: { id: string }) => c.id === 'node');
+      expect(nodeCheck.ok).toBe(true);
+    });
+
+    it('passes for a node major version well above 20', async () => {
+      setCommandRunnerForTest(withRunner({ 'node --version': { ok: true, out: 'v22.4.1' } }));
+      let captured = '';
+      console.log = jest.fn((line: string) => {
+        captured += line;
+      });
+
+      await runDoctor({ json: true });
+
+      const parsed = JSON.parse(captured);
+      expect(parsed.checks.find((c: { id: string }) => c.id === 'node').ok).toBe(true);
+    });
+
+    it('fails when node --version reports < 20', async () => {
+      setCommandRunnerForTest(withRunner({ 'node --version': { ok: true, out: 'v18.19.0' } }));
+      let captured = '';
+      console.log = jest.fn((line: string) => {
+        captured += line;
+      });
+
+      const code = await runDoctor({ json: true });
+
+      const parsed = JSON.parse(captured);
+      const nodeCheck = parsed.checks.find((c: { id: string }) => c.id === 'node');
+      expect(nodeCheck.ok).toBe(false);
+      // node is a required check, so an overall failing exit code follows.
+      expect(code).toBe(1);
+    });
+  });
+
+  describe('--json output shape', () => {
+    it('produces valid JSON containing every check id, ok, and required flag', async () => {
+      setCommandRunnerForTest(withRunner());
+      let captured = '';
+      console.log = jest.fn((line: string) => {
+        captured += line;
+      });
+
+      await runDoctor({ json: true });
+
+      const parsed = JSON.parse(captured);
+      expect(Array.isArray(parsed.checks)).toBe(true);
+      expect(parsed.checks.length).toBeGreaterThan(0);
+      for (const check of parsed.checks) {
+        expect(typeof check.id).toBe('string');
+        expect(typeof check.ok).toBe('boolean');
+        expect(typeof check.required).toBe('boolean');
+      }
+      // Every check id doctor.ts defines should be present.
+      const ids = parsed.checks.map((c: { id: string }) => c.id).sort();
+      expect(ids).toEqual(
+        ['disk', 'git', 'horizon', 'node', 'npm', 'pnpm', 'rustc', 'soroban', 'stellar-cli', 'wasm32', 'yarn'].sort(),
+      );
+    });
+
+    it('includes passed/failed/requiredFailures summary counts', async () => {
+      setCommandRunnerForTest(withRunner({ 'git --version': { ok: false, out: 'not found' } }));
+      let captured = '';
+      console.log = jest.fn((line: string) => {
+        captured += line;
+      });
+
+      await runDoctor({ json: true });
+
+      const parsed = JSON.parse(captured);
+      expect(parsed.requiredFailures).toBeGreaterThanOrEqual(1);
+      expect(parsed.passed + parsed.failed).toBe(parsed.checks.length);
+    });
+  });
+
+  describe('no real subprocesses or network calls', () => {
+    it('never invokes the real command runner once overridden', async () => {
+      const spy = jest.fn(withRunner());
+      setCommandRunnerForTest(spy);
+      console.log = jest.fn();
+
+      await runDoctor();
+
+      expect(spy).toHaveBeenCalled();
+      // Every call went through the mock; if the real subprocess runner had
+      // been used instead, `node --version` etc. would still happen to
+      // succeed locally, so the meaningful assertion is that our injected
+      // spy is what actually got called for each known command.
+      const calledCommands = spy.mock.calls.map((args) => args[0]);
+      expect(calledCommands).toEqual(expect.arrayContaining(['node --version', 'git --version']));
+    });
+
+    it('never calls the real fetch implementation', async () => {
+      setCommandRunnerForTest(withRunner());
+      console.log = jest.fn();
+
+      await runDoctor();
+
+      expect(global.fetch).toHaveBeenCalled();
+      expect(jest.isMockFunction(global.fetch)).toBe(true);
+    });
+  });
+});

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,4 +1,18 @@
-import { detectPackageManager, getInstallCommand, runInstall } from '../src/lib/install.js';
+import { jest } from '@jest/globals';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+// Genuine ESM module under this repo's Jest config (extensionsToTreatAsEsm),
+// so mocking execa needs jest.unstable_mockModule — classic jest.mock relies
+// on babel's hoist-to-require transform, which doesn't apply once Jest is
+// actually running the file as ESM (--experimental-vm-modules).
+const mockExeca = jest.fn();
+jest.unstable_mockModule('execa', () => ({ execa: mockExeca }));
+
+const { detectPackageManager, getInstallCommand, runInstall, networkErrorHint } = await import(
+  '../src/lib/install.js'
+);
 
 describe('install utilities', () => {
   beforeEach(() => {
@@ -33,9 +47,59 @@ describe('install utilities', () => {
   });
 
   describe('runInstall', () => {
+    let tmpDir: string | undefined;
+
+    beforeEach(() => {
+      mockExeca.mockReset();
+    });
+
+    afterEach(async () => {
+      if (tmpDir) {
+        await fs.remove(tmpDir);
+        tmpDir = undefined;
+      }
+    });
+
     it('skips installation when skipInstall is true', async () => {
       const result = await runInstall({ cwd: '/test', skipInstall: true });
       expect(result).toEqual({ success: true, packageManager: 'skipped' });
+    });
+
+    it('returns success: false with the raw error message when the install command fails', async () => {
+      mockExeca.mockRejectedValueOnce(new Error('some install error'));
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nextellar-install-test-'));
+
+      const result = await runInstall({
+        cwd: tmpDir,
+        packageManager: 'npm',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.packageManager).toBe('npm');
+      expect(result.error).toBe('some install error');
+    });
+  });
+
+  // #673 — targeted hints for common network/registry failure signatures,
+  // so the user isn't left decoding a raw stack trace.
+  describe('networkErrorHint', () => {
+    it('returns undefined when there is no error message', () => {
+      expect(networkErrorHint(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for an error unrelated to networking', () => {
+      expect(networkErrorHint('EACCES: permission denied, open package.json')).toBeUndefined();
+    });
+
+    it.each([
+      ['ENOTFOUND', 'getaddrinfo ENOTFOUND registry.npmjs.org'],
+      ['ETIMEDOUT', 'connect ETIMEDOUT 104.16.0.35:443'],
+      ['EAI_AGAIN', 'getaddrinfo EAI_AGAIN registry.npmjs.org'],
+      ['403 Forbidden', 'npm ERR! 403 Forbidden - GET https://registry.npmjs.org/some-package'],
+      ['proxy', 'Error: connect ECONNREFUSED behind corporate proxy'],
+    ])('recognizes a %s error and returns a hint', (_label, message) => {
+      expect(networkErrorHint(message)).toBeDefined();
+      expect(typeof networkErrorHint(message)).toBe('string');
     });
   });
 });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1,8 +1,20 @@
+import { jest } from '@jest/globals';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { scaffold } from '../src/lib/scaffold';
+
+// Genuine ESM module (this file uses import.meta.url below), so mocking
+// needs jest.unstable_mockModule rather than the classic jest.mock — the
+// latter relies on babel's hoist-to-require transform, which doesn't apply
+// once Jest is actually running the file as ESM (--experimental-vm-modules).
+const mockRunInstall = jest.fn();
+jest.unstable_mockModule('../src/lib/install.js', () => ({
+  detectPackageManager: () => 'npm',
+  runInstall: mockRunInstall,
+}));
+
+const { scaffold } = await import('../src/lib/scaffold');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,6 +30,18 @@ describe('scaffold integration', () => {
     tmpParents.push(dir);
     return dir;
   };
+
+  beforeEach(() => {
+    // Default: behaves like the real runInstall's skipInstall short-circuit,
+    // so every pre-existing test below (all of which pass skipInstall: true)
+    // is unaffected by mocking this module. Tests that exercise a failing
+    // install override this with mockResolvedValueOnce.
+    mockRunInstall.mockImplementation(async (options) =>
+      options.skipInstall
+        ? { success: true, packageManager: 'skipped' }
+        : { success: true, packageManager: 'npm' }
+    );
+  });
 
   afterEach(async () => {
     // restore cwd
@@ -180,5 +204,59 @@ describe('scaffold integration', () => {
         await fs.remove(path.join(templateDirCandidate, 'node_modules'));
       } catch (_) {}
     }
+  });
+
+  // #673 — an install-only failure must leave the scaffolded project
+  // directory intact and tell the user exactly what to run, instead of
+  // deleting the directory it just told them to run a command inside.
+  describe('install failure handling (#673)', () => {
+    test('keeps the project directory and prints the manual install command when only install fails', async () => {
+      mockRunInstall.mockResolvedValueOnce({
+        success: false,
+        packageManager: 'npm',
+        error: 'Some non-network install error',
+      });
+
+      origCwd = process.cwd();
+      const parent = await makeTempParent();
+      process.chdir(parent);
+
+      const appName = 'install-fails-app';
+
+      await expect(
+        scaffold({ appName, useTs: true, template: 'minimal', skipInstall: false })
+      ).rejects.toThrow(/cd install-fails-app[\s\S]*npm install/);
+
+      // The directory (and its scaffolded files) must still be there —
+      // deleting it would make "run install manually" impossible.
+      const target = path.join(parent, appName);
+      expect(await fs.pathExists(target)).toBe(true);
+      expect(await fs.pathExists(path.join(target, 'package.json'))).toBe(true);
+    });
+
+    test('still cleans up fully when the failure happens during the copy phase, before any files are usable', async () => {
+      origCwd = process.cwd();
+      const parent = await makeTempParent();
+      process.chdir(parent);
+
+      const appName = 'copy-fails-app';
+      const target = path.join(parent, appName);
+
+      const copySpy = jest.spyOn(fs, 'copy').mockRejectedValueOnce(new Error('disk full'));
+
+      try {
+        await expect(
+          scaffold({ appName, useTs: true, template: 'minimal', skipInstall: true })
+        ).rejects.toThrow('disk full');
+
+        // fs.copy never completed, so nothing worth keeping was ever
+        // written — full cleanup is correct here, unlike the install-only
+        // failure case above.
+        expect(await fs.pathExists(target)).toBe(false);
+      } finally {
+        copySpy.mockRestore();
+      }
+    });
+
   });
 });


### PR DESCRIPTION
## Summary

closes #639
closes #673

## Changes

### #639 — `doctor` command unit tests

Adds `tests/doctor.test.ts`: exit-code semantics (a required-check failure returns non-zero; an optional-check-only failure returns zero), Node.js version gating (major < 20 fails, >= 20 passes, tested at the boundary and well above it), and `--json` output shape (every check has `id`/`ok`/`required`, valid JSON, correct summary counts).

Two minimal test-only seams added to `src/lib/doctor.ts`, both following the same shape:
- `setCommandRunnerForTest` — lets every tool check (node/npm/yarn/pnpm/git/rustc/stellar-cli/wasm32) be forced to pass/fail deterministically without spawning a real subprocess.
- `setFreeMemoryProviderForTest` — same idea for the disk/RAM check, which previously read real `os.freemem()` directly with no way to control it in tests. This turned out not to be optional: **this sandbox has under 1GB free RAM right now**, which made that required check fail for real and made "required fails → exit 1, optional-only fails → exit 0" impossible to test reliably without this seam.

Network checks (Horizon/Soroban, via `fetch`) are stubbed to a fixed successful response in test setup *only* to prevent real network I/O during the run — exercising their specific pass/fail behavior is intentionally left to the separate testing issue on doctor network checks, per this issue's own scope note.

### #673 — friendlier network error messages for install/scaffold failures

When install failed inside `runInstall` but the project files were already scaffolded, `scaffold()` threw a generic message and then its own `catch` block deleted the entire project directory right after — making "run install manually" literally impossible, since there was nothing left to install into.

- `scaffold.ts` now tracks whether `fs.copy` completed (`filesScaffolded`). The catch block only wipes `targetDir` when that's still `false` (a failure before/during the copy phase); an install-only failure leaves the directory intact and the thrown error tells the user exactly what to run (`cd <appName> && <packageManager> install`).
- `install.ts` adds `networkErrorHint()`, matching common network/registry failure signatures (`ENOTFOUND`, `ETIMEDOUT`, `EAI_AGAIN`, `403`/Forbidden, proxy) against the install error message and returning a targeted hint, printed alongside `runInstall`'s existing remediation instructions.

Also fixes a pre-existing bug that was blocking `tests/scaffold.test.ts` from running at all: `jest.setTimeout(30000)` referenced the bare `jest` global, which isn't available in this repo's genuine-ESM Jest config (`extensionsToTreatAsEsm` + `--experimental-vm-modules`) without `import { jest } from '@jest/globals'`. All 5 pre-existing tests in that file were failing to even load before this one-line fix. The same bug affects roughly 50 other test files across the repo (verified via a stash-and-recompare against this branch's base commit — identical 52 failing suites before and after this PR's changes) — out of scope to fix broadly here; only the one file blocking this issue's required tests was touched.

## Test plan

- `npx tsc -p tsconfig.build.json` (typecheck) and `npm run build`: both clean.
- `tests/doctor.test.ts` (new, 11 tests), `tests/scaffold.test.ts` (5 pre-existing + 2 new for #673, all 7 passing), `tests/install.test.ts` (5 pre-existing + 8 new for `networkErrorHint`/failure-path coverage, all 13 passing) — **31/31 passing**.
- Full repo suite (`npm test`): 104 suites / 942 tests passing, identical 52 pre-existing failing suites before and after this branch (stash-verified against the base commit) — no regressions introduced.