### PR TITLE
fix(templates): remove duplicate inline storage in js-template WalletProvider (follow-up to #790)

### DIFF
--- a/src/templates/js-template/src/contexts/WalletProvider.jsx
+++ b/src/templates/js-template/src/contexts/WalletProvider.jsx
@@ -8,22 +8,6 @@ import { NETWORKS } from '../config/networks';
 
 const Server = Horizon.Server;
 
-// Storage helper — mirrors src/lib/storage.ts
-const storage = {
-    get: (key) => {
-        if (typeof window === 'undefined') return null;
-        return window.localStorage.getItem(key);
-    },
-    set: (key, value) => {
-        if (typeof window === 'undefined') return;
-        window.localStorage.setItem(key, value);
-    },
-    remove: (key) => {
-        if (typeof window === 'undefined') return;
-        window.localStorage.removeItem(key);
-    },
-};
-
 // Create contexts
 const WalletContext = createContext(undefined);
 const WalletConfigContext = createContext(undefined);


### PR DESCRIPTION
## Problem
#790 added `import { storage } from '../lib/storage.js'` to `js-template/src/contexts/WalletProvider.jsx` but did not remove the pre-existing inline `const storage = { ... }` helper. Two top-level `storage` bindings in an ES module is a parse-time error:

```
SyntaxError: Identifier 'storage' has already been declared
```

So on current `main`, **every scaffolded js-template app fails to build** because `WalletProvider.jsx` (the primary provider) won't parse.

## Fix
Remove the inline `const storage` block (16 lines). The imported `storage` from the new `lib/storage.js` is already used by all get/set/remove call sites (18 references), matching the TS default template which imports `storage` with no inline copy.

One file changed, deletions only.