### PR TITLE
fix(templates): make defi stellar-wallet-kit network-aware (follow-up to #780)

### DIFF
--- a/src/templates/defi/src/lib/stellar-wallet-kit.ts
+++ b/src/templates/defi/src/lib/stellar-wallet-kit.ts
@@ -10,16 +10,23 @@ import {
   ISupportedWallet,
 } from "@creit.tech/stellar-wallets-kit";
 
-// Placeholder for injected wallets
+// Placeholder for injected wallets. During scaffold-time this token is replaced
+// with an array literal.
 const INJECTED_WALLETS: string[] = {{WALLETS}};
 
 let kitInstance: StellarWalletsKit | null = null;
+let currentNetwork: WalletNetwork | null = null;
 
-export const getKit = (): StellarWalletsKit => {
+export const getKit = (network?: WalletNetwork): StellarWalletsKit => {
   if (typeof window === 'undefined') {
     return {} as StellarWalletsKit;
   }
   
+  // Re-initialize if network has changed
+  if (kitInstance && network && network !== currentNetwork) {
+    kitInstance = null;
+  }
+
   if (!kitInstance) {
     // Dynamic module loading based on INJECTED_WALLETS
     // or fallback to defaults if placeholder not replaced
@@ -32,6 +39,10 @@ export const getKit = (): StellarWalletsKit => {
     if (walletList.includes('xbull')) modules.push(new xBullModule());
     if (walletList.includes('hana')) modules.push(new HanaModule());
 
+    // Determine network: priority to passed param, then injected placeholder, then default to TESTNET
+    const targetNetwork = network || (('{{NETWORK}}' as string) === 'PUBLIC' ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET);
+    currentNetwork = targetNetwork;
+
     kitInstance = new StellarWalletsKit({
       network: ('{{NETWORK}}' as string) === 'PUBLIC' ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
       selectedWalletId: FREIGHTER_ID,
@@ -43,7 +54,7 @@ export const getKit = (): StellarWalletsKit => {
 };
 
 // Export as function to ensure lazy evaluation
-export const kit = () => getKit();
+export const kit = (network?: WalletNetwork) => getKit(network);
 
 interface signTransactionProps {
   unsignedTransaction: string;


### PR DESCRIPTION
## Problem
#780 added the NetworkSwitcher to the **defi** template and updated its `WalletProvider` to call `kit(walletNetwork)`, but `src/templates/defi/src/lib/stellar-wallet-kit.ts` was left with the old **zero-arg** `kit()`/`getKit()`. As a result, on current `main`:

- **`next build` fails** in a scaffolded defi app — `kit(walletNetwork)` passes an argument to a `() => ...` function (TS2554: Expected 0 arguments, but got 1).
- Even if it compiled, the wallet kit would never re-point to the selected network, so the NetworkSwitcher wouldn't actually switch.

## Fix
Sync `defi/src/lib/stellar-wallet-kit.ts` with the **default** template's network-aware version (`network?: WalletNetwork` param, `currentNetwork` tracking, re-init on change). One file changed; defi's kit is now byte-identical to default's, matching the other defi lib/context files.

## Verification
- `kit(walletNetwork)` call sites in defi's WalletProvider now match `export const kit = (network?: WalletNetwork)`.
- All five defi lib/context files (`WalletProvider.tsx`, `NetworkSwitcher.tsx`, `config/networks.ts`, `lib/stellar-wallet-kit.ts`, `lib/storage.ts`) are byte-identical to the default template.
- `stellar-wallet-kit.ts` is in scaffold's `filesToProcess`, so the `{{NETWORK}}`/`{{WALLETS}}` placeholders still substitute correctly.