### PR TITLE
feat: port ErrorBoundary to all templates and wire into layouts

### DIFF
--- a/src/templates/default/src/app/layout.tsx
+++ b/src/templates/default/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
-import { ErrorBoundary } from "@/components/ErrorBoundary";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/templates/default/src/app/layout.tsx
+++ b/src/templates/default/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,9 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/templates/default/src/components/ErrorBoundary.tsx
+++ b/src/templates/default/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  showDetails: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
+    showDetails: false,
+  };
+
+  public static getDerivedStateFromError(
+    error: Error
+  ): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(
+      "ErrorBoundary caught an error:",
+      error,
+      errorInfo.componentStack
+    );
+    this.setState({ errorInfo });
+  }
+
+  private handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+  };
+
+  private toggleDetails = () => {
+    this.setState((prevState) => ({ showDetails: !prevState.showDetails }));
+  };
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-linear-to-br from-white/70 via-slate-100/55 to-white/65 dark:from-black/70 dark:via-zinc-900/60 dark:to-black/75 backdrop-blur-2xl text-black dark:text-white">
+          <div className="w-full max-w-2xl rounded-3xl border border-white/60 dark:border-white/20 bg-white/55 dark:bg-white/10 backdrop-blur-xl p-6 sm:p-8 shadow-sm">
+            <h1 className="text-2xl sm:text-3xl font-semibold mb-3">
+              Something went wrong
+            </h1>
+            <p className="text-sm sm:text-base text-gray-700 dark:text-white/80 mb-6">
+              The app hit an unexpected error while rendering. You can try again
+              to recover.
+            </p>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={this.handleReset}
+                className="px-5 py-2.5 rounded-full font-medium bg-black text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200 transition-colors"
+              >
+                Try Again
+              </button>
+              {this.state.error && (
+                <button
+                  type="button"
+                  onClick={this.toggleDetails}
+                  className="px-5 py-2.5 rounded-full font-medium border border-gray-300 text-gray-900 hover:bg-gray-100 dark:border-white/20 dark:text-white dark:hover:bg-white/10 transition-colors"
+                >
+                  {this.state.showDetails ? "Hide Details" : "Show Details"}
+                </button>
+              )}
+            </div>
+
+            {this.state.showDetails && this.state.error && (
+              <div className="mt-6 rounded-xl border border-white/60 dark:border-white/15 bg-white/45 dark:bg-black/35 backdrop-blur-sm p-4">
+                <p className="text-sm font-semibold mb-2">Error Details</p>
+                <pre className="text-xs sm:text-sm whitespace-pre-wrap wrap-break-word text-red-700 dark:text-red-300">
+                  {this.state.error.toString()}
+                  {this.state.errorInfo?.componentStack
+                    ? `\n\nComponent Stack:${this.state.errorInfo.componentStack}`
+                    : ""}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/templates/defi/src/app/layout.tsx
+++ b/src/templates/defi/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,9 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/templates/defi/src/components/ErrorBoundary.tsx
+++ b/src/templates/defi/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  showDetails: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
+    showDetails: false,
+  };
+
+  public static getDerivedStateFromError(
+    error: Error
+  ): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(
+      "ErrorBoundary caught an error:",
+      error,
+      errorInfo.componentStack
+    );
+    this.setState({ errorInfo });
+  }
+
+  private handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+  };
+
+  private toggleDetails = () => {
+    this.setState((prevState) => ({ showDetails: !prevState.showDetails }));
+  };
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-linear-to-br from-white/70 via-slate-100/55 to-white/65 dark:from-black/70 dark:via-zinc-900/60 dark:to-black/75 backdrop-blur-2xl text-black dark:text-white">
+          <div className="w-full max-w-2xl rounded-3xl border border-white/60 dark:border-white/20 bg-white/55 dark:bg-white/10 backdrop-blur-xl p-6 sm:p-8 shadow-sm">
+            <h1 className="text-2xl sm:text-3xl font-semibold mb-3">
+              Something went wrong
+            </h1>
+            <p className="text-sm sm:text-base text-gray-700 dark:text-white/80 mb-6">
+              The app hit an unexpected error while rendering. You can try again
+              to recover.
+            </p>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={this.handleReset}
+                className="px-5 py-2.5 rounded-full font-medium bg-black text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200 transition-colors"
+              >
+                Try Again
+              </button>
+              {this.state.error && (
+                <button
+                  type="button"
+                  onClick={this.toggleDetails}
+                  className="px-5 py-2.5 rounded-full font-medium border border-gray-300 text-gray-900 hover:bg-gray-100 dark:border-white/20 dark:text-white dark:hover:bg-white/10 transition-colors"
+                >
+                  {this.state.showDetails ? "Hide Details" : "Show Details"}
+                </button>
+              )}
+            </div>
+
+            {this.state.showDetails && this.state.error && (
+              <div className="mt-6 rounded-xl border border-white/60 dark:border-white/15 bg-white/45 dark:bg-black/35 backdrop-blur-sm p-4">
+                <p className="text-sm font-semibold mb-2">Error Details</p>
+                <pre className="text-xs sm:text-sm whitespace-pre-wrap wrap-break-word text-red-700 dark:text-red-300">
+                  {this.state.error.toString()}
+                  {this.state.errorInfo?.componentStack
+                    ? `\n\nComponent Stack:${this.state.errorInfo.componentStack}`
+                    : ""}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/templates/js-defi/src/app/layout.jsx
+++ b/src/templates/js-defi/src/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,9 +24,11 @@ export default function RootLayout({ children }) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/templates/js-defi/src/components/ErrorBoundary.jsx
+++ b/src/templates/js-defi/src/components/ErrorBoundary.jsx
@@ -1,33 +1,20 @@
 "use client";
 
-import React, { Component, type ErrorInfo, type ReactNode } from "react";
+import React, { Component } from "react";
 
-interface ErrorBoundaryProps {
-  children: ReactNode;
-}
-
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-  errorInfo: ErrorInfo | null;
-  showDetails: boolean;
-}
-
-class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  public state: ErrorBoundaryState = {
+class ErrorBoundary extends Component {
+  state = {
     hasError: false,
     error: null,
     errorInfo: null,
     showDetails: false,
   };
 
-  public static getDerivedStateFromError(
-    error: Error
-  ): Partial<ErrorBoundaryState> {
+  static getDerivedStateFromError(error) {
     return { hasError: true, error };
   }
 
-  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  componentDidCatch(error, errorInfo) {
     console.error(
       "ErrorBoundary caught an error:",
       error,
@@ -36,7 +23,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     this.setState({ errorInfo });
   }
 
-  private handleReset = () => {
+  handleReset = () => {
     this.setState({
       hasError: false,
       error: null,
@@ -45,11 +32,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     });
   };
 
-  private toggleDetails = () => {
+  toggleDetails = () => {
     this.setState((prevState) => ({ showDetails: !prevState.showDetails }));
   };
 
-  public render() {
+  render() {
     if (this.state.hasError) {
       return (
         <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-linear-to-br from-white/70 via-slate-100/55 to-white/65 dark:from-black/70 dark:via-zinc-900/60 dark:to-black/75 backdrop-blur-2xl text-black dark:text-white">

--- a/src/templates/js-template/src/app/layout.jsx
+++ b/src/templates/js-template/src/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
+import ErrorBoundary from "@/components/ErrorBoundary";
 const geistSans = Geist({
     variable: "--font-geist-sans",
     subsets: ["latin"],
@@ -16,9 +17,11 @@ export const metadata = {
 export default function RootLayout({ children, }) {
     return (<html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>);
 }

--- a/src/templates/js-template/src/components/ErrorBoundary.jsx
+++ b/src/templates/js-template/src/components/ErrorBoundary.jsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { Component } from "react";
+
+class ErrorBoundary extends Component {
+  state = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
+    showDetails: false,
+  };
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error(
+      "ErrorBoundary caught an error:",
+      error,
+      errorInfo.componentStack
+    );
+    this.setState({ errorInfo });
+  }
+
+  handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+  };
+
+  toggleDetails = () => {
+    this.setState((prevState) => ({ showDetails: !prevState.showDetails }));
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-linear-to-br from-white/70 via-slate-100/55 to-white/65 dark:from-black/70 dark:via-zinc-900/60 dark:to-black/75 backdrop-blur-2xl text-black dark:text-white">
+          <div className="w-full max-w-2xl rounded-3xl border border-white/60 dark:border-white/20 bg-white/55 dark:bg-white/10 backdrop-blur-xl p-6 sm:p-8 shadow-sm">
+            <h1 className="text-2xl sm:text-3xl font-semibold mb-3">
+              Something went wrong
+            </h1>
+            <p className="text-sm sm:text-base text-gray-700 dark:text-white/80 mb-6">
+              The app hit an unexpected error while rendering. You can try again
+              to recover.
+            </p>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={this.handleReset}
+                className="px-5 py-2.5 rounded-full font-medium bg-black text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200 transition-colors"
+              >
+                Try Again
+              </button>
+              {this.state.error && (
+                <button
+                  type="button"
+                  onClick={this.toggleDetails}
+                  className="px-5 py-2.5 rounded-full font-medium border border-gray-300 text-gray-900 hover:bg-gray-100 dark:border-white/20 dark:text-white dark:hover:bg-white/10 transition-colors"
+                >
+                  {this.state.showDetails ? "Hide Details" : "Show Details"}
+                </button>
+              )}
+            </div>
+
+            {this.state.showDetails && this.state.error && (
+              <div className="mt-6 rounded-xl border border-white/60 dark:border-white/15 bg-white/45 dark:bg-black/35 backdrop-blur-sm p-4">
+                <p className="text-sm font-semibold mb-2">Error Details</p>
+                <pre className="text-xs sm:text-sm whitespace-pre-wrap wrap-break-word text-red-700 dark:text-red-300">
+                  {this.state.error.toString()}
+                  {this.state.errorInfo?.componentStack
+                    ? `\n\nComponent Stack:${this.state.errorInfo.componentStack}`
+                    : ""}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/templates/minimal/src/app/layout.tsx
+++ b/src/templates/minimal/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { WalletProvider } from "@/contexts";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,9 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <WalletProvider>
-          {children}
-        </WalletProvider>
+        <ErrorBoundary>
+          <WalletProvider>
+            {children}
+          </WalletProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/templates/minimal/src/components/ErrorBoundary.tsx
+++ b/src/templates/minimal/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  showDetails: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
+    showDetails: false,
+  };
+
+  public static getDerivedStateFromError(
+    error: Error
+  ): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(
+      "ErrorBoundary caught an error:",
+      error,
+      errorInfo.componentStack
+    );
+    this.setState({ errorInfo });
+  }
+
+  private handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+  };
+
+  private toggleDetails = () => {
+    this.setState((prevState) => ({ showDetails: !prevState.showDetails }));
+  };
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-linear-to-br from-white/70 via-slate-100/55 to-white/65 dark:from-black/70 dark:via-zinc-900/60 dark:to-black/75 backdrop-blur-2xl text-black dark:text-white">
+          <div className="w-full max-w-2xl rounded-3xl border border-white/60 dark:border-white/20 bg-white/55 dark:bg-white/10 backdrop-blur-xl p-6 sm:p-8 shadow-sm">
+            <h1 className="text-2xl sm:text-3xl font-semibold mb-3">
+              Something went wrong
+            </h1>
+            <p className="text-sm sm:text-base text-gray-700 dark:text-white/80 mb-6">
+              The app hit an unexpected error while rendering. You can try again
+              to recover.
+            </p>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={this.handleReset}
+                className="px-5 py-2.5 rounded-full font-medium bg-black text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200 transition-colors"
+              >
+                Try Again
+              </button>
+              {this.state.error && (
+                <button
+                  type="button"
+                  onClick={this.toggleDetails}
+                  className="px-5 py-2.5 rounded-full font-medium border border-gray-300 text-gray-900 hover:bg-gray-100 dark:border-white/20 dark:text-white dark:hover:bg-white/10 transition-colors"
+                >
+                  {this.state.showDetails ? "Hide Details" : "Show Details"}
+                </button>
+              )}
+            </div>
+
+            {this.state.showDetails && this.state.error && (
+              <div className="mt-6 rounded-xl border border-white/60 dark:border-white/15 bg-white/45 dark:bg-black/35 backdrop-blur-sm p-4">
+                <p className="text-sm font-semibold mb-2">Error Details</p>
+                <pre className="text-xs sm:text-sm whitespace-pre-wrap wrap-break-word text-red-700 dark:text-red-300">
+                  {this.state.error.toString()}
+                  {this.state.errorInfo?.componentStack
+                    ? `\n\nComponent Stack:${this.state.errorInfo.componentStack}`
+                    : ""}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION

  Port ErrorBoundary to all templates (closes #102)
  
  What
  
  Adds the ErrorBoundary component introduced in #101 to the three remaining templates and wires
  it into each layout identically to default.
  
  Changes
  
  - src/templates/default/src/components/ErrorBoundary.tsx — new (TSX, typed)
  - src/templates/minimal/src/components/ErrorBoundary.tsx — new (TSX, typed)
  - src/templates/defi/src/components/ErrorBoundary.tsx — new (TSX, typed)
  - src/templates/js-template/src/components/ErrorBoundary.jsx — new (pure JSX, no TypeScript
  syntax, addresses the stray-TSX cleanup issue)
  - All four layout.* files updated to import ErrorBoundary and wrap <WalletProvider> with it
  
  How to verify
  
  In each scaffolded template, throw a render error from any child component (e.g. throw new
  Error("test") inside a useEffect-triggered render). The glassmorphism fallback UI should appear
  with Try Again and Show Details buttons. Clicking Try Again resets the boundary; Show Details
  exposes the error message and component stack.
  
  Notes
  
  - Blocked-by: #101 must be merged before this lands
  - js-template/src/components/ErroBoundary.jsx (typo, left by a previous cleanup commit) is
  unrelated clutter — covered by the stray-TSX cleanup issue

closes #665 