### PR TITLE
feat(ci): add CI workflow for PR and push-to-main checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -p tsconfig.build.json --noEmit
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary

Create `.github/workflows/ci.yml` — a general CI workflow that gates every PR and push to `main` on typechecking and tests.

With 368 closed issues worth of contributor PRs merged, every merge has relied on manual review alone. This workflow establishes a safety net to catch regressions automatically.

## Changes

- **`.github/workflows/ci.yml`** (new)
  - Triggers: `pull_request` (any branch → `main`) + `push` to `main`
  - Steps: checkout → setup-node 20 (npm cache) → `npm ci` → `npx tsc -p tsconfig.build.json --noEmit` → `npm test`
  - Concurrency group (`ci-${{ github.ref }}`) with `cancel-in-progress: true` to cancel superseded runs

## Acceptance criteria

- ✅ Workflow green on a no-op PR (both checks pass)
- ✅ A deliberately broken type causes `tsc --noEmit` to exit non-zero → red
- ✅ A failing test causes `npm test` to exit non-zero → red
- ✅ Parallel pushes to the same branch cancel the stale run automatically

## Branch protection recommendation

Once this workflow lands on `main`, enable the following branch protection rules in **Settings → Branches → Add rule** (for the `main` branch):

| Setting | Value |
|---------|-------|
| Require a pull request before merging | ✅ |
| Require status checks to pass before merging | ✅ |
| Status check to require | **ci / ci (20)** |
| Require branches to be up to date | ✅ |
| Do not allow bypassing the above | ✅ (includes admins) |

## Files touched

- `.github/workflows/ci.yml` (new)

Closes the CI foundation issue.